### PR TITLE
Added optional height and width to HTMLPanel

### DIFF
--- a/panel/panels.py
+++ b/panel/panels.py
@@ -338,18 +338,25 @@ class MatplotlibPanel(DivBasePanel):
 class HTMLPanel(DivBasePanel):
     """
     HTMLPanel renders any object which has a _repr_html_ method and wraps
-    the HTML in a bokeh Div model.
+    the HTML in a bokeh Div model. The height and width can optionally
+    be specified, to allow room for whatever is being wrapped.
     """
 
     precedence = 1
+
+    height = param.Integer(default=None, bounds=(0, None))
+
+    width = param.Integer(default=None, bounds=(0, None))
 
     @classmethod
     def applies(cls, obj):
         return hasattr(obj, '_repr_html_')
 
     def _get_properties(self):
-        return dict(text=self.object._repr_html_())
-
+        p = dict(text=self.object._repr_html_())
+        if self.width  is not None: p["width"] =self.width
+        if self.height is not None: p["height"]=self.height
+        return p
 
 
 class GGPlotPanel(DivBasePanel):

--- a/panel/panels.py
+++ b/panel/panels.py
@@ -308,8 +308,8 @@ class DivBasePanel(PanelBase):
         objects=["fixed", "scale_width", "scale_height", "scale_both", "stretch_both"], 
         doc="How the item being displayed should size itself.")
                                        
-    style = param.Parameter(default=None, doc="""
-        Raw CSS style declaration for this Div.""")
+    style = param.Dict(default=None, doc="""
+        Dictionary of CSS property:value pairs to apply to this Div.""")
 
     def _get_properties(self):
         return {p : getattr(self,p) for p in ["width", "height", "sizing_mode", "style"]


### PR DESCRIPTION
HTMLPanel works well, but it doesn't seem to allot any space for the actual object being shown:

```
import numpy as np, pandas as pd, datashader as ds
from datashader import transfer_functions as tf
from datashader.colors import inferno, viridis
from numba import jit
from colorcet import fire

@jit
def clifford_trajectory(a, b, c, d, x0, y0, n):
    xs, ys = np.zeros(n), np.zeros(n)
    xs[0], ys[0] = x0, y0
    for i in np.arange(n-1):
        xs[i+1] = np.sin(a * ys[i]) + c * np.cos(a * xs[i])
        ys[i+1] = np.sin(b * xs[i]) + d * np.cos(b * ys[i])
    return pd.DataFrame(dict(x=xs,y=ys))

def clifford_plot(a, b, c, d, n=10000000, cmap=fire[::-1]):
    cvs = ds.Canvas(plot_width=400, plot_height=400)
    agg = cvs.points(clifford_trajectory(a, b, c, d, 0, 0, n), 'x', 'y')
    return tf.shade(agg, cmap=cmap)
```

```
from panel import Row, Column
from panel.panels import HTMLPanel
import param

class DatashaderPanel(param.Parameterized):
    a = param.Number(1.7, bounds=(-2, 2))
    b = param.Number(1.7, bounds=(-2, 2))
    c = param.Number(0.6, bounds=(-2, 2))
    d = param.Number(1.2, bounds=(-2, 2))

    @param.depends('a', 'b', 'c', 'd')
    def view(self):
        return HTMLPanel(clifford_plot(self.a, self.b, self.c, self.d))
    
panel = DatashaderPanel()
Column(panel, panel.view)
```
![image](https://user-images.githubusercontent.com/1695496/44861801-eed9c880-ac3e-11e8-8e90-8686e8d60dca.png)

This PR adds optional `height` and `width` parameters to HTMLPanel, allowing users to specify those if they wish:

![image](https://user-images.githubusercontent.com/1695496/44861860-129d0e80-ac3f-11e8-8877-cf51e0b3a6dd.png)

If there is a better way to achieve this; let me know!

Note that we could consider moving the parameters up to the base class and the implementation to `_get_model()` in the base class so that `height` and `width` would always be allowed for any Panel object. I think doing that would let users situate their content in a box of their own choosing.  Maybe that's a better option than this? Probably would have to supply options for centering or justifying the content in that box, though.