### PR TITLE
Added decoding for base64-encoded images

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -430,6 +430,8 @@ class Image(DivPaneBase):
     def _get_properties(self):
         p = super(Image,self)._get_properties()
         data = self._img()
+        if isinstance(data, str):
+            data = base64.b64decode(data)
         width, height = self._imgshape(data)
         if self.width is not None:
             if self.height is None:


### PR DESCRIPTION
Right now, Image types accept a binary bytes object and return a base64-encoded HTML representation of the image suitable for embedding in an HTML document.  Some packages like Datashader return such a bytes object from their `_repr_png_()` methods, which works well, but other `_repr_png_` methods like the ones in `nxpd` return a string already base64 encoded.  With this PR, if a string is provided as the image data, Panel will base64-decode the string before moving on; it will later be base64 encoded again.  This double decoding and subsequent re-encoding isn't optimal, but it's a simple fix for not being able to view such objects.

The code uses `isinstance(...,str)` to check for the string, which seems safe for py2/py3 because a base64-encoded string should not normally be unicode on either Python version.
