### PR TITLE
Uneditable params

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -123,26 +123,21 @@ class PaneBase(Reactive):
             if self._updates:
                 def update_models():
                     self._update(old_model)
-                if comm:
-                    update_models()
-                    push(doc, comm)
-                else:
-                    doc.add_next_tick_callback(update_models)
-                return
-
-            # Otherwise replace the whole model
-            new_model = self._get_model(doc, root, parent, comm)
-            def update_models():
+            else:
+                # Otherwise replace the whole model
                 self._cleanup(old_model)
-                index = parent.children.index(old_model)
-                parent.children[index] = new_model
-                history[0] = new_model
+                new_model = self._get_model(doc, root, parent, comm)
+                def update_models():
+                    index = parent.children.index(old_model)
+                    parent.children[index] = new_model
+                    history[0] = new_model
 
             if comm:
                 update_models()
                 push(doc, comm)
             else:
                 doc.add_next_tick_callback(update_models)
+
         self.param.watch(update_pane, 'object')
         self._callbacks[model.ref['id']]['object'] = update_pane
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -17,7 +17,7 @@ from .layout import WidgetBox, Row, Layout, Tabs, Spacer
 from .util import default_label_formatter
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
-    MultiSelect, DatePicker, StaticText, Button, Toggle
+    MultiSelect, DatePicker, StaticText, Button, Toggle, TextInput
 )
 
 
@@ -68,6 +68,7 @@ class Param(PaneBase):
         param.Number:        FloatSlider,
         param.Integer:       IntSlider,
         param.Range:         RangeSlider,
+        param.String:        TextInput,
         param.ListSelector:  MultiSelect,
         param.Date:          DatePicker,
     }
@@ -150,7 +151,7 @@ class Param(PaneBase):
             if None not in bounds:
                 kw['start'], kw['end'] = bounds
             else:
-                widget_class = StaticText
+                widget_class = LiteralInput
 
         kwargs = {k: v for k, v in kw.items() if k in widget_class.params()}
         widget = widget_class(**kwargs)


### PR DESCRIPTION
Ensures that number parameters without bounds are editable as literals and that string parameters use a regular ``TextInput`` widget.

- [x] Fixes https://github.com/pyviz/panel/issues/33
- [x] Fixes https://github.com/pyviz/panel/issues/34