### PR TITLE
Added yt support

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -540,3 +540,38 @@ class Str(DivPaneBase):
     def _get_properties(self):
         properties = super(Str, self)._get_properties()
         return dict(properties, text='<pre>'+escape(str(self.object))+'</pre>')
+
+
+
+class YT(HTML):
+    """
+    YT panes wrap plottable objects from the YT library.  
+    By default, the height and width are calculated by summing all
+    contained plots, but can optionally be specified explicitly to
+    provide additional space.
+    """
+
+    precedence = 0.5
+
+    @classmethod
+    def applies(cls, obj):
+        return ('yt' in repr(obj) and
+                hasattr(obj, "plots") and
+                hasattr(obj, "_repr_html_"))
+
+    def _get_properties(self):
+        p = super(YT, self)._get_properties()
+
+        width = height = 0
+        if self.width  is None or self.height is None:
+            for k,v in self.object.plots.items():
+                if hasattr(v, "_repr_png_"):
+                    img = v._repr_png_()
+                    w,h = PNG._imgshape(img)
+                    height += h
+                    width = max(w, width)
+        
+        if self.width  is None: p["width"]  = width
+        if self.height is None: p["height"] = height
+
+        return p


### PR DESCRIPTION
The [yt](https://yt-project.org/) library uses Matplotlib to render one or more plots per object to PNG.  Although yt objects have a `_repr_html_` and can thus be displayed without any special support, the enclosing Bokeh Div does not resize appropriately to the size of the contents, which is very inconvenient.  This PR adds a pane.YT class that is the same as pane.HTML except that it calculates the total height (of all stacked PNGs) and the maximum width (of all stacked PNGs) and uses those to size the Div.  This implementation is somewhat inefficient, in that it renders the images to PNG just to get their sizes, but doing so seemed simpler than trying to parse them out of the HTML representation to find out their sizes.  Example:

```
try:
    import yt
except:
    !conda install -c conda-forge yt

import os
file = "enzo_tiny_cosmology"
if not os.path.exists(file):
    !curl -sSO http://yt-project.org/data/$file.tar.gz
    !tar xzf $file.tar.gz

import yt

import panel as pp
from panel import pane
pp.extension()

ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
p = yt.ProjectionPlot(ds, "z", ["density", "temperature"], weight_field="density")

pp.Row(p)
```

![image](https://user-images.githubusercontent.com/1695496/45139510-968e5380-b175-11e8-8459-49c36f3adfa6.png)
![image](https://user-images.githubusercontent.com/1695496/45139530-a3ab4280-b175-11e8-99b5-81fcb3a2e028.png)

I don't know how to get a tiny YT data file in order to add more official tests than this.