### PR TITLE
Added support for selecting lists and dicts

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -160,7 +160,7 @@ class Param(PaneBase):
             kw['button_type'] = 'primary'
             kw['name'] = value.name
 
-        if hasattr(p_obj, 'get_range') and not isinstance(kw['value'], dict):
+        if hasattr(p_obj, 'get_range'):
             kw['options'] = p_obj.get_range()
 
         if hasattr(p_obj, 'get_soft_bounds'):

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -168,7 +168,8 @@ def test_select_list_constructor():
 
 
 def test_select(document, comm):
-    select = Select(options={'A': 'A', '1': 1}, value=1, name='Select')
+    opts = {'A': 'a', '1': 1}
+    select = Select(options=opts, value=opts['1'], name='Select')
 
     box = select._get_model(document, comm=comm)
 
@@ -182,13 +183,39 @@ def test_select(document, comm):
 
     widget.value = '1'
     select._comm_change({'value': 'A'})
-    assert select.value == 'A'
+    assert select.value == opts['A']
 
     widget.value = '1'
     select._comm_change({'value': '1'})
-    assert select.value == 1
+    assert select.value == opts['1']
 
-    select.value = 'A'
+    select.value = opts['A']
+    assert widget.value == 'A'
+
+
+def test_select_mutables(document, comm):
+    opts={'A':[1,2,3], 'B':[2,4,6], 'C':dict(a=1,b=2)}
+    select = Select(options=opts, value=opts['B'], name='Select')
+
+    box = select._get_model(document, comm=comm)
+
+    assert isinstance(box, WidgetBox)
+
+    widget = box.children[0]
+    assert isinstance(widget, select._widget_type)
+    assert widget.title == 'Select'
+    assert widget.value == 'B'
+    assert widget.options == ['A', 'B', 'C']
+
+    widget.value = 'B'
+    select._comm_change({'value': 'A'})
+    assert select.value == opts['A']
+
+    widget.value = 'B'
+    select._comm_change({'value': 'B'})
+    assert select.value == opts['B']
+
+    select.value = opts['A']
     assert widget.value == 'A'
 
 

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import ast
 from datetime import datetime
-from collections import OrderedDict, MutableSequence
+from collections import OrderedDict, MutableSequence, MutableMapping
 
 import param
 import numpy as np
@@ -289,7 +289,12 @@ class Checkbox(Widget):
 
 
 def hashable(x):
-    return tuple(x) if isinstance(x, MutableSequence) else x
+    if isinstance(x, MutableSequence):
+        return tuple(x)
+    elif isinstance(x, MutableMapping):
+        return tuple([(k,v) for k,v in x.items()])
+    else:
+        return x
             
 class Select(Widget):
 

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import ast
 from datetime import datetime
-from collections import OrderedDict, Sequence
+from collections import OrderedDict, MutableSequence
 
 import param
 import numpy as np
@@ -289,7 +289,7 @@ class Checkbox(Widget):
 
 
 def hashable(x):
-    return tuple(x) if isinstance(x, Sequence) else x
+    return tuple(x) if isinstance(x, MutableSequence) else x
             
 class Select(Widget):
 

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 import ast
 from datetime import datetime
-from collections import OrderedDict
+from collections import OrderedDict, Sequence
 
 import param
 import numpy as np
@@ -288,6 +288,9 @@ class Checkbox(Widget):
         return msg
 
 
+def hashable(x):
+    return tuple(x) if isinstance(x, Sequence) else x
+            
 class Select(Widget):
 
     options = param.Dict(default={})
@@ -307,9 +310,9 @@ class Select(Widget):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        mapping = {v: k for k, v in self.options.items()}
+        mapping = {hashable(v): k for k, v in self.options.items()}
         if msg.get('value') is not None:
-            msg['value'] = mapping[msg['value']]
+            msg['value'] = mapping[hashable(msg['value'])]
         if 'options' in msg:
             msg['options'] = list(msg['options'])
         return msg
@@ -330,9 +333,9 @@ class MultiSelect(Select):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        mapping = {v: k for k, v in self.options.items()}
+        mapping = {hashable(v): k for k, v in self.options.items()}
         if 'value' in msg:
-            msg['value'] = [mapping[v] for v in msg['value']]
+            msg['value'] = [hashable(mapping[v]) for v in msg['value']]
         if 'options' in msg:
             msg['options'] = list(msg['options'])
         return msg


### PR DESCRIPTION
Selector widgets currently need to do a reverse lookup on object identity, which requires that objects be hashable, which Bokeh palettes (as lists) are not.  This PR and a [matching PR on param](https://github.com/ioam/param/pull/268) converts lists to tuples when doing lookups, which works:

```
import panel as pp
from colorcet import kbc, fire
pp.extension()

def fn(a=1.7, cmap=kbc):
    return a,cmap[0]

pp.interact(fn, cmap=[kbc,fire])
```
![image](https://user-images.githubusercontent.com/1695496/45817763-5cf53680-bca5-11e8-83d2-f73b321ccb2e.png)

```
import param

class C(param.Parameterized):
    a = param.Number(1.7, bounds=(-2, 2))
    cmap = param.ObjectSelector(kbc,[kbc,fire])

    def view(self):
        return self.a, self.cmap[0]
c=C()
pp.Row(c.param,c.view)
```

![image](https://user-images.githubusercontent.com/1695496/45817787-6e3e4300-bca5-11e8-8227-a8601a5b53b8.png)

However, note that in both cases the representation of the list is vastly larger than the widget box, which in the second example ends before `(2, '#000000')` starts.  @philippjfr, is there a way to truncate the representation in the widget when it's longer than the box?

For a Param-based widget the solution is to provide string names, but I'm not sure how to do that with `interact`:

```
class C(param.Parameterized):
    a = param.Number(1.7, bounds=(-2, 2))
    cmap = param.ObjectSelector(kbc,dict(kbc=kbc,fire=fire))

    def view(self):
        return self.a, self.cmap[0]
c=C()
pp.Row(c.param,c.view)
```

![image](https://user-images.githubusercontent.com/1695496/45817936-d68d2480-bca5-11e8-89fc-a463b4ad54ca.png)
