### PR TITLE
Ensure that model state is updated inside interact and Params

### DIFF
--- a/panel/interact.py
+++ b/panel/interact.py
@@ -185,6 +185,7 @@ class interactive(PaneBase):
                 new_object = self.object(**self.kwargs)
                 pane_type = self.get_pane_type(new_object)
                 if type(self._pane) is pane_type:
+                    index = layout.children.index(old_model)
                     if isinstance(new_object, PaneBase):
                         new_params = {k: v for k, v in new_object.get_param_values()
                                       if k != 'name'}
@@ -192,6 +193,19 @@ class interactive(PaneBase):
                         new_object._cleanup(None, new_object._temporary)
                     else:
                         self._pane.object = new_object
+
+                    # If model has changed update history and remap callbacks
+                    def update_state():
+                        if old_model is layout.children[index]:
+                            return
+                        new_model = layout.children[index]
+                        history[0] = new_model
+
+                    if comm:
+                        update_state()
+                    else:
+                        doc.add_next_tick_callback(update_state)
+
                     return
 
                 # Replace pane entirely

--- a/panel/param.py
+++ b/panel/param.py
@@ -394,7 +394,9 @@ class ParamMethod(PaneBase):
                     self._pane.object = new_object
 
                 # If model has changed update history and remap callbacks
-                if old_model is not parent.children[index]:
+                def update_state():
+                    if old_model is parent.children[index]:
+                        return
                     new_model = parent.children[index]
                     history[0] = new_model
                     new_ref = new_model.ref['id']
@@ -402,6 +404,10 @@ class ParamMethod(PaneBase):
                     if old_callbacks:
                         self._callbacks[new_ref] = old_callbacks
 
+                if comm:
+                    update_state()
+                else:
+                    doc.add_next_tick_callback(update_state)
                 return
 
             # Replace pane entirely


### PR DESCRIPTION
When a ParamMethod pane or interact pane updates a plot without replacing the model entirely the internal state of the callback needs to be updated to keep track of the current models. On bokeh server this update to the state needs to be scheduled on the event loop rather than executing it immediately.

- [x] Fixes https://github.com/pyviz/pyviz/issues/116