### PR TITLE
Rough implementation of GridSpec

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -285,7 +285,7 @@ class GridSpec(Reactive):
     def __init__(self, nrows, ncols, **params):
         super(GridSpec, self).__init__(nrows=nrows, ncols=ncols, **params)
         self._objects = []
-        self._grid = {}
+        self._grid = np.zeros((nrows, ncols))
         self._bounds = {}
         self._shapes = {}
 
@@ -302,7 +302,7 @@ class GridSpec(Reactive):
         """
         Whether the grid is fully populated.
         """
-        return (np.sum(list(self._shapes.values()), axis=0) == 0).sum() == 0
+        return np.sum(self._grid) == (self.nrows*self.ncols)
 
     def __setitem__(self, index, obj):
         xidx, yidx = index
@@ -321,9 +321,9 @@ class GridSpec(Reactive):
         obj.height = int(self._cell_height * (y1-y0))
         for x in range(x0, x1):
             for y in range(y0, y1):
-                if (x, y) in self._grid:
+                if self._grid[y, x]:
                     raise IndexError('(%d, %d) already populated' % ((x, y)) )
-                self._grid[(x, y)] = index
+                self._grid[y, x] = True
         self._shapes[index] = shape
 
     def _full_grid(self):
@@ -335,7 +335,7 @@ class GridSpec(Reactive):
         width, height = self.width/self.ncols, self.height/self.nrows
         for x in range(self.ncols):
             for y in range(self.nrows):
-                if (x, y) in new_gs._grid: continue
+                if new_gs._grid[y, x]: continue
                 new_gs[(x, y)] = Spacer(width=int(width), height=int(height))
         return new_gs
 

--- a/panel/util.py
+++ b/panel/util.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import param
 import bokeh
 import bokeh.embed.notebook
+import numpy as np
 from bokeh.io.notebook import load_notebook as bk_load_notebook
 from bokeh.models import Model, LayoutDOM, Div as BkDiv, WidgetBox as BkWidgetBox
 from bokeh.protocol import Protocol
@@ -77,6 +78,14 @@ class default_label_formatter(param.ParameterizedFunction):
         if self.capitalize:
             pname = pname[:1].upper() + pname[1:]
         return pname
+
+
+def is_rectangle(img):
+    rows = np.any(img, axis=1)
+    cols = np.any(img, axis=0)
+    ymin, ymax = np.where(rows)[0][[0, -1]]
+    xmin, xmax = np.where(cols)[0][[0, -1]]
+    return (img[ymin:ymax+1, xmin:xmax+1] == 0).sum() == 0
 
 
 ################################


### PR DESCRIPTION
Implements a GridSpec layout which allows declaring an NxM grid and assigning objects to the grid cells. Here is an example of a 3x3 grid:

<img width="637" alt="screen shot 2018-09-06 at 6 33 17 pm" src="https://user-images.githubusercontent.com/1550771/45174842-bf5d2a00-b203-11e8-9790-dfa19270253e.png">

- [ ] Invert indexing coordinates (rows then columns)
- [ ] Improve width/height setting logic
- [ ] Fix vertical margin issues
- [ ] Add unit tests
- [ ] Add documentation
