### PR TITLE
Add support for rendering Vega and altair plots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYENV_VERSION
         - source activate test-environment
         - doit develop_install -o recommended -o tests $CHANS_DEV
-        - pip install codecov
+        - pip install codecov altair
         - doit env_capture
       script: doit test_all_recommended
       after_success: codecov

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -29,7 +29,7 @@ export class PlotlyPlotView extends LayoutDOMView {
 
   _init(): void {
     this._plot()
-    this.connect(this.model.change, this._plot)
+    this.connect(this.model.properties.data.change, this._plot)
   }
 
   _plot(): void {

--- a/panel/models/vega.ts
+++ b/panel/models/vega.ts
@@ -7,21 +7,21 @@ export class VegaPlotView extends LayoutDOMView {
   initialize(options): void {
     super.initialize(options)
     const vega_url = "https://cdn.jsdelivr.net/npm/vega@4.2.0"
-	const vega_lite_url = "https://cdn.jsdelivr.net/npm/vega-lite@3.0.0-rc4"
-	const vega_embed_url = "https://cdn.jsdelivr.net/npm/vega-embed@3.18.2"
+    const vega_lite_url = "https://cdn.jsdelivr.net/npm/vega-lite@3.0.0-rc4"
+    const vega_embed_url = "https://cdn.jsdelivr.net/npm/vega-embed@3.18.2"
 
     if (window.vega) {
       this._init()
     } else {
-	  const init = () => { this._init() }
-	  const load_vega_embed = () => { this._add_script(vega_embed_url, init) }
-	  const load_vega_lite = () => { this._add_script(vega_lite_url, load_vega_embed) }
+      const init = () => { this._init() }
+      const load_vega_embed = () => { this._add_script(vega_embed_url, init) }
+      const load_vega_lite = () => { this._add_script(vega_lite_url, load_vega_embed) }
       this._add_script(vega_url, load_vega_lite)
     }
   }
 
   _add_script(url: string, callback): void {
-	const script = document.createElement('script')
+    const script = document.createElement('script')
     script.src = url
     script.async = false
     script.onreadystatechange = script.onload = callback
@@ -42,28 +42,28 @@ export class VegaPlotView extends LayoutDOMView {
   }
 
   _fetch_datasets() {
-	const datasets = {}
-	for (const ds in this.model.data_sources) {
+    const datasets = {}
+    for (const ds in this.model.data_sources) {
       const cds = this.model.data_sources[ds];
-	  const data = []
-	  const columns = cds.columns()
-	  for (const i = 0; i < cds.data[columns[0]].length; i++) {
+      const data = []
+      const columns = cds.columns()
+      for (const i = 0; i < cds.data[columns[0]].length; i++) {
         const item = {}
-	    for (const column of columns) {
-		  item[column] = cds.data[column][i]
+        for (const column of columns) {
+          item[column] = cds.data[column][i]
         }
-		data.push(item)
+        data.push(item)
       }
-	  datasets[ds] = data;
-	}
-	return datasets
+      datasets[ds] = data;
+    }
+    return datasets
   }
 
   _plot(): void {
-	if (!('datasets' in this.model.data)) {
-	  this.model.data['datasets'] = this._fetch_datasets()
-	}
-	vegaEmbed(this.el, this.model.data);
+    if (!('datasets' in this.model.data)) {
+      this.model.data['datasets'] = this._fetch_datasets()
+    }
+    vegaEmbed(this.el, this.model.data);
   }
 }
 

--- a/panel/models/vega.ts
+++ b/panel/models/vega.ts
@@ -1,0 +1,95 @@
+import * as p from "core/properties"
+import {LayoutDOM, LayoutDOMView} from "models/layouts/layout_dom"
+
+export class VegaPlotView extends LayoutDOMView {
+  model: VegaPlot
+
+  initialize(options): void {
+    super.initialize(options)
+    const vega_url = "https://cdn.jsdelivr.net/npm/vega@4.2.0"
+	const vega_lite_url = "https://cdn.jsdelivr.net/npm/vega-lite@3.0.0-rc4"
+	const vega_embed_url = "https://cdn.jsdelivr.net/npm/vega-embed@3.18.2"
+
+    if (window.vega) {
+      this._init()
+    } else {
+	  const init = () => { this._init() }
+	  const load_vega_embed = () => { this._add_script(vega_embed_url, init) }
+	  const load_vega_lite = () => { this._add_script(vega_lite_url, load_vega_embed) }
+      this._add_script(vega_url, load_vega_lite)
+    }
+  }
+
+  _add_script(url: string, callback): void {
+	const script = document.createElement('script')
+    script.src = url
+    script.async = false
+    script.onreadystatechange = script.onload = callback
+    document.querySelector("head").appendChild(script)
+  }
+
+  get_width(): number {
+    return this.model.data.config.view.width
+  }
+
+  get_height(): number {
+    return this.model.data.config.view.height + 50
+  }
+
+  _init(): void {
+    this._plot()
+    this.connect(this.model.properties.data.change, this._plot)
+  }
+
+  _fetch_datasets() {
+	const datasets = {}
+	for (const ds in this.model.data_sources) {
+      const cds = this.model.data_sources[ds];
+	  const data = []
+	  const columns = cds.columns()
+	  for (const i = 0; i < cds.data[columns[0]].length; i++) {
+        const item = {}
+	    for (const column of columns) {
+		  item[column] = cds.data[column][i]
+        }
+		data.push(item)
+      }
+	  datasets[ds] = data;
+	}
+	return datasets
+  }
+
+  _plot(): void {
+	if (!('datasets' in this.model.data)) {
+	  this.model.data['datasets'] = this._fetch_datasets()
+	}
+	vegaEmbed(this.el, this.model.data);
+  }
+}
+
+
+export namespace VegaPlot {
+  export interface Attrs extends LayoutDOM.Attrs {}
+  export interface Props extends LayoutDOM.Props {}
+}
+
+export interface VegaPlot extends VegaPlot.Attrs {}
+
+export class VegaPlot extends LayoutDOM {
+  properties: VegaPlot.Props
+
+  constructor(attrs?: Partial<VegaPlot.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "VegaPlot"
+    this.prototype.default_view = VegaPlotView
+
+    this.define({
+      data: [ p.Any         ],
+      data_sources: [ p.Any  ],
+    })
+  }
+}
+VegaPlot.initClass()

--- a/panel/models/vega.ts
+++ b/panel/models/vega.ts
@@ -61,7 +61,12 @@ export class VegaPlotView extends LayoutDOMView {
 
   _plot(): void {
     if (!('datasets' in this.model.data)) {
-      this.model.data['datasets'] = this._fetch_datasets()
+	  const datasets = this._fetch_datasets()
+	  if ('data' in datasets) {
+        this.model.data.data['values'] = datasets['data']
+		delete datasets['data']
+      }
+      this.model.data['datasets'] = datasets
     }
     vegaEmbed(this.el, this.model.data);
   }

--- a/panel/models/vega.ts
+++ b/panel/models/vega.ts
@@ -3,6 +3,8 @@ import {LayoutDOM, LayoutDOMView} from "models/layouts/layout_dom"
 
 export class VegaPlotView extends LayoutDOMView {
   model: VegaPlot
+  _width: number
+  _height: number
 
   initialize(options): void {
     super.initialize(options)
@@ -29,11 +31,11 @@ export class VegaPlotView extends LayoutDOMView {
   }
 
   get_width(): number {
-    return this.model.data.config.view.width
+	return undefined;
   }
 
   get_height(): number {
-    return this.model.data.config.view.height + 50
+	return undefined;
   }
 
   _init(): void {
@@ -68,7 +70,7 @@ export class VegaPlotView extends LayoutDOMView {
       }
       this.model.data['datasets'] = datasets
     }
-    vegaEmbed(this.el, this.model.data);
+    vegaEmbed(this.el, this.model.data, {actions: false})
   }
 }
 

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -7,7 +7,7 @@ try:
     import plotly.graph_objs as go
 except:
     plotly = None
-plotly_available = pytest.mark.skipif(plotly is None, reason="requires matplotlib")
+plotly_available = pytest.mark.skipif(plotly is None, reason="requires plotly")
 
 import numpy as np
 from bokeh.models import Row as BkRow

--- a/panel/tests/test_vega.py
+++ b/panel/tests/test_vega.py
@@ -1,5 +1,13 @@
 from __future__ import absolute_import
 
+import pytest
+
+try:
+    import altair as alt
+except:
+    alt = None
+altair_available = pytest.mark.skipif(alt is None, reason="requires altair")
+
 import numpy as np
 from bokeh.models import Row as BkRow
 from panel.pane import Pane, PaneBase
@@ -17,7 +25,6 @@ vega_example = {
                  'y': {'type': 'quantitative', 'field': 'y'}},
     '$schema': 'https://vega.github.io/schema/vega-lite/v2.6.0.json'
 }
-
 
 def test_get_vega_pane_type_from_dict():
     assert PaneBase.get_pane_type(vega_example) is Vega
@@ -44,6 +51,59 @@ def test_vega_pane(document, comm):
     point_example['data']['values'][0]['x'] = 'C'
     pane.object = point_example
     point_example['data'].pop('values')
+    assert model.data == point_example
+    cds_data = model.data_sources['data'].data
+    assert np.array_equal(cds_data['x'], np.array(['C', 'B', 'C', 'D', 'E'])) 
+    assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
+
+    pane._cleanup(model)
+    assert pane._callbacks == {}
+
+
+def altair_example():
+    import altair as alt
+    data = alt.Data(values=[{'x': 'A', 'y': 5},
+                            {'x': 'B', 'y': 3},
+                            {'x': 'C', 'y': 6},
+                            {'x': 'D', 'y': 7},
+                            {'x': 'E', 'y': 2}])
+    chart = alt.Chart(data).mark_bar().encode(
+        x='x:O',  # specify ordinal data
+        y='y:Q',  # specify quantitative data
+    )
+    return chart
+
+
+@altair_available
+def test_get_vega_pane_type_from_altair():
+    assert PaneBase.get_pane_type(altair_example()) is Vega
+
+
+@altair_available
+def test_altair_pane(document, comm):
+    pane = Pane(altair_example())
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert isinstance(model, VegaPlot)
+
+    expected = dict(vega_example, data={})
+
+    assert model.data == expected
+    
+    print(model.data)
+    cds_data = model.data_sources['data'].data
+    assert np.array_equal(cds_data['x'], np.array(['A', 'B', 'C', 'D', 'E'])) 
+    assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
+
+    chart = altair_example()
+    chart.mark = 'point'
+    chart.data.values[0]['x'] = 'C'
+    pane.object = chart
+    point_example = dict(vega_example, mark='point')
     assert model.data == point_example
     cds_data = model.data_sources['data'].data
     assert np.array_equal(cds_data['x'], np.array(['C', 'B', 'C', 'D', 'E'])) 

--- a/panel/tests/test_vega.py
+++ b/panel/tests/test_vega.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+import numpy as np
+from bokeh.models import Row as BkRow
+from panel.pane import Pane, PaneBase
+from panel.vega import Vega, VegaPlot
+
+vega_example = {
+    'config': {'view': {'width': 400, 'height': 300}},
+    'data': {'values': [{'x': 'A', 'y': 5},
+                        {'x': 'B', 'y': 3},
+                        {'x': 'C', 'y': 6},
+                        {'x': 'D', 'y': 7},
+                        {'x': 'E', 'y': 2}]},
+    'mark': 'bar',
+    'encoding': {'x': {'type': 'ordinal', 'field': 'x'},
+                 'y': {'type': 'quantitative', 'field': 'y'}},
+    '$schema': 'https://vega.github.io/schema/vega-lite/v2.6.0.json'
+}
+
+
+def test_get_vega_pane_type_from_dict():
+    assert PaneBase.get_pane_type(vega_example) is Vega
+
+
+def test_vega_pane(document, comm):
+    pane = Pane(vega_example)
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert isinstance(model, VegaPlot)
+
+    expected = dict(vega_example, data={})
+
+    assert model.data == expected
+    cds_data = model.data_sources['data'].data
+    assert np.array_equal(cds_data['x'], np.array(['A', 'B', 'C', 'D', 'E'])) 
+    assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
+
+    point_example = dict(vega_example, mark='point')
+    point_example['data']['values'][0]['x'] = 'C'
+    pane.object = point_example
+    point_example['data'].pop('values')
+    assert model.data == point_example
+    cds_data = model.data_sources['data'].data
+    assert np.array_equal(cds_data['x'], np.array(['C', 'B', 'C', 'D', 'E'])) 
+    assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
+
+    pane._cleanup(model)
+    assert pane._callbacks == {}

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -12,7 +12,7 @@ from .pane import PaneBase
 
 def ds_as_cds(dataset):
     """
-    Converts vega dataset into bokeh ColumnDataSource data
+    Converts Vega dataset into Bokeh ColumnDataSource data
     """
     if len(dataset) == 0:
         return {}
@@ -26,8 +26,8 @@ def ds_as_cds(dataset):
 
 class VegaPlot(LayoutDOM):
     """
-    A bokeh model that wraps around a plotly plot and renders it inside
-    a bokeh plot.
+    A Bokeh model that wraps around a Vega plot and renders it inside
+    a Bokeh plot.
     """
 
     __implementation__ = os.path.join(os.path.dirname(__file__), 'models', 'vega.ts')
@@ -39,7 +39,7 @@ class VegaPlot(LayoutDOM):
 
 class Vega(PaneBase):
     """
-    Vega panes allow rendering plotly Figures and traces.
+    Vega panes allow rendering Vega plots and traces.
 
     For efficiency any array objects found inside a Figure are added
     to a ColumnDataSource which allows using binary transport to sync
@@ -86,7 +86,7 @@ class Vega(PaneBase):
 
     def _get_model(self, doc, root, parent=None, comm=None):
         """
-        Should return the bokeh model to be rendered.
+        Should return the Bokeh model to be rendered.
         """
         json = self._to_json(self.object)
         sources = {}

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -1,0 +1,102 @@
+from __future__ import division
+
+import os
+import sys
+
+import param
+import numpy as np
+from bokeh.core.properties import Dict, String, List, Any, Instance
+from bokeh.models import LayoutDOM, ColumnDataSource
+
+from .pane import PaneBase
+
+
+def ds_as_cds(dataset):
+    """
+    Converts vega dataset into bokeh ColumnDataSource data
+    """
+    if len(dataset) == 0:
+        return {}
+    data = {k: [] for k, v in dataset[0].items()}
+    for item in dataset:
+        for k, v in item.items():
+            data[k].append(v)
+    data = {k: np.asarray(v) for k, v in data.items()}
+    return data
+
+
+class VegaPlot(LayoutDOM):
+    """
+    A bokeh model that wraps around a plotly plot and renders it inside
+    a bokeh plot.
+    """
+
+    __implementation__ = os.path.join(os.path.dirname(__file__), 'models', 'vega.ts')
+
+    data = Dict(String, Any)
+
+    data_sources = Dict(String, Instance(ColumnDataSource))
+
+
+class Vega(PaneBase):
+    """
+    Vega panes allow rendering plotly Figures and traces.
+
+    For efficiency any array objects found inside a Figure are added
+    to a ColumnDataSource which allows using binary transport to sync
+    the figure on bokeh server and via Comms.
+    """
+
+    _updates = True
+
+    def __init__(self, object, **params):
+        super(Vega, self).__init__(object, **params)
+
+    @classmethod
+    def is_altair(cls, obj):
+        if 'altair' in sys.modules:
+            import altair as alt
+            return isinstance(obj, alt.vegalite.v2.api.Chart)
+        return False
+
+    @classmethod
+    def applies(cls, obj):
+        if isinstance(obj, dict) and 'vega' in obj.get('$schema', '').lower():
+            return True
+        return cls.is_altair(obj)
+
+    @classmethod
+    def _to_json(cls, obj):
+        return obj if isinstance(obj, dict) else obj.to_dict()
+
+    def _get_sources(self, json, sources):
+        for name, data in json.pop('datasets', {}).items():
+            if name in sources:
+                continue
+            columns = set(data[0]) if data else []
+            if self.is_altair(self.object):
+                import altair as alt
+                if (not isinstance(self.object.data, alt.Data) and
+                    columns == set(self.object.data)):
+                    data = ColumnDataSource.from_df(self.object.data)
+                else:
+                    data = ds_as_cds(data)
+                sources[name] = ColumnDataSource(data=data)
+            else:
+                sources[name] = ColumnDataSource(data=ds_as_cds(data))
+
+    def _get_model(self, doc, root, parent=None, comm=None):
+        """
+        Should return the bokeh model to be rendered.
+        """
+        json = self._to_json(self.object)
+        sources = {}
+        self._get_sources(json, sources)
+        model = VegaPlot(data=json, data_sources=sources)
+        self._link_object(model, doc, root, parent, comm)
+        return model
+
+    def _update(self, model):
+        json = self._to_json(self.object)
+        self._get_sources(json, model.data_sources)
+        model.data = json

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -66,7 +66,11 @@ class Vega(PaneBase):
 
     @classmethod
     def _to_json(cls, obj):
-        return obj if isinstance(obj, dict) else obj.to_dict()
+        if isinstance(obj, dict):
+            json = dict(obj)
+            json['data'] = dict(json['data'])
+            return json
+        return obj.to_dict()
 
     def _get_sources(self, json, sources):
         for name, data in json.pop('datasets', {}).items():
@@ -83,12 +87,16 @@ class Vega(PaneBase):
                 sources[name] = ColumnDataSource(data=data)
             else:
                 sources[name] = ColumnDataSource(data=ds_as_cds(data))
+        data = json.get('data', {}).pop('values', {})
+        if data:
+            sources['data'] = ColumnDataSource(data=ds_as_cds(data))
 
     def _get_model(self, doc, root, parent=None, comm=None):
         """
         Should return the Bokeh model to be rendered.
         """
         json = self._to_json(self.object)
+        json['data'] = dict(json['data'])
         sources = {}
         self._get_sources(json, sources)
         model = VegaPlot(data=json, data_sources=sources)

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -3,9 +3,8 @@ from __future__ import division
 import os
 import sys
 
-import param
 import numpy as np
-from bokeh.core.properties import Dict, String, List, Any, Instance
+from bokeh.core.properties import Dict, String, Any, Instance
 from bokeh.models import LayoutDOM, ColumnDataSource
 
 from .pane import PaneBase


### PR DESCRIPTION
Adds support for rendering vega specs and altair charts. Just like the plotly renderer, the embedded data is synced using ColumnDataSources, which means binary transport is supported.

<img width="537" alt="screen shot 2018-09-05 at 3 15 47 pm" src="https://user-images.githubusercontent.com/1550771/45099193-a2026000-b11e-11e8-90fb-39f24606e9f3.png">
