### PR TITLE
Added PNG/Matplotlib-based LaTeX pane

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -571,7 +571,7 @@ def latex_to_img(text, size=25, dpi=100):
     import io
     
     buf = io.BytesIO()
-    with plt.rc_context({'text.usetex': True, 'font.family': 'serif'}):
+    with plt.rc_context({'text.usetex': False, 'mathtext.fontset': 'stix'}):
         fig = plt.figure()
         ax = fig.add_subplot(111)
         ax.axis('off')

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -620,6 +620,10 @@ class LaTeX(PNG):
     @classmethod
     def applies(cls, obj):
         if hasattr(obj, '_repr_latex_'):
+            try:
+                import matplotlib, PIL
+            except ImportError:
+                return False
             return 0.25
         elif isinstance(obj, basestring):
             return None

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -612,16 +612,16 @@ class LaTeX(PNG):
     precedence = None
 
     size = param.Number(default=25, bounds=(1, 100), doc="""
-        Scales the size of the rendered equation.""")
+        Size of the rendered equation.""")
 
-    dpi = param.Number(default=100, bounds=(1, 1900), doc="""
-        Matplotlib dpi parameter.""")
+    dpi = param.Number(default=72, bounds=(1, 1900), doc="""
+        Resolution per inch for the rendered equation.""")
 
     @classmethod
     def applies(cls, obj):
         if hasattr(obj, '_repr_latex_'):
             try:
-                import matplotlib, PIL
+                import matplotlib, PIL # noqa
             except ImportError:
                 return False
             return 0.25
@@ -629,6 +629,12 @@ class LaTeX(PNG):
             return None
         else:
             return False
+
+    def _imgshape(self, data):
+        """Calculate and return image width,height"""
+        w, h = super(LaTeX, self)._imgshape(data)
+        w, h = (w/self.dpi), (h/self.dpi)
+        return int(w*72), int(h*72)
 
     def _img(self):
         obj=self.object if isinstance(self.object, basestring) else \

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -9,7 +9,7 @@ from bokeh.models import (Div, Row as BkRow, WidgetBox as BkWidgetBox,
 from bokeh.plotting import Figure
 from panel.layout import Column
 from panel.pane import (Pane, PaneBase, Bokeh, HoloViews, Matplotlib,
-                        HTML, Str, PNG, JPG, GIF, SVG, Markdown)
+                        HTML, Str, PNG, JPG, GIF, SVG, Markdown, LaTeX)
 from panel.widgets import FloatSlider, DiscreteSlider, Select
 
 try:
@@ -351,6 +351,25 @@ def test_html_pane(document, comm):
     assert div is get_div(model)
     assert model.ref['id'] in pane._callbacks
     assert div.text == "<h2>Test</h2>"
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._callbacks == {}
+
+
+def test_latex_pane(document, comm):
+    pane = LaTeX(r"$\frac{p^3}{q}$")
+
+    # Create pane
+    row = pane._get_root(document, comm=comm)
+    assert isinstance(row, BkRow)
+    assert len(row.children) == 1
+    model = row.children[0]
+    assert model.ref['id'] in pane._callbacks
+    div = get_div(model)
+    # Just checks for a PNG, not a specific rendering, to avoid
+    # false alarms when formatting of the PNG changes
+    assert div.text[0:37] == "<img src='data:image/png;base64,iVBOR"
 
     # Cleanup
     pane._cleanup(model)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ _recommended = [
     'notebook >=5.4',
     'holoviews>1.10.5',
     'matplotlib',
+    'pillow',
     'plotly'
 ]
 


### PR DESCRIPTION
Accepts LaTeX strings and objects with `_repr_latex_`, such as `IPython.display.Latex`:

```
import panel as pn
from panel import pane
from IPython.display import Latex
pn.Row(pane.LaTeX(r'$\frac{x}{y^2}$'), Latex(r'$\frac{x}{y^2}$'))
```
![image](https://user-images.githubusercontent.com/1695496/46675962-2d02ca00-cba5-11e8-90fb-8eafa0e95e5b.png)

Uses Matplotlib to render to a PNG and Pillow to crop it and make it transparent.  Could also consider using MathJax to create true (non-image) equations, but that would require a custom Bokeh model to get the JavaScript required.