### PR TITLE
Renamed HTML to fix error message

### DIFF
--- a/panel/panels.py
+++ b/panel/panels.py
@@ -248,9 +248,9 @@ class MatplotlibPanel(PanelBase):
         return model
 
 
-class HTML(PanelBase):
+class HTMLPanel(PanelBase):
     """
-    HTML renders any object which has a _repr_html_ method and wraps
+    HTMLPanel renders any object which has a _repr_html_ method and wraps
     the HTML in a bokeh Div model.
     """
 


### PR DESCRIPTION
The HTML object didn't follow the naming convention of the other Panel objects, and the PanelBase error message stripped off the last 5 characters of the class name when reporting issues, leaving this name with nothing in it. Renamed to HTMLPanel to match the other objects, so that the error message correctly reports that it expects HTML objects.