### PR TITLE
Minor packaging fixups

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE.txt
 include panel/.version
+include panel/models/*.ts
 global-exclude *.py[co]
 global-exclude *~
 global-exclude *.ipynb_checkpoints/*

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,6 +32,6 @@ test:
     {% endfor %}
 
 about:
-  home: www.pyviz.org
-  summary: Bidirectional communication for PyViz
-  license: BSD 3-Clause
+  home: {{ sdata['url'] }}
+  summary: {{ sdata['description'] }}
+  license: {{ sdata['license'] }}

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,7 @@ setup_args = dict(
     license='BSD',
     url='http://pyviz.org',
     packages=find_packages(),
-    package_data={'panel': ['.version'],
-                  'panel.models': ['*.ts']},
+    include_package_data=True,
     classifiers = [
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Some things I just happened to notice:

  * fix summary on anaconda.org (is currently 'Bidirectional communication for PyViz')
  * include ts files in sdist (currently they're missed, although it doesn't really matter yet since we don't yet put a package on pypi)
