### PR TITLE
Add Markdown pane

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -21,8 +21,7 @@ import param
 from bokeh.layouts import Row as _BkRow, WidgetBox as _BkWidgetBox
 from bokeh.models import LayoutDOM, CustomJS, Widget as _BkWidget, Div as _BkDiv
 
-from .util import (Div, basestring, unicode, get_method_owner, push,
-                   remove_root)
+from .util import Div, basestring, get_method_owner, push, remove_root
 from .viewable import Reactive, Viewable
 
 

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -17,6 +17,7 @@ except:
     from cgi import escape
 
 import param
+import markdown
 
 from bokeh.layouts import Row as _BkRow, WidgetBox as _BkWidgetBox
 from bokeh.models import LayoutDOM, CustomJS, Widget as _BkWidget, Div as _BkDiv
@@ -647,10 +648,6 @@ class Markdown(DivPaneBase):
 
     @classmethod
     def applies(cls, obj):
-        try:
-            import markdown # noqa
-        except:
-            return False
         if hasattr(obj, '_repr_markdown_'):
             return 0.3
         elif isinstance(obj, basestring):
@@ -659,7 +656,6 @@ class Markdown(DivPaneBase):
             return False
 
     def _get_properties(self):
-        import markdown
         data = self.object
         if not isinstance(data, basestring):
             data = data._repr_markdown_()

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -80,13 +80,13 @@ class PaneBase(Reactive):
         descendents = []
         for p in param.concrete_descendents(PaneBase).values():
             precedence = p.applies(obj) if p.precedence is None else p.precedence
-            if isinstance(precedence, bool):
+            if isinstance(precedence, bool) and precedence:
                 raise ValueError('If a Pane declares no precedence '
                                  'the applies method should return a '
                                  'precedence value specific to the '
-                                 'object type, %s pane declares no '
-                                 'precedence.' % p.__name__)
-            elif precedence is None:
+                                 'object type or False, %s pane '
+                                 'declares no precedence.' % p.__name__)
+            elif precedence is None or precedence is False:
                 continue
             descendents.append((precedence, p))
         pane_types = reversed(sorted(descendents, key=lambda x: x[0]))
@@ -97,7 +97,8 @@ class PaneBase(Reactive):
         raise TypeError('%s type could not be rendered.' % type(obj).__name__)
 
     def __init__(self, object, **params):
-        if not self.applies(object):
+        applies = self.applies(object)
+        if isinstance(applies, bool) and not applies:
             name = type(self).__name__
             raise ValueError('%s object not understood by %s, '
                              'expected %s object.' %
@@ -603,6 +604,8 @@ class HTML(DivPaneBase):
             return 0.2
         elif isinstance(obj, basestring):
             return None
+        else:
+            return False
 
     def _get_properties(self):
         properties = super(HTML, self)._get_properties()
@@ -648,13 +651,13 @@ class Markdown(DivPaneBase):
         try:
             import markdown # noqa
         except:
-            return None
+            return False
         if hasattr(obj, '_repr_markdown_'):
             return 0.3
         elif isinstance(obj, basestring):
             return 0.1
         else:
-            return None
+            return False
 
     def _get_properties(self):
         import markdown

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -9,7 +9,7 @@ from bokeh.models import (Div, Row as BkRow, WidgetBox as BkWidgetBox,
 from bokeh.plotting import Figure
 from panel.layout import Column
 from panel.pane import (Pane, PaneBase, Bokeh, HoloViews, Matplotlib,
-                        HTML, Str, PNG, JPG, GIF, SVG)
+                        HTML, Str, PNG, JPG, GIF, SVG, Markdown)
 from panel.widgets import FloatSlider, DiscreteSlider, Select
 
 try:
@@ -305,12 +305,36 @@ def test_matplotlib_pane(document, comm):
     assert pane._callbacks == {}
 
 
-def test_get_html_pane_type():
-    assert PaneBase.get_pane_type("<h1>Test</h1>") is HTML
+def test_get_markdown_pane_type():
+    assert PaneBase.get_pane_type("**Markdown**") is Markdown
+
+
+def test_markdown_pane(document, comm):
+    pane = Pane("**Markdown**")
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert model.ref['id'] in pane._callbacks
+    div = get_div(model)
+    assert div.text == "<p><strong>Markdown</strong></p>"
+
+    # Replace Pane.object
+    pane.object = "*Markdown*"
+    model = row.children[0]
+    assert div is get_div(model)
+    assert model.ref['id'] in pane._callbacks
+    assert div.text == "<p><em>Markdown</em></p>"
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._callbacks == {}
 
 
 def test_html_pane(document, comm):
-    pane = Pane("<h1>Test</h1>")
+    pane = HTML("<h1>Test</h1>")
 
     # Create pane
     row = pane._get_root(document, comm=comm)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'bokeh >=0.12.15',
     'param >=1.8.0a0',    
     'pyviz_comms >=0.6.0',
+    'markdown',
     'testpath<0.4' # temporary due to pip issue?
 ]
 


### PR DESCRIPTION
The ``Markdown`` pane renders to HTML using the markdown python library. It has a precedence of None which means it will never be used automatically, therefore a user has to explicitly wrap their markdown formatted text in a ``Markdown`` pane.

![screen shot 2018-10-08 at 2 30 29 am](https://user-images.githubusercontent.com/1550771/46589515-38b99800-caa2-11e8-8e48-b4c6d68ff1f8.png)
