### PR TITLE
Added DatetimeInput widget

### DIFF
--- a/examples/user_guide/Widgets.ipynb
+++ b/examples/user_guide/Widgets.ipynb
@@ -191,6 +191,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### DatetimeInput\n",
+    "\n",
+    "``DatetimeInput`` allows entering a ``datetime`` object as a string. Optionally a ``format`` to change the formatting and input parsing may be declared and ``start`` and ``end`` values may be defined to validate the bounds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "\n",
+    "dt_input = DatetimeInput(name='Type a datetime string here:', value=dt.datetime(2018, 9, 23), end=dt.datetime(2018, 9, 30), format='%Y-%m-%d %H:%M:%S')\n",
+    "dt_input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt_input.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Select"
    ]
   },
@@ -275,8 +305,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime as dt\n",
-    "\n",
     "date_picker = DatePicker(name='Date Picker', value=dt.datetime(2017, 1, 2), start=dt.datetime(2017, 1, 1))\n",
     "date_picker"
    ]

--- a/panel/param.py
+++ b/panel/param.py
@@ -18,8 +18,8 @@ from .layout import WidgetBox, Row, Layout, Tabs
 from .util import default_label_formatter
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
-    MultiSelect, DatePicker, StaticText, Button, Toggle, TextInput,
-    DiscreteSlider
+    MultiSelect, StaticText, Button, Toggle, TextInput, DiscreteSlider,
+    DatetimeInput
 )
 
 
@@ -85,7 +85,7 @@ class Param(PaneBase):
         param.Range:          RangeSlider,
         param.String:         TextInput,
         param.ListSelector:   MultiSelect,
-        param.Date:           DatePicker,
+        param.Date:           DatetimeInput,
     }
 
     def __init__(self, object, **params):
@@ -165,9 +165,11 @@ class Param(PaneBase):
 
         if hasattr(p_obj, 'get_soft_bounds'):
             bounds = p_obj.get_soft_bounds()
-            if None not in bounds:
-                kw['start'], kw['end'] = bounds
-            else:
+            if bounds[0] is not None:
+                kw['start'] = bounds[0]
+            if bounds[1] is not None:
+                kw['end'] = bounds[1]
+            if ('start' not in kw or 'end' not in kw) and not issubclass(widget_class, LiteralInput):
                 widget_class = LiteralInput
 
         kwargs = {k: v for k, v in kw.items() if k in widget_class.params()}

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -6,7 +6,7 @@ from bokeh.models import Div as BkDiv, Slider as BkSlider
 from panel.widgets import (
     TextInput, StaticText, FloatSlider, IntSlider, RangeSlider,
     LiteralInput, Checkbox, Select, MultiSelect, Button, Toggle,
-    DatePicker, DateRangeSlider, DiscreteSlider
+    DatePicker, DateRangeSlider, DiscreteSlider, DatetimeInput
 )
 
 
@@ -139,6 +139,39 @@ def test_literal_input(document, comm):
     literal._comm_change({'value': "invalid"})
     assert literal.value == {'key': (0, 2)}
     assert widget.title == 'Literal (invalid)'
+
+    literal._comm_change({'value': "{'key': (0, 3)}"})
+    assert literal.value == {'key': (0, 3)}
+    assert widget.title == 'Literal'
+
+
+def test_datetime_input(document, comm):
+    dt_input = DatetimeInput(value=datetime(2018, 1, 1), end=datetime(2018, 1, 10), name='Datetime')
+
+    box = dt_input._get_model(document, comm=comm)
+
+    assert isinstance(box, WidgetBox)
+
+    widget = box.children[0]
+    assert isinstance(widget, dt_input._widget_type)
+    assert widget.title == 'Datetime'
+    assert widget.value == '2018-01-01 00:00:00'
+
+    dt_input._comm_change({'value': '2018-01-01 00:00:01'})
+    assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
+    assert widget.title == 'Datetime'
+
+    dt_input._comm_change({'value': '2018-01-01 00:00:01a'})
+    assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
+    assert widget.title == 'Datetime (invalid)'
+
+    dt_input._comm_change({'value': '2018-01-11 00:00:00'})
+    assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
+    assert widget.title == 'Datetime (out of bounds)'
+
+    dt_input._comm_change({'value': '2018-01-02 00:00:01'})
+    assert dt_input.value == datetime(2018, 1, 2, 0, 0, 1)
+    assert widget.title == 'Datetime'
 
 
 def test_checkbox(document, comm):


### PR DESCRIPTION
Allows entering a datetime as a string providing control over the ``format`` and the bounds.