### PR TITLE
Implemented support for HoloViews widgets

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -259,9 +259,8 @@ class HoloViews(PaneBase):
                 layout = _BkRow()
                 wbox = self.widget_box._get_model(doc, root, parent, comm)
                 layout.children = [model, wbox]
-                parent = layout
             self._link_widgets(widgets, child_pane, layout, plot, comm)
-        self._link_object(model, doc, root, parent, comm)
+        self._link_object(layout, doc, root, parent, comm)
         return layout
 
     def _link_widgets(self, widgets, pane, model, plot, comm):
@@ -331,6 +330,7 @@ class HoloViews(PaneBase):
                                      end=dim.range[1], value=default)
             widgets.append(widget)
         return widgets
+
 
 
 class DivPaneBase(PaneBase):

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -19,7 +19,7 @@ except:
 
 import param
 
-from bokeh.layouts import Row as _BkRow, Column as _BkColumn, WidgetBox as _BkWidgetBox
+from bokeh.layouts import Row as _BkRow, WidgetBox as _BkWidgetBox
 from bokeh.models import LayoutDOM, CustomJS, Widget as _BkWidget, Div as _BkDiv
 
 from .util import (Div, basestring, unicode, get_method_owner, push,
@@ -291,12 +291,13 @@ class HoloViews(PaneBase):
         from .widgets import DiscreteSlider, Select, FloatSlider
 
         dims, keys = unique_dimkeys(object)
+        values = dict(zip(dims, zip(*keys)))
         widgets = []
         for dim in dims:
+            values = dim.values or values[dim]
             if dim.name in self.widgets:
                 widget = self.widgets[dim.name]
-            elif dim.values:
-                values = dim.values
+            elif values:
                 if all(isnumeric(v) for v in values):
                     values = sorted(values)
                     labels = [unicode(dim.pprint_value(v)) for v in values]
@@ -312,8 +313,6 @@ class HoloViews(PaneBase):
                 step = 0.1 if dim.step is None else dim.step 
                 widget = FloatSlider(step=step, name=dim.label, start=dim.range[0],
                                      end=dim.range[1], value=default)
-            else:
-                continue
             widgets.append(widget)
         return widgets
 

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -7,6 +7,7 @@ import pytest
 from bokeh.models import (Div, Row as BkRow, WidgetBox as BkWidgetBox,
                           GlyphRenderer, Circle, Line)
 from bokeh.plotting import Figure
+from panel.layout import Column
 from panel.pane import (Pane, PaneBase, Bokeh, HoloViews, Matplotlib,
                         HTML, Str, PNG, JPG, GIF)
 from panel.widgets import FloatSlider, DiscreteSlider, Select
@@ -181,7 +182,50 @@ def test_holoviews_widgets_from_dynamicmap(document, comm):
 
 
 @hv_available
-def test_holoviews_widgets_from_holomap(document, comm):
+def test_holoviews_with_widgets(document, comm):
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
+
+    hv_pane = HoloViews(hmap)
+    layout = hv_pane._get_root(document, comm)
+    model = layout.children[0]
+    assert len(hv_pane.widget_box.objects) == 2
+    assert hv_pane.widget_box.objects[0].name == 'X'
+    assert hv_pane.widget_box.objects[1].name == 'Y'
+
+    assert model.ref['id'] in hv_pane._callbacks
+
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['A', 'B'])
+    hv_pane.object = hmap
+    assert model.ref['id'] not in hv_pane._callbacks
+    assert len(hv_pane.widget_box.objects) == 2
+    assert hv_pane.widget_box.objects[0].name == 'A'
+    assert hv_pane.widget_box.objects[1].name == 'B'
+
+
+@hv_available
+def test_holoviews_with_widgets_not_shown(document, comm):
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
+
+    hv_pane = HoloViews(hmap, show_widgets=False)
+    layout_obj = Column(hv_pane, hv_pane.widget_box)
+    layout = layout_obj._get_root(document, comm)
+    model = layout.children[0]
+    assert len(hv_pane.widget_box.objects) == 2
+    assert hv_pane.widget_box.objects[0].name == 'X'
+    assert hv_pane.widget_box.objects[1].name == 'Y'
+
+    assert model.ref['id'] in hv_pane._callbacks
+
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['A', 'B'])
+    hv_pane.object = hmap
+    assert model.ref['id'] not in hv_pane._callbacks
+    assert len(hv_pane.widget_box.objects) == 2
+    assert hv_pane.widget_box.objects[0].name == 'A'
+    assert hv_pane.widget_box.objects[1].name == 'B'
+
+    
+@hv_available
+def test_holoviews_widgets_from_holomap():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     widgets = HoloViews.widgets_from_dimensions(hmap)
@@ -198,7 +242,7 @@ def test_holoviews_widgets_from_holomap(document, comm):
 
 
 @hv_available
-def test_holoviews_widgets_explicit_widget_type_override(document, comm):
+def test_holoviews_widgets_explicit_widget_type_override():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     widgets = HoloViews.widgets_from_dimensions(hmap, widget_types={'X': Select})
@@ -210,7 +254,7 @@ def test_holoviews_widgets_explicit_widget_type_override(document, comm):
 
 
 @hv_available
-def test_holoviews_widgets_invalid_widget_type_override(document, comm):
+def test_holoviews_widgets_invalid_widget_type_override():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     with pytest.raises(ValueError):
@@ -218,7 +262,7 @@ def test_holoviews_widgets_invalid_widget_type_override(document, comm):
 
 
 @hv_available
-def test_holoviews_widgets_explicit_widget_type_override(document, comm):
+def test_holoviews_widgets_explicit_widget_instance_override():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     widget = Select(options=[1, 2, 3], value=3)


### PR DESCRIPTION
This PR allows the HoloViews pane to display widgets for a DynamicMap and HoloMap. By default the display will match the HoloViews behavior but by setting ``show_widgets=False`` the widgets may be laid out manually:

![screen shot 2018-10-03 at 1 57 20 pm](https://user-images.githubusercontent.com/1550771/46411789-981b4f00-c714-11e8-8c7c-489bdf9e15dc.png)

Additionally it also allows overriding the default widgets with a custom widget instance:

![dmap_widgets](https://user-images.githubusercontent.com/1550771/46411868-c26d0c80-c714-11e8-8498-73978db06f33.gif)

- [x] Handle HoloMaps
- [x] Add unit tests