### PR TITLE
Add String pane to support any representable object

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -452,12 +452,14 @@ class HTML(DivPaneBase):
         return dict(properties, text=self.object._repr_html_())
 
 
-class Repr(DivPaneBase):
+class String(DivPaneBase):
     """
-    Repr panes render any object for which `repr()` can be called, wrapping
-    the resulting string in a bokeh Div model.  Set to a low precedence
-    because generally one will want a better representation than just
-    the repr, but allows arbitrary objects to be used as a Pane.
+    A String pane renders any object for which `str()` can be called,
+    wrapping the resulting string in a bokeh Div model.  Set to a low
+    precedence because generally one will want a better
+    representation, but allows arbitrary objects to be used as a Pane.
+    HTML markup will be interpreted, so this type of pane is also 
+    useful for arbitrary HTML code provided as a Python string.
     """
 
     precedence = 10
@@ -467,5 +469,5 @@ class Repr(DivPaneBase):
         return True
 
     def _get_properties(self):
-        properties = super(Repr, self)._get_properties()
-        return dict(properties, text=repr(self.object))
+        properties = super(String, self)._get_properties()
+        return dict(properties, text=str(self.object))

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -408,24 +408,6 @@ class Matplotlib(PNG):
         return b.getvalue()
 
 
-class HTML(DivPaneBase):
-    """
-    HTML panes render any object which has a _repr_html_ method and wraps
-    the HTML in a bokeh Div model. The height and width can optionally
-    be specified, to allow room for whatever is being wrapped.
-    """
-
-    precedence = 1
-
-    @classmethod
-    def applies(cls, obj):
-        return hasattr(obj, '_repr_html_')
-
-    def _get_properties(self):
-        properties = super(HTML, self)._get_properties()
-        return dict(properties, text=self.object._repr_html_())
-
-
 class RGGPlot(PNG):
     """
     An RGGPlot panes render an r2py-based ggplot2 figure to png
@@ -450,3 +432,40 @@ class RGGPlot(PNG):
                  res=self.dpi, antialias="subpixel") as b:
             robjects.r("print")(self.object)
         return b.getvalue()
+
+
+class HTML(DivPaneBase):
+    """
+    HTML panes render any object that has a _repr_html_ method and wraps
+    the HTML in a bokeh Div model. The height and width can optionally
+    be specified, to allow room for whatever is being wrapped.
+    """
+
+    precedence = 1
+
+    @classmethod
+    def applies(cls, obj):
+        return hasattr(obj, '_repr_html_')
+
+    def _get_properties(self):
+        properties = super(HTML, self)._get_properties()
+        return dict(properties, text=self.object._repr_html_())
+
+
+class Repr(DivPaneBase):
+    """
+    Repr panes render any object for which `repr()` can be called, wrapping
+    the resulting string in a bokeh Div model.  Set to a low precedence
+    because generally one will want a better representation than just
+    the repr, but allows arbitrary objects to be used as a Pane.
+    """
+
+    precedence = 10
+
+    @classmethod
+    def applies(cls, obj):
+        return True
+
+    def _get_properties(self):
+        properties = super(Repr, self)._get_properties()
+        return dict(properties, text=repr(self.object))

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -152,6 +152,8 @@ class Bokeh(PaneBase):
     Bokeh panes allow including any Bokeh model in a panel.
     """
 
+    precedence = 0.8
+
     @classmethod
     def applies(cls, obj):
         return isinstance(obj, LayoutDOM)
@@ -184,7 +186,9 @@ class HoloViews(PaneBase):
     HoloViews panes render any HoloViews object to a corresponding
     Bokeh model while respecting the currently selected backend.
     """
-
+    
+    precedence = 0.8
+    
     @classmethod
     def applies(cls, obj):
         if 'holoviews' not in sys.modules:
@@ -483,4 +487,4 @@ class Str(DivPaneBase):
     
     def _get_properties(self):
         properties = super(Str, self)._get_properties()
-        return dict(properties, text=escape(str(self.object)))
+        return dict(properties, text='<pre>'+escape(str(self.object))+'</pre>')

--- a/panel/param.py
+++ b/panel/param.py
@@ -57,7 +57,7 @@ class Param(PaneBase):
     label_formatter = param.Callable(default=default_label_formatter, allow_None=True,
         doc="Callable used to format the parameter names into widget labels.")
 
-    precedence = 1
+    precedence = 0.1
 
     _mapping = {
         param.Action:        Button,

--- a/panel/plotly.py
+++ b/panel/plotly.py
@@ -36,6 +36,8 @@ class Plotly(PaneBase):
 
     _updates = True
 
+    precedence = 0.8
+    
     def __init__(self, object, layout=None, **params):
         super(Plotly, self).__init__(self._to_figure(object, layout),
                                      layout=layout, **params)

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -7,7 +7,7 @@ from bokeh.models import (Div, Row as BkRow, WidgetBox as BkWidgetBox,
                           GlyphRenderer, Circle, Line)
 from bokeh.plotting import Figure
 from panel.pane import (Pane, PaneBase, Bokeh, HoloViews, Matplotlib,
-                        ParamMethod)
+                        ParamMethod, HTML, Str)
 
 try:
     import holoviews as hv
@@ -276,3 +276,55 @@ def test_param_method_pane_changing_type(document, comm):
     # Cleanup pane
     new_pane._cleanup(model)
     assert new_pane._callbacks == {}
+
+
+def test_get_html_pane_type():
+    assert PaneBase.get_pane_type("<h1>Test</h1>") is HTML
+
+
+def test_html_pane(document, comm):
+    pane = Pane("<h1>Test</h1>")
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert model.ref['id'] in pane._callbacks
+    div = get_div(model)
+    assert div.text == "<h1>Test</h1>"
+
+    # Replace Pane.object
+    pane.object = "<h2>Test</h2>"
+    model = row.children[0]
+    assert div is get_div(model)
+    assert model.ref['id'] in pane._callbacks
+    assert div.text == "<h2>Test</h2>"
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._callbacks == {}
+
+
+def test_string_pane(document, comm):
+    pane = Str("<h1>Test</h1>")
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert model.ref['id'] in pane._callbacks
+    div = get_div(model)
+    assert div.text == "<pre>&lt;h1&gt;Test&lt;/h1&gt;</pre>"
+
+    # Replace Pane.object
+    pane.object = "<h2>Test</h2>"
+    model = row.children[0]
+    assert div is get_div(model)
+    assert model.ref['id'] in pane._callbacks
+    assert div.text == "<pre>&lt;h2&gt;Test&lt;/h2&gt;</pre>"
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._callbacks == {}


### PR DESCRIPTION
@jlstevens suggested we add support for a string-based representation for any Python object as a Pane.  About 20 minutes after his suggestion, I already realized that I needed that, so here it is.

Adding the Repr class is the only change; the other diffs are just to reorganize the other classes to be in a more readable order.

Questions:
- [x] What range are the priority values meant to have?  I chose 10 for this one to be higher than HTML's current value of 1 and as an indication that this class is really a last resort, but we could instead keep them all in [0.0,1.0] as is typical for Parameter precedences.  Up to @philippjfr.
- [ ] Should we have an (optional?) character limit on the representation, to be useful for objects whose representation might be many pages of text?
- [x] Should we escape the values in some way, or let HTML be interpreted as HTML if there is any HTML in the representation?