### PR TITLE
Allow hiding Params widget by setting negative precedence dynamically

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -260,6 +260,16 @@ class Param(PaneBase):
                 updates = {}
                 if change.what == 'constant':
                     updates['disabled'] = change.new
+                elif change.what == 'precedence':
+                    if change.new < 0 and widget in self._widget_box.objects:
+                        self._widget_box.pop(widget)
+                    elif change.new >= 0 and widget not in self._widget_box.objects:
+                        precedence = lambda k: self.object.params(k).precedence
+                        widgets = []
+                        for k, ws in self._widgets.items():
+                            if precedence(k) is None or precedence(k) >= self.display_threshold:
+                                widgets += ws
+                        self._widget_box.objects = widgets
                 elif change.what == 'objects':
                     updates['options'] = p_obj.get_range()
                 elif change.what == 'bounds':
@@ -277,6 +287,7 @@ class Param(PaneBase):
 
             # Set up links to parameterized object
             watchers.append(self.object.param.watch(link, p_name, 'constant'))
+            watchers.append(self.object.param.watch(link, p_name, 'precedence'))
             watchers.append(self.object.param.watch(link, p_name))
             if hasattr(p_obj, 'get_range'):
                 watchers.append(self.object.param.watch(link, p_name, 'objects'))

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -348,7 +348,6 @@ def test_param_precedence(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
 
     # Check changing precedence attribute hides and shows widget
     a_param = test.params('a')

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -342,6 +342,23 @@ def test_explicit_params(document, comm):
     assert isinstance(model.children[0].children[1], CheckboxGroup)
 
 
+def test_param_precedence(document, comm):
+    class Test(param.Parameterized):
+        a = param.Number(default=1.2, bounds=(0, 5))
+
+    test = Test()
+    test_pane = Pane(test, _temporary=True)
+    model = test_pane._get_model(document, comm=comm)
+
+    # Check changing precedence attribute hides and shows widget
+    a_param = test.params('a')
+    a_param.precedence = -1
+    assert test_pane._widgets['a'][0] not in test_pane._widget_box.objects
+
+    a_param.precedence = 1
+    assert test_pane._widgets['a'][0] in test_pane._widget_box.objects
+
+
 def test_expand_param_subobject(document, comm):
     class Test(param.Parameterized):
         a = param.Parameter()


### PR DESCRIPTION
Allows a Params widget to be hidden and shown again by setting a precedence below the display threshold.