### PR TITLE
Reduced LaTeX pane priority so it is a last resort

### DIFF
--- a/panel/pane.py
+++ b/panel/pane.py
@@ -473,7 +473,7 @@ class LaTeX(PNG):
                 import matplotlib, PIL # noqa
             except ImportError:
                 return False
-            return 0.25
+            return 0.05
         elif isinstance(obj, basestring):
             return None
         else:


### PR DESCRIPTION
Pandas dataframes have both `_repr_latex_` and `_repr_html_` methods, but pane.LaTeX can only handle equations, not full LaTeX tables, so we need to use pane.HTML instead.  In general pane.HTML is more general in its support than pane.LaTeX, so it makes sense to prefer pane.HTML.