### PR TITLE
Added SVG Pane

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -488,7 +488,7 @@ class SVG(Image):
     def _img(self):
         if (isinstance(self.object, basestring) and
             self.object.lstrip().startswith('<svg')):
-            return self.object.encode('utf-8')
+            return self.object
         return super(SVG, self)._img()
 
     def _imgshape(self, data):
@@ -498,6 +498,8 @@ class SVG(Image):
         p = super(Image, self)._get_properties()
         data = self._img()
         width, height = self._imgshape(data)
+        if not isinstance(data, bytes):
+            data = data.encode('utf-8')
         b64 = base64.b64encode(data).decode("utf-8")
         src = "data:image/svg+xml;base64,{b64}".format(b64=b64)
         html = "<img src='{src}' width={width} height={height}></img>".format(

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -476,6 +476,25 @@ class JPG(Image):
         return int(w), int(h)
 
 
+class SVG(Image):
+
+    imgtype = 'svg'
+
+    def _imgshape(self, data):
+        return (self.width, self.height)
+
+    def _get_properties(self):
+        p = super(Image, self)._get_properties()
+        data = self._img()
+        width, height = self._imgshape(data)
+        b64 = base64.b64encode(data).decode("utf-8")
+        src = "data:image/svg+xml;base64,{b64}".format(b64=b64)
+        html = "<img src='{src}' width={width} height={height}></img>".format(
+            src=src, width=width, height=height
+        )
+        return dict(p, width=width, height=height, text=html)
+
+
 class Matplotlib(PNG):
     """
     A Matplotlib pane renders a matplotlib figure to png and wraps the

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -480,6 +480,17 @@ class SVG(Image):
 
     imgtype = 'svg'
 
+    @classmethod
+    def applies(cls, obj):
+        return (super(SVG, cls).applies(obj) or
+                (isinstance(obj, basestring) and obj.lstrip().startswith('<svg')))
+
+    def _img(self):
+        if (isinstance(self.object, basestring) and
+            self.object.lstrip().startswith('<svg')):
+            return self.object.encode('utf-8')
+        return super(SVG, self)._img()
+
     def _imgshape(self, data):
         return (self.width, self.height)
 


### PR DESCRIPTION
Adds an SVG pane, unlike other image types the size and/or aspect ratio of the SVG cannot be easily computed ahead of time, but it still seems default to its native size unless explicitly overridden.

![screen shot 2018-10-08 at 2 13 10 am](https://user-images.githubusercontent.com/1550771/46589284-c0ea6e00-ca9f-11e8-9727-5c7861be7525.png)
