### PR TITLE
WIP: try to clean up dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ sudo: false
 env:
   global:
     - PYENV_VERSION=3.6
-    - CHANS_DEV="-c pyviz/label/dev -c jbednar"
-    - CHANS_REL="-c pyviz -c jbednar"
+    - CHANS_DEV="-c pyviz/label/dev -c defaults -c conda-forge"
+    - CHANS_REL="-c pyviz -c defaults -c conda-forge"
     - LABELS_DEV="--label dev"
     - LABELS_REL="--label dev --label main"
     - PKG_TEST_PYTHON="--test-python=py27 --test-python=py36"
@@ -50,7 +50,6 @@ jobs:
         - doit env_create $CHANS_DEV --python=$PYENV_VERSION
         - source activate test-environment
         - doit develop_install -o recommended -o tests $CHANS_DEV
-        - pip install codecov altair
         - doit env_capture
       script: doit test_all_recommended
       after_success: codecov

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ extras_require = {
         'scipy',
         'nbsmoke >=0.2.0',
         'pytest-cov',
+        'codecov',
         # For Panes.ipynb
         'plotly',
         'altair',


### PR DESCRIPTION
Couple of questions...

### Which dependencies are not on defaults but are on conda-forge? 

To avoid the conda-forge channel being a requirement, what about requesting those packages be added to defaults? Or if they are straightforward python packages, why not copy them to the pyviz channel instead of adding another channel?

### Which code coverage tools and services do you want to use?

### Dependencies needed to run examples/build docs

In the 'test' dependencies, there's:
```
        # For Panes.ipynb                                                                                                                      
        'plotly',
        'altair',
        'vega_datasets'
```

Are they really test dependencies, or are they needed to run the examples (e.g. for a doc build, or a user who wants to run the examples)?