### PR TITLE
Implement Player widget

### DIFF
--- a/examples/user_guide/Widgets.ipynb
+++ b/examples/user_guide/Widgets.ipynb
@@ -209,6 +209,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The widget will parse the string that is entered as long as it conforms to the specified ``format`` and return the value as a datetime object:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -270,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MultiSelect allows selecting "
+    "MultiSelect allows selecting multiple values which may be of any type:"
    ]
   },
   {
@@ -300,6 +307,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The DatePicker allows selecting a date using arrow keys and a date selection widget that pops up:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -307,6 +321,13 @@
    "source": [
     "date_picker = DatePicker(name='Date Picker', value=dt.datetime(2017, 1, 2), start=dt.datetime(2017, 1, 1))\n",
     "date_picker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just like the ``DatetimeInput`` widget it returns a datetime object:"
    ]
   },
   {
@@ -326,6 +347,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DateRangeSlider allows selecting a range of dates:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -334,6 +362,13 @@
     "date_range = DateRangeSlider(start=dt.datetime(2017, 1, 1), end=dt.datetime(2017, 1, 5),\n",
     "                     value=(dt.datetime(2017, 1, 2), dt.datetime(2017, 1, 3)), name='DateRange')\n",
     "date_range"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The value is returned as a tuple of datetimes:"
    ]
   },
   {
@@ -350,6 +385,13 @@
    "metadata": {},
    "source": [
     "### Checkbox"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A ``Checkbox`` allows toggling between true and false states:"
    ]
   },
   {
@@ -379,6 +421,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A RangeSlider allows selecting a range of numeric values:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -386,6 +435,13 @@
    "source": [
     "range_slider = RangeSlider(name='Range Slider', start=0, end=10, value=(2, 10))\n",
     "range_slider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current range is returned as a tuple of the lower and upper bound:"
    ]
   },
   {
@@ -402,6 +458,13 @@
    "metadata": {},
    "source": [
     "### FloatSlider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A FloatSlider allows defining a single float value within a certain range and allows customizing the step:"
    ]
   },
   {
@@ -431,12 +494,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A FloatSlider allows selecting a single integer value within a certain range and allows customizing the (integer) step:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "int_slider = IntSlider(name='Slider', start=0, end=10, value=1)\n",
+    "int_slider = IntSlider(name='Slider', start=0, end=15, value=5, step=5)\n",
     "int_slider"
    ]
   },
@@ -454,6 +524,13 @@
    "metadata": {},
    "source": [
     "### DiscreteSlider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A DiscreteSlider allows selecting between any number of discrete numeric values defined via the ``options``:"
    ]
   },
   {
@@ -509,6 +586,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A ``Toggle`` button allows toggling between boolean True and False states:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -519,12 +603,71 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current state is available as the ``active`` parameter value:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "toggle.active"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Player\n",
+    "\n",
+    "The Player widget allows playing and skipping through a number of frames defined by the ``length``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "player = Player(length=100)\n",
+    "player"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current value of the player widget can be read out:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "player.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All the Player state including the ``length``, ``value``, ``interval`` and ``loop_policy`` can be set dynamically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "player.loop_policy = 'loop'\n",
+    "player.length = 20"
    ]
   }
  ],

--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -135,7 +135,7 @@ class HoloViews(PaneBase):
 
         dims, keys = unique_dimkeys(object)
         if dims == [Dimension('Frame')] and keys == [(0,)]:
-            return []
+            return [], {}
 
         nframes = 1
         values = dict(zip(dims, zip(*keys)))

--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -9,11 +9,12 @@ import sys
 from collections import OrderedDict
 
 import param
-from bokeh.layouts import Row as _BkRow
+from bokeh.layouts import Row as _BkRow, Column as _BkColumn
 
 from .layout import Layout, WidgetBox
 from .pane import PaneBase, Pane
 from .viewable import Viewable
+from .widgets import Player
 
 
 class HoloViews(PaneBase):
@@ -29,6 +30,11 @@ class HoloViews(PaneBase):
     show_widgets = param.Boolean(default=True, doc="""
         Whether to display widgets for the object. If disabled the
         widget_box may be laid out manually.""")
