### PR TITLE
Add support for listening to subobject dependencies

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -291,7 +291,7 @@ class ParamMethod(PaneBase):
                 else:
                     doc.add_next_tick_callback(update_models)
 
-            parameterized.param.watch(update_pane, p.name, p.what)
+            (p.inst or p.cls).param.watch(update_pane, p.name, p.what)
         return model
 
     def _cleanup(self, model, final=False):


### PR DESCRIPTION
Decorated parameterized methods used as a ``Pane`` may now listen to subobject parameters. Together with https://github.com/ioam/param/pull/264 it is now also possible to listen to all subobject parameters by using ``param.depends('subobject.param')``.