### PR TITLE
Always wrap Div and widgets in WidgetBox

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -155,7 +155,9 @@ class Bokeh(PaneBase):
         """
         model = self.object
         if isinstance(model, _BkWidget):
-            model = _BkWidgetBox(model, width=model.width)
+            box_kws = {k: getattr(model, k) for k in ['width', 'height', 'sizing_mode']
+                       if k in model.properties()}
+            model = _BkWidgetBox(model, **box_kws)
 
         if root:
             plot_id = root.ref['id']

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -332,7 +332,7 @@ class DivPaneBase(PaneBase):
         return model
 
     def _update(self, model):
-        div = model if isinstance(model, _BkDiv) else model.children[0].children[0]
+        div = model if isinstance(model, _BkDiv) else model.children[0]
         div.update(**self._get_properties())
 
 

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -75,9 +75,8 @@ def test_holoviews_pane_mpl_renderer(document, comm):
     assert len(row.children) == 1
     assert len(pane._callbacks) == 1
     model = row.children[0]
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div = model.children[0]
     assert isinstance(div, Div)
     assert '<img' in div.text
 
@@ -85,9 +84,8 @@ def test_holoviews_pane_mpl_renderer(document, comm):
     scatter = hv.Scatter([1, 2, 3])
     pane.object = scatter
     model = row.children[0]
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div2 = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div2 = model.children[0]
     assert isinstance(div2, Div)
     assert div2.text != div.text
 
@@ -143,9 +141,8 @@ def test_matplotlib_pane(document, comm):
     assert len(row.children) == 1
     assert len(pane._callbacks) == 1
     model = row.children[0]
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div = model.children[0]
     assert isinstance(div, Div)
     assert '<img' in div.text
     text = div.text
@@ -153,9 +150,8 @@ def test_matplotlib_pane(document, comm):
     # Replace Pane.object
     pane.object = mpl_figure()
     model = row.children[0]
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div2 = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div2 = model.children[0]
     assert div is div2
     assert div.text != text
 
@@ -228,9 +224,8 @@ def test_param_method_pane_mpl(document, comm):
     assert len(row.children) == 1
     model = row.children[0]
     assert model.ref['id'] in inner_pane._callbacks
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div = model.children[0]
     assert isinstance(div, Div)
     text = div.text
 
@@ -238,7 +233,7 @@ def test_param_method_pane_mpl(document, comm):
     test.a = 5
     model = row.children[0]
     assert inner_pane is pane._pane
-    assert div is row.children[0].children[0].children[0]
+    assert div is row.children[0].children[0]
     assert div.text != text
     assert len(inner_pane._callbacks) == 1
     assert model.ref['id'] in inner_pane._callbacks
@@ -261,9 +256,8 @@ def test_param_method_pane_changing_type(document, comm):
     assert len(row.children) == 1
     model = row.children[0]
     assert model.ref['id'] in inner_pane._callbacks
-    assert isinstance(model, BkRow)
-    assert isinstance(model.children[0], BkWidgetBox)
-    div = model.children[0].children[0]
+    assert isinstance(model, BkWidgetBox)
+    div = model.children[0]
     assert isinstance(div, Div)
     text = div.text
 

--- a/panel/util.py
+++ b/panel/util.py
@@ -10,7 +10,7 @@ import param
 import bokeh
 import bokeh.embed.notebook
 from bokeh.io.notebook import load_notebook as bk_load_notebook
-from bokeh.models import Model, LayoutDOM, Div as BkDiv, Spacer, Row, WidgetBox as BkWidgetBox
+from bokeh.models import Model, LayoutDOM, Div as BkDiv, WidgetBox as BkWidgetBox
 from bokeh.protocol import Protocol
 from bokeh.resources import CDN, INLINE
 from bokeh.util.string import encode_utf8

--- a/panel/util.py
+++ b/panel/util.py
@@ -10,7 +10,7 @@ import param
 import bokeh
 import bokeh.embed.notebook
 from bokeh.io.notebook import load_notebook as bk_load_notebook
-from bokeh.models import Model, LayoutDOM, Div as BkDiv, Spacer, Row
+from bokeh.models import Model, LayoutDOM, Div as BkDiv, Spacer, Row, WidgetBox as BkWidgetBox
 from bokeh.protocol import Protocol
 from bokeh.resources import CDN, INLINE
 from bokeh.util.string import encode_utf8
@@ -87,9 +87,9 @@ class default_label_formatter(param.ParameterizedFunction):
 def Div(**kwargs):
     # Hack to work around issues with Div height in notebooks
     div = BkDiv(**kwargs)
-    if 'height' in kwargs:
-        return Row(div, Spacer(height=kwargs['height']))
-    return div
+    box_kws = {k: v for k, v in kwargs.items()
+               if k in ['width', 'height', 'sizing_mode']}
+    return BkWidgetBox(div, **box_kws)
 
 
 def diff(doc, binary=True, events=None):


### PR DESCRIPTION
Makes the handling of Div and widget bokeh models more consistent by always wrapping them in a widget box, which inherits width/height/sizing_mode from the model.