### PR TITLE
Add support for efficient updates to Panels

### DIFF
--- a/panel/panels.py
+++ b/panel/panels.py
@@ -22,12 +22,8 @@ def Panel(obj, **kwargs):
     """
     if isinstance(obj, Viewable):
         return obj
-    descendents = [(p.precedence, p) for p in param.concrete_descendents(PanelBase).values()]
-    panel_types = sorted(descendents, key=lambda x: x[0])
-    for _, panel_type in panel_types:
-        if not panel_type.applies(obj): continue
-        return panel_type(obj, **kwargs)
-    raise TypeError('%s type could not be rendered.' % type(obj).__name__)
+    return PanelBase.get_panel_type(obj)(obj, **kwargs)
+
 
 
 class PanelBase(Reactive):
@@ -61,6 +57,17 @@ class PanelBase(Reactive):
         can render the object.
         """
         return None
+
+    @classmethod
+    def get_panel_type(cls, obj):
+        if isinstance(obj, Viewable):
+            return type(obj)
+        descendents = [(p.precedence, p) for p in param.concrete_descendents(PanelBase).values()]
+        panel_types = sorted(descendents, key=lambda x: x[0])
+        for _, panel_type in panel_types:
+            if not panel_type.applies(obj): continue
+            return panel_type
+        raise TypeError('%s type could not be rendered.' % type(obj).__name__)
 
     def __init__(self, object, **params):
         if not self.applies(object):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -59,9 +59,15 @@ class Viewable(param.Parameterized):
         """
         return self._get_model(doc, comm=comm)
 
-    def _cleanup(self, model):
+    def _cleanup(self, model, final=False):
         """
         Clean up method which is called when a Viewable is destroyed.
+
+        model: bokeh.model.Model
+            Bokeh model for the view being cleaned up
+
+        final: boolean
+            Whether the Panel can be destroyed entirely
         """
 
     def _repr_mimebundle_(self, include=None, exclude=None):
@@ -139,8 +145,10 @@ class Reactive(Viewable):
                 raise AttributeError('Linked object %s has no attribute %s.'
                                      % (obj, other_param))
 
-    def _cleanup(self, model):
-        super(Reactive, self)._cleanup(model)
+    def _cleanup(self, model, final=False):
+        super(Reactive, self)._cleanup(model, final)
+        if model is None:
+            return
         callbacks = self._callbacks[model.ref['id']]
         for p, cb in callbacks.items():
             self.param.unwatch(cb, p)


### PR DESCRIPTION
Previously whenever the ``object`` on a model changed or when a ``ParamMethodPanel`` triggered an update a completely new bokeh model would be generated. This PR makes it possible for Panel classes to implement an ``_update`` method which simply updates the existing model, which can greatly improve the efficiency of updates.