### PR TITLE
Use released nbsite package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,12 +82,9 @@ jobs:
       env: DESC="docs"
       script:
         - doit develop_install $CHANS_DEV -o doc -o examples -c conda-forge # phantomjs still not on defaults
-        - conda uninstall nbsite --force
-        - pip install git+https://github.com/pyviz/nbsite.git --upgrade
-
         # note: will vastly simplified in a future version of nbsite
         - cd doc
-        - nbsite_nbpagebuild.py ioam panel ../examples .
+        - nbsite_nbpagebuild.py pyviz panel ../examples .
         - HV_DOC_HTML='true' sphinx-build -b html . ./_build/html
         - nbsite_fix_links.py _build/html
         - nbsite_cleandisthtml.py ./_build/html take_a_chance


### PR DESCRIPTION
As far as I know, there should be no reason to use nbsite master any more, since the released version has caught up (and releases can be generated by tagging, so shouldn't fall behind again).

Also, fixed an 'ioam' reference (download notebook links).

(Note: I think the recent release of sphinx 1.8 might have broken nbsite, but that's an unrelated issue I'll try to fix asap...)