+
+    widget_type = param.ObjectSelector(default='individual',
+                                       objects=['individual', 'scrubber'], doc=""")
+        Whether to generate individual widgets for each dimension or
+        on global scrubber.""")
 
     widgets = param.Dict(default={}, doc="""
         A mapping from dimension name to a widget instance which will
@@ -78,13 +84,17 @@ class HoloViews(PaneBase):
         plot = self._render(doc, comm, root)
         child_pane = Pane(plot.state, _temporary=True)
         model = child_pane._get_model(doc, root, parent, comm)
-        widgets = self.widgets_from_dimensions(self.object, self.widgets)
+        widgets, values = self.widgets_from_dimensions(self.object, self.widgets, self.widget_type)
+        self._values = values
         layout = model
         if widgets:
             self.widget_box.objects = widgets
             if self.show_widgets:
-                layout = _BkRow()
                 wbox = self.widget_box._get_model(doc, root, parent, comm)
+                if self.widget_type == 'individual':
+                    layout = _BkRow()
+                else:
+                    layout = _BkColumn()
                 layout.children = [model, wbox]
             self._link_widgets(widgets, child_pane, layout, plot, comm)
         self._link_object(layout, doc, root, parent, comm)
@@ -92,9 +102,14 @@ class HoloViews(PaneBase):
         return layout
 
     def _link_widgets(self, widgets, pane, model, plot, comm):
+        from holoviews.core.util import cross_index
+
         def update_plot(change):
             from holoviews.plotting.bokeh.plot import BokehPlot
-            key = tuple(w.value for w in widgets)
+            if self.widget_type == 'scrubber':
+                key = cross_index([v for v in self._values.values()], widgets[0].value)
+            else:
+                key = tuple(w.value for w in widgets)
             if isinstance(plot, BokehPlot):
                 if comm:
                     plot.update(key)
@@ -112,7 +127,7 @@ class HoloViews(PaneBase):
             self._callbacks[model.ref['id']].append(watcher)
 
     @classmethod
-    def widgets_from_dimensions(cls, object, widget_types={}):
+    def widgets_from_dimensions(cls, object, widget_types={}, widgets_type='individual'):
         from holoviews.core import Dimension
         from holoviews.core.util import isnumeric, unicode
         from holoviews.core.traversal import unique_dimkeys
@@ -122,12 +137,19 @@ class HoloViews(PaneBase):
         if dims == [Dimension('Frame')] and keys == [(0,)]:
             return []
 
+        nframes = 1
         values = dict(zip(dims, zip(*keys)))
+        dim_values = OrderedDict()
         widgets = []
         for dim in dims:
             widget_type = None
             vals = dim.values or values.get(dim, None)
-            if dim.name in widget_types:
+            dim_values[dim.name] = vals
+            if widgets_type == 'scrubber':
+                if not vals:
+                    raise ValueError('Scrubber widget may only be used if all dimensions define values.')
+                nframes *= len(vals)
+            elif dim.name in widget_types:
                 widget = widget_types[dim.name]
                 if isinstance(widget, Widget):
                     widgets.append(widget)
@@ -157,7 +179,9 @@ class HoloViews(PaneBase):
                 widget = widget_type(step=step, name=dim.label, start=dim.range[0],
                                      end=dim.range[1], value=default)
             widgets.append(widget)
-        return widgets
+        if widgets_type == 'scrubber':
+            widgets = [Player(length=nframes)]
+        return widgets, dim_values
 
 
 

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -31,7 +31,7 @@ export class PlayerView extends WidgetView {
     } else {
       this.sliderEl.style = `width:{this.model.width}px`
       this.sliderEl.max = this.model.length - 1;
-	  this.sliderEl.value = this.model.value;
+      this.sliderEl.value = this.model.value;
       return
     }
 
@@ -41,11 +41,11 @@ export class PlayerView extends WidgetView {
     this.sliderEl.style = `width:{this.model.width}px`
     this.sliderEl.value = 0;
     this.sliderEl.max = this.model.length - 1;
-	this.sliderEl.onchange = (ev) => this.set_frame(parseInt(ev.target.value))
+    this.sliderEl.onchange = (ev) => this.set_frame(parseInt(ev.target.value))
 
     // Buttons
     const button_div = div() as any;
-	button_div.style = "margin: 0 auto; display: table; padding: 5px"
+    button_div.style = "margin: 0 auto; display: table; padding: 5px"
     const button_style = "text-align: center; min-width: 40px";
 
     const slower = document.createElement('button')
@@ -104,31 +104,31 @@ export class PlayerView extends WidgetView {
 
     // Loop control
     this.loop_state = document.createElement('form')
-	this.loop_state.style = "margin: 0 auto; display: table"
+    this.loop_state.style = "margin: 0 auto; display: table"
 
     const once = document.createElement('input')
-	once.type = "radio";
+    once.type = "radio";
     once.value = "once";
     once.name = "state";
-	const once_label = document.createElement('label');
-	once_label.innerHTML = "Once"
-	once_label.style = "padding: 0 10px 0 5px; user-select:none;"
+    const once_label = document.createElement('label');
+    once_label.innerHTML = "Once"
+    once_label.style = "padding: 0 10px 0 5px; user-select:none;"
 
     const loop = document.createElement('input')
     loop.setAttribute("type", "radio");
     loop.setAttribute("value", "loop");
     loop.setAttribute("name", "state");
-	const loop_label = document.createElement('label');
-	loop_label.innerHTML = "Loop"
-	loop_label.style = "padding: 0 10px 0 5px; user-select:none;"
+    const loop_label = document.createElement('label');
+    loop_label.innerHTML = "Loop"
+    loop_label.style = "padding: 0 10px 0 5px; user-select:none;"
 
     const reflect = document.createElement('input')
     reflect.setAttribute("type", "radio");
     reflect.setAttribute("value", "reflect");
     reflect.setAttribute("name", "state");
-	const reflect_label = document.createElement('label');
-	reflect_label.innerHTML = "Reflect"
-	reflect_label.style = "padding: 0 10px 0 5px; user-select:none;"
+    const reflect_label = document.createElement('label');
+    reflect_label.innerHTML = "Reflect"
+    reflect_label.style = "padding: 0 10px 0 5px; user-select:none;"
 
     if (this.model.loop_policy == "once")
       once.checked = true
@@ -151,10 +151,10 @@ export class PlayerView extends WidgetView {
   }
 
   set_frame(frame: number): void {
-	if (this.model.value != frame)
+    if (this.model.value != frame)
       this.model.value = frame;
-	if (this.sliderEl.value != frame)
-	  this.sliderEl.value = frame;
+    if (this.sliderEl.value != frame)
+      this.sliderEl.value = frame;
   }
 
   get_loop_state(): void {
@@ -170,8 +170,8 @@ export class PlayerView extends WidgetView {
     var button_group = this.loop_state.state;
     for (var i = 0; i < button_group.length; i++) {
       var button = button_group[i];
-	  if (button.value == state)
-		button.checked = true
+      if (button.value == state)
+        button.checked = true
     }
   }
 
@@ -292,7 +292,7 @@ export abstract class Player extends Widget {
       value:             [ p.Any,         0            ],
     })
 
-	this.override({width: 350})
+    this.override({width: 350})
   }
 }
 

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -1,0 +1,299 @@
+import * as p from "core/properties"
+import {div} from "core/dom"
+import {Widget, WidgetView} from "models/widgets/widget"
+
+export class PlayerView extends WidgetView {
+  model: Player
+
+  protected sliderEl: HTMLElement
+  protected loop_state: HTMLElement
+  protected timer: any
+
+  initialize(options: any): void {
+    super.initialize(options)
+    this.render()
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+    this.connect(this.model.change, () => this.render())
+    this.connect(this.model.properties.value.change, () => this.render())
+    this.connect(this.model.properties.loop_policy.change, () => this.set_loop_state(this.model.loop_policy))
+  }
+
+  get_height(): number {
+    return 250
+  }
+
+  render(): void {
+    if (this.sliderEl == null) {
+      super.render()
+    } else {
+      this.sliderEl.style = `width:{this.model.width}px`
+      this.sliderEl.max = this.model.length - 1;
+	  this.sliderEl.value = this.model.value;
+      return
+    }
+
+    // Slider
+    this.sliderEl = document.createElement('input')
+    this.sliderEl.setAttribute("type", "range");
+    this.sliderEl.style = `width:{this.model.width}px`
+    this.sliderEl.value = 0;
+    this.sliderEl.max = this.model.length - 1;
+	this.sliderEl.onchange = (ev) => this.set_frame(parseInt(ev.target.value))
+
+    // Buttons
+    const button_div = div() as any;
+	button_div.style = "margin: 0 auto; display: table; padding: 5px"
+    const button_style = "text-align: center; min-width: 40px";
+
+    const slower = document.createElement('button')
+    slower.style = "text-align: center; min-width: 20px"
+    slower.appendChild(document.createTextNode('–'))
+    slower.onclick = () => this.slower()
+    button_div.appendChild(slower)
+
+    const first = document.createElement('button')
+    first.style = button_style
+    first.appendChild(document.createTextNode('❚◀◀'))
+    first.onclick = () => this.first_frame()
+    button_div.appendChild(first)
+
+    const previous = document.createElement('button')
+    previous.style = button_style
+    previous.appendChild(document.createTextNode('❚◀'))
+    previous.onclick = () => this.previous_frame()
+    button_div.appendChild(previous)
+
+    const reverse = document.createElement('button')
+    reverse.style = button_style
+    reverse.appendChild(document.createTextNode('◀'))
+    reverse.onclick = () => this.reverse_animation()
+    button_div.appendChild(reverse)
+
+    const pause = document.createElement('button')
+    pause.style = button_style
+    pause.appendChild(document.createTextNode('❚❚'))
+    pause.onclick = () => this.pause_animation()
+    button_div.appendChild(pause)
+
+    const play = document.createElement('button')
+    play.style = button_style
+    play.appendChild(document.createTextNode('▶'))
+    play.onclick = () => this.play_animation()
+    button_div.appendChild(play)
+
+    const next = document.createElement('button')
+    next.style = button_style
+    next.appendChild(document.createTextNode('▶❚'))
+    next.onclick = () => this.next_frame()
+    button_div.appendChild(next)
+
+    const last = document.createElement('button')
+    last.style = button_style
+    last.appendChild(document.createTextNode('▶▶❚'))
+    last.onclick = () => this.last_frame()
+    button_div.appendChild(last)
+
+    const faster = document.createElement('button')
+    faster.style = "text-align: center; min-width: 20px"
+    faster.appendChild(document.createTextNode('+'))
+    faster.onclick = () => this.faster()
+    button_div.appendChild(faster)
+
+    // Loop control
+    this.loop_state = document.createElement('form')
+	this.loop_state.style = "margin: 0 auto; display: table"
+
+    const once = document.createElement('input')
+	once.type = "radio";
+    once.value = "once";
+    once.name = "state";
+	const once_label = document.createElement('label');
+	once_label.innerHTML = "Once"
+	once_label.style = "padding: 0 10px 0 5px; user-select:none;"
+
+    const loop = document.createElement('input')
+    loop.setAttribute("type", "radio");
+    loop.setAttribute("value", "loop");
+    loop.setAttribute("name", "state");
+	const loop_label = document.createElement('label');
+	loop_label.innerHTML = "Loop"
+	loop_label.style = "padding: 0 10px 0 5px; user-select:none;"
+
+    const reflect = document.createElement('input')
+    reflect.setAttribute("type", "radio");
+    reflect.setAttribute("value", "reflect");
+    reflect.setAttribute("name", "state");
+	const reflect_label = document.createElement('label');
+	reflect_label.innerHTML = "Reflect"
+	reflect_label.style = "padding: 0 10px 0 5px; user-select:none;"
+
+    if (this.model.loop_policy == "once")
+      once.checked = true
+    else if (this.model.loop_policy == "loop")
+      loop.checked = true
+    else
+      reflect.checked = true
+
+    // Compose everything
+    this.loop_state.appendChild(once)
+    this.loop_state.appendChild(once_label)
+    this.loop_state.appendChild(loop)
+    this.loop_state.appendChild(loop_label)
+    this.loop_state.appendChild(reflect)
+    this.loop_state.appendChild(reflect_label)
+
+    this.el.appendChild(this.sliderEl)
+    this.el.appendChild(button_div)
+    this.el.appendChild(this.loop_state)
+  }
+
+  set_frame(frame: number): void {
+	if (this.model.value != frame)
+      this.model.value = frame;
+	if (this.sliderEl.value != frame)
+	  this.sliderEl.value = frame;
+  }
+
+  get_loop_state(): void {
+    var button_group = this.loop_state.state;
+    for (var i = 0; i < button_group.length; i++) {
+      var button = button_group[i];
+      if (button.checked)
+        return button.value;
+    }
+  }
+
+  set_loop_state(state: string): void {
+    var button_group = this.loop_state.state;
+    for (var i = 0; i < button_group.length; i++) {
+      var button = button_group[i];
+	  if (button.value == state)
+		button.checked = true
+    }
+  }
+
+
+  next_frame(): void {
+    this.set_frame(Math.min(this.model.length - 1, this.model.value + 1));
+  }
+
+  previous_frame(): void {
+    this.set_frame(Math.max(0, this.model.value - 1));
+  }
+
+  first_frame(): void {
+    this.set_frame(0);
+  }
+
+  last_frame(): void {
+    this.set_frame(this.model.length - 1);
+  }
+
+  slower(): void {
+    this.model.interval = Math.round(this.model.interval/0.7);
+    if (this.model.direction > 0)
+      this.play_animation()
+    else if (this.direction < 0)
+      this.reverse_animation()
+  }
+
+  faster(): void {
+    this.model.interval = Math.round(this.model.interval * 0.7);
+    if (this.model.direction > 0)
+      this.play_animation()
+    else if(this.model.direction < 0)
+      this.reverse_animation()
+  }
+
+  anim_step_forward(): void {
+    if(this.model.value < this.model.length - 1){
+      this.next_frame();
+    } else {
+      var loop_state = this.get_loop_state();
+      if(loop_state == "loop"){
+        this.first_frame();
+      }else if(loop_state == "reflect"){
+        this.last_frame();
+        this.reverse_animation();
+      }else{
+        this.pause_animation();
+        this.last_frame();
+      }
+    }
+  }
+
+  anim_step_reverse(): void {
+    if(this.model.value > 0){
+      this.previous_frame();
+    } else {
+      var loop_state = this.get_loop_state();
+      if(loop_state == "loop"){
+        this.last_frame();
+      }else if(loop_state == "reflect"){
+        this.first_frame();
+        this.play_animation();
+      }else{
+        this.pause_animation();
+        this.first_frame();
+      }
+    }
+  }
+
+  pause_animation(): void {
+    this.direction = 0;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  play_animation(): void {
+    this.pause_animation();
+    this.model.direction = 1;
+    if (!this.timer)
+      this.timer = setInterval(() => this.anim_step_forward(), this.model.interval);
+  }
+
+  reverse_animation(): void {
+    this.pause_animation();
+    this.model.direction = -1;
+    if (!this.timer)
+      this.timer = setInterval(() => this.anim_step_reverse(), this.model.interval);
+  }
+}
+
+export namespace Player {
+  export interface Attrs extends Widget.Attrs {}
+  export interface Props extends Widget.Props {}
+}
+
+export interface Player extends Player.Attrs {}
+
+export abstract class Player extends Widget {
+
+  properties: Player.Props
+
+  constructor(attrs?: Partial<Player.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "Player"
+    this.prototype.default_view = PlayerView
+
+    this.define({
+      direction:         [ p.Number,      0            ],
+      interval:          [ p.Number,      500          ],
+      length:            [ p.Number,                   ],
+      loop_policy:       [ p.Any,         "once"       ],
+      value:             [ p.Any,         0            ],
+    })
+
+	this.override({width: 350})
+  }
+}
+
+Player.initClass()

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -1,7 +1,8 @@
 import os
 
 from bokeh.core.properties import Int, Override, Enum
-from bokeh.models import Widget, WidgetBox
+from bokeh.models import Widget
+
 
 class Player(Widget):
     """

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -1,0 +1,25 @@
+import os
+
+from bokeh.core.properties import Int, Override, Enum
+from bokeh.models import Widget, WidgetBox
+
+class Player(Widget):
+    """
+    The Player widget provides controls to play through a number of frames.
+    """
+
+    __implementation__ = os.path.join(os.path.dirname(__file__), 'player.ts')
+
+    length = Int(help="The number of frames to play through")
+
+    value = Int(0, help="Current value of the player app")
+
+    interval = Int(500, help="Interval between updates")
+
+    direction = Int(0, help="""
+        Current play direction of the Player (-1: playing in reverse,
+        0: paused, 1: playing)""")
+
+    loop_policy = Enum('once', 'reflect', 'loop', default='once')
+
+    height = Override(default=250)

--- a/panel/tests/test_holoviews.py
+++ b/panel/tests/test_holoviews.py
@@ -99,7 +99,7 @@ def test_holoviews_widgets_from_dynamicmap(document, comm):
     kdims = [range_dim, range_step_dim, range_default_dim,
              value_dim, value_default_dim, value_numeric_dim]
     dmap = hv.DynamicMap(lambda A, B, C, D, E, F: hv.Curve([]), kdims=kdims)
-    widgets = HoloViews.widgets_from_dimensions(dmap)
+    widgets, _ = HoloViews.widgets_from_dimensions(dmap)
 
     assert len(widgets) == len(kdims)
 
@@ -187,7 +187,7 @@ def test_holoviews_with_widgets_not_shown(document, comm):
 def test_holoviews_widgets_from_holomap():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
-    widgets = HoloViews.widgets_from_dimensions(hmap)
+    widgets, _ = HoloViews.widgets_from_dimensions(hmap)
 
     assert isinstance(widgets[0], DiscreteSlider)
     assert widgets[0].name == 'X'
@@ -204,7 +204,7 @@ def test_holoviews_widgets_from_holomap():
 def test_holoviews_widgets_explicit_widget_type_override():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
-    widgets = HoloViews.widgets_from_dimensions(hmap, widget_types={'X': Select})
+    widgets, _ = HoloViews.widgets_from_dimensions(hmap, widget_types={'X': Select})
 
     assert isinstance(widgets[0], Select)
     assert widgets[0].name == 'X'
@@ -225,7 +225,7 @@ def test_holoviews_widgets_explicit_widget_instance_override():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     widget = Select(options=[1, 2, 3], value=3)
-    widgets = HoloViews.widgets_from_dimensions(hmap, widget_types={'X': widget})
+    widgets, _ = HoloViews.widgets_from_dimensions(hmap, widget_types={'X': widget})
 
     assert widgets[0] is widget
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -318,7 +318,8 @@ class Reactive(Viewable):
         _rename class level attribute to map between parameter and
         property names.
         """
-        return {self._rename.get(k, k): v for k, v in msg.items()}
+        return {self._rename.get(k, k): v for k, v in msg.items()
+                if self._rename.get(k, False) is not None}
 
     def _link_params(self, model, params, doc, root, comm=None):
         def param_change(*events):

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -21,6 +21,7 @@ from bokeh.models.widgets import (
 )
 
 from .layout import WidgetBox # noqa
+from .models.widgets import Player as _BkPlayer
 from .viewable import Reactive
 from .util import as_unicode, push, value_as_datetime, hashable
 
@@ -575,3 +576,27 @@ class DiscreteSlider(Widget):
         if 'value' in msg:
             msg['value'] = self.values[msg['value']]
         return msg
+
+
+class Player(Widget):
+    """
+    The Player provides controls to play and skip through a number of
+    frames defined by the length. The speed at which the widget plays
+    is defined by the interval.
+    """
+
+    interval = param.Integer(default=500, doc="Interval between updates")
+
+    length = param.Integer(default=10, doc="Number of frames")
+
+    loop_policy = param.ObjectSelector(default='once',
+                                       objects=['once', 'loop', 'reflect'], doc="""
+       Policy used when player hits last frame""")
+
+    value = param.Integer(default=0, doc="Current player value")
+
+    height = param.Integer(default=250, readonly=True)
+
+    _widget_type = _BkPlayer
+
+    _rename = {'name': None}


### PR DESCRIPTION
This PR adds a custom bokeh model which replicates the "scrubber" style widget from HoloViews.

Unlike the HoloViews version this one is fully dynamic and the state can be controlled from Python.

![screen shot 2018-10-19 at 12 41 37 pm](https://user-images.githubusercontent.com/1550771/47216305-6359f980-d39c-11e8-9bce-87a2cd04fcf3.png)

Also implements support for using the widget on HoloViews plots:

![screen shot 2018-10-19 at 1 05 50 pm](https://user-images.githubusercontent.com/1550771/47217291-cc8f3c00-d39f-11e8-8889-a8d4391f3766.png)
