### PR TITLE
Add compositional reprs

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -149,18 +149,18 @@ class Panel(Reactive):
         params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None)
                   and p != 'objects' and not (p == 'name' and v.startswith(cls))]
-        objs = [obj.__repr__(depth+1) for obj in self.objects]
+        objs = ['[%d] %s' % (i, obj.__repr__(depth+1)) for i, obj in enumerate(self.objects)]
         if not params and not objs:
             return super(Panel, self).__repr__(depth+1)
         elif not params:
-            template = '{cls}({spacer}{objs}{small})'
+            template = '{cls}{spacer}{objs}'
         elif not objs:
             template = '{cls}({params})'
         else:
-            template = '{cls}({spacer}{objs},{small} {params})'
+            template = '{cls}({params}){spacer}{objs}'
         return template.format(
-            cls=cls, params=', '.join(params), small=spacer[:-4],
-            objs=(',%s' % spacer).join(objs), spacer=spacer
+            cls=cls, params=', '.join(params),
+            objs=('%s' % spacer).join(objs), spacer=spacer
         )
 
     def append(self, pane):

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -146,7 +146,7 @@ class Panel(Reactive):
     def __repr__(self, depth=0):
         spacer = '\n' + ('    ' * (depth+1))
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
                   if v is not self.params(p).default and v not in ('', None)
                   and p != 'objects' and not (p == 'name' and v.startswith(cls))]
         objs = ['[%d] %s' % (i, obj.__repr__(depth+1)) for i, obj in enumerate(self.objects)]

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -143,6 +143,26 @@ class Panel(Reactive):
         new_objects[index] = panel(pane, _internal=True)
         self.objects = new_objects
 
+    def __repr__(self, depth=0):
+        spacer = '\n' + ('    ' * (depth+1))
+        cls = type(self).__name__
+        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
+                  if v is not self.params(p).default and v not in ('', None)
+                  and p != 'objects' and not (p == 'name' and v.startswith(cls))]
+        objs = [obj.__repr__(depth+1) for obj in self.objects]
+        if not params and not objs:
+            return super(Panel, self).__repr__(depth+1)
+        elif not params:
+            template = '{cls}({spacer}{objs}{small})'
+        elif not objs:
+            template = '{cls}({params})'
+        else:
+            template = '{cls}({spacer}{objs},{small} {params})'
+        return template.format(
+            cls=cls, params=', '.join(params), small=spacer[:-4],
+            objs=(',%s' % spacer).join(objs), spacer=spacer
+        )
+
     def append(self, pane):
         from .pane import panel
         new_objects = list(self.objects)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -10,7 +10,7 @@ from bokeh.layouts import (Column as BkColumn, Row as BkRow,
                            WidgetBox as BkWidgetBox, Spacer as BkSpacer)
 from bokeh.models.widgets import Tabs as BkTabs, Panel as BkPanel
 
-from .util import push
+from .util import push, abbreviated_repr
 from .viewable import Reactive, Viewable
 
 
@@ -146,7 +146,7 @@ class Panel(Reactive):
     def __repr__(self, depth=0):
         spacer = '\n' + ('    ' * (depth+1))
         cls = type(self).__name__
-        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None)
                   and p != 'objects' and not (p == 'name' and v.startswith(cls))]
         objs = ['[%d] %s' % (i, obj.__repr__(depth+1)) for i, obj in enumerate(self.objects)]

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -20,7 +20,7 @@ from bokeh.layouts import WidgetBox as _BkWidgetBox
 from bokeh.models import LayoutDOM, CustomJS, Widget as _BkWidget, Div as _BkDiv
 
 from .layout import Panel, Row
-from .util import Div, basestring, push, remove_root
+from .util import Div, basestring, push, remove_root, abbreviated_repr
 from .viewable import Reactive, Viewable
 
 
@@ -125,7 +125,7 @@ class PaneBase(Reactive):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%s' % (p, v) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None, {}, [])
                   and p != 'object' and not (p == 'name' and v.startswith(cls))]
         obj = type(self.object).__name__

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -125,7 +125,7 @@ class PaneBase(Reactive):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
                   if v is not self.params(p).default and v not in ('', None, {}, [])
                   and p != 'object' and not (p == 'name' and v.startswith(cls))]
         obj = type(self.object).__name__

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -123,6 +123,15 @@ class PaneBase(Reactive):
             return pane_type
         raise TypeError('%s type could not be rendered.' % type(obj).__name__)
 
+    def __repr__(self, depth=0):
+        cls = type(self).__name__
+        params = ['%s=%s' % (p, v) for p, v in self.get_param_values()
+                  if v is not self.params(p).default and v not in ('', None, {}, [])
+                  and p != 'object' and not (p == 'name' and v.startswith(cls))]
+        obj = type(self.object).__name__
+        template = '{cls}({obj}, {params})' if params else '{cls}({obj})'
+        return template.format(cls=cls, params=', '.join(params), obj=obj)
+
     def __init__(self, object, **params):
         applies = self.applies(object)
         if isinstance(applies, bool) and not applies:

--- a/panel/param.py
+++ b/panel/param.py
@@ -18,7 +18,7 @@ from .pane import Pane, PaneBase
 from .layout import WidgetBox, Row, Panel, Tabs
 from .util import (
     default_label_formatter, is_parameterized, get_method_owner,
-    full_groupby
+    full_groupby, abbreviated_repr
 )
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
@@ -141,7 +141,7 @@ class Param(PaneBase):
     def __repr__(self, depth=0):
         cls = type(self).__name__
         params = [k for k in self.object.params() if k != 'name']
-        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None, {}, [])
                   and p != 'object' and not (p == 'name' and v.startswith(cls))
                   and not (p == 'parameters' and v == params)]

--- a/panel/param.py
+++ b/panel/param.py
@@ -140,10 +140,11 @@ class Param(PaneBase):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
+        obj_cls = type(self.object).__name__
         params = [k for k in self.object.params() if k != 'name']
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
                   if v is not self.params(p).default and v not in ('', None, {}, [])
-                  and p != 'object' and not (p == 'name' and v.startswith(cls))
+                  and p != 'object' and not (p == 'name' and v.startswith(obj_cls))
                   and not (p == 'parameters' and v == params)]
         obj = type(self.object).__name__
         template = '{cls}({obj}, {params})' if params else '{cls}({obj})'

--- a/panel/param.py
+++ b/panel/param.py
@@ -138,6 +138,17 @@ class Param(PaneBase):
         if not (self.expand_button == False and not self.expand):
             self._link_subobjects()
 
+    def __repr__(self, depth=0):
+        cls = type(self).__name__
+        params = [k for k in self.object.params() if k != 'name']
+        params = ['%s=%s' % (p, v) for p, v in self.get_param_values()
+                  if v is not self.params(p).default and v not in ('', None, {}, [])
+                  and p != 'object' and not (p == 'name' and v.startswith(cls))
+                  and not (p == 'parameters' and v == params)]
+        obj = type(self.object).__name__
+        template = '{cls}({obj}, {params})' if params else '{cls}({obj})'
+        return template.format(cls=cls, params=', '.join(params), obj=obj)
+
     def _link_subobjects(self):
         for pname, widgets in self._widgets.items():
             if not any(is_parameterized(getattr(w, 'value', None)) or

--- a/panel/param.py
+++ b/panel/param.py
@@ -141,7 +141,7 @@ class Param(PaneBase):
     def __repr__(self, depth=0):
         cls = type(self).__name__
         params = [k for k in self.object.params() if k != 'name']
-        params = ['%s=%s' % (p, v) for p, v in self.get_param_values()
+        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None, {}, [])
                   and p != 'object' and not (p == 'name' and v.startswith(cls))
                   and not (p == 'parameters' and v == params)]

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -45,6 +45,16 @@ def test_layout_getitem(panel):
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
+def test_layout_repr(panel):
+    div1 = Div()
+    div2 = Div()
+    layout = panel(div1, div2)
+
+    name = panel.__name__
+    assert repr(layout) == '%s\n    [0] Bokeh(Div)\n    [1] Bokeh(Div)' % name
+
+
+@pytest.mark.parametrize('panel', [Column, Row])
 def test_layout_select_by_type(panel):
     div1 = Div()
     div2 = Div()

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -65,7 +65,12 @@ def test_bokeh_pane(document, comm):
     pane._cleanup(new_model)
     assert pane._callbacks == {}
 
-    
+
+def test_pane_repr(document, comm):
+    pane = Pane('Some text', width=400)
+    assert repr(pane) == 'Markdown(str, width=400)'
+
+
 @mpl_available
 def test_get_matplotlib_pane_type():
     assert PaneBase.get_pane_type(mpl_figure()) is Matplotlib

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -58,6 +58,23 @@ def test_instantiate_from_parameters_on_instance():
     assert isinstance(Pane(Test().param), Param)
 
 
+def test_param_pane_repr(document, comm):
+
+    class Test(param.Parameterized):
+        pass
+
+    assert repr(Pane(Test())) == 'Param(Test)'
+
+
+def test_param_pane_repr_with_params(document, comm):
+
+    class Test(param.Parameterized):
+        a = param.Number()
+        b = param.Number()
+
+    assert repr(Pane(Test(), parameters=['a'])) == "Param(Test, parameters=['a'])"
+
+
 def test_get_model(document, comm):
 
     class Test(param.Parameterized):

--- a/panel/tests/test_util.py
+++ b/panel/tests/test_util.py
@@ -1,7 +1,12 @@
+from collections import OrderedDict
+
 from bokeh.models import Div
 
 from panel.pane import PaneBase
-from panel.util import render_mimebundle, default_label_formatter, get_method_owner
+from panel.util import (
+    render_mimebundle, default_label_formatter, get_method_owner,
+    abbreviated_repr
+)
 
 
 def test_get_method_owner_class():
@@ -38,3 +43,16 @@ def test_default_label_formatter_not_replace_underscores():
 
 def test_default_label_formatter_overrides():
     assert default_label_formatter.instance(overrides={'a': 'b'})('a') == 'b'
+
+
+def test_abbreviated_repr_dict():
+    assert abbreviated_repr({'key': 'some really, really long string'}) == "{'key': 'some really, ...}"
+
+
+def test_abbreviated_repr_list():
+    assert abbreviated_repr(['some really, really long string']) == "['some really, ...]"
+
+
+def test_abbreviated_repr_ordereddict():
+    assert (abbreviated_repr(OrderedDict([('key', 'some really, really long string')]))
+            == "OrderedDict([('key', ...])")

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -31,6 +31,7 @@ def test_text_input(document, comm):
 
     text.value = 'A'
     assert widget.value == 'A'
+    assert repr(text) == "TextInput(name='Text:', value='A')"
 
 
 def test_static_text(document, comm):
@@ -47,6 +48,7 @@ def test_static_text(document, comm):
 
     text.value = 'CBA'
     assert widget.text == '<b>Text:</b>: CBA'
+    assert repr(text) == "StaticText(name='Text:', value='CBA')"
 
 
 def test_float_slider(document, comm):
@@ -70,6 +72,7 @@ def test_float_slider(document, comm):
 
     slider.value = 0.3
     assert widget.value == 0.3
+    assert repr(slider) == "FloatSlider(end=0.5, name='Slider', start=0.1, value=0.3)"
 
 
 def test_int_slider(document, comm):
@@ -93,6 +96,7 @@ def test_int_slider(document, comm):
 
     slider.value = 0
     assert widget.value == 0
+    assert repr(slider) == "IntSlider(end=3, name='Slider')"
 
 
 def test_range_slider(document, comm):
@@ -116,6 +120,7 @@ def test_range_slider(document, comm):
 
     slider.value = (0, 1)
     assert widget.value == (0, 1)
+    assert repr(slider) == "RangeSlider(end=3, name='Slider', start=0.0, value=(0, 1))"
 
 
 def test_literal_input(document, comm):

--- a/panel/util.py
+++ b/panel/util.py
@@ -8,7 +8,7 @@ import inspect
 import numbers
 import hashlib
 
-from collections import defaultdict, MutableSequence, MutableMapping
+from collections import defaultdict, MutableSequence, MutableMapping, OrderedDict
 from datetime import datetime
 
 import param
@@ -82,6 +82,35 @@ def as_unicode(obj):
     if sys.version_info.major < 3 and isinstance(obj, str):
         obj = obj.decode('utf-8')
     return unicode(obj)
+
+
+def abbreviated_repr(value, max_length=25, natural_breaks=(',', ' ')):
+    """
+    Returns an abbreviated repr for the supplied object. Attempts to
+    find a natural break point while adhering to the maximum length.
+    """
+    vrepr = repr(value)
+    if len(vrepr) > max_length:
+
+        # Attempt to find natural cutoff point
+        abbrev = vrepr[max_length//2:]
+        natural_break = None
+        for brk in natural_breaks:
+            if brk in abbrev:
+                natural_break = abbrev.index(brk) + max_length//2
+                break
+        if natural_break and natural_break < max_length:
+            max_length = natural_break + 1
+
+        end_char = ''
+        if isinstance(value, list):
+            end_char = ']'
+        elif isinstance(value, OrderedDict):
+            end_char = '])'
+        elif isinstance(value, (dict, set)):
+            end_char = '}'
+        return vrepr[:max_length+1] + '...' + end_char
+    return vrepr
 
 
 def full_groupby(l, key=lambda x: x):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -116,6 +116,12 @@ class Viewable(param.Parameterized):
         self._cleanup(self._documents[doc], final=self._temporary)
         del self._documents[doc]
 
+    def pprint(self):
+        """
+        Prints a compositional repr of the class.
+        """
+        print(self)
+
     def select(self, selector=None):
         """
         Iterates over the Viewable and any potential children in the

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -21,7 +21,7 @@ from bokeh.models import CustomJS
 from bokeh.server.server import Server
 from pyviz_comms import JS_CALLBACK, CommManager, JupyterCommManager
 
-from .util import render_mimebundle, add_to_doc, push
+from .util import render_mimebundle, add_to_doc, push, abbreviated_repr
 
 
 class Viewable(param.Parameterized):
@@ -48,7 +48,7 @@ class Viewable(param.Parameterized):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
                   if v is not self.params(p).default and v not in ('', None)
                   and not (p == 'name' and v.startswith(cls))]
         return '{cls}({params})'.format(cls=type(self).__name__, params=', '.join(params))

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -48,7 +48,7 @@ class Viewable(param.Parameterized):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in self.get_param_values()
+        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
                   if v is not self.params(p).default and v not in ('', None)
                   and not (p == 'name' and v.startswith(cls))]
         return '{cls}({params})'.format(cls=type(self).__name__, params=', '.join(params))

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -46,6 +46,16 @@ class Viewable(param.Parameterized):
         super(Viewable, self).__init__(**params)
         self._documents = {}
 
+    def __repr__(self, depth=0):
+        cls = type(self).__name__
+        params = ['%s=%r' % (p, v) for p, v in self.get_param_values()
+                  if v is not self.params(p).default and v not in ('', None)
+                  and not (p == 'name' and v.startswith(cls))]
+        return '{cls}({params})'.format(cls=type(self).__name__, params=', '.join(params))
+
+    def __str__(self):
+        return self.__repr__()
+
     def _get_model(self, doc, root=None, parent=None, comm=None):
         """
         Converts the objects being wrapped by the viewable into a


### PR DESCRIPTION
An initial implementation of compositional reprs, which can be improved later.

Some sample outputs for moderately complex dashboards include:

```
Row(
    HTML(str, width=200),
    Spacer(width=30),
    ParamMethod(method),
    Spacer(width=50),
    Column(
        Param(ParameterSets, name='Attractors', width=220),
        Param(Attractors, expand=True, name='Options', width=220)
    )
)
```

```
Column(
    Row(
        Markdown(str, width=170),
        Spacer(width=50),
        Column(
            Markdown(str, height=25, width=400),
            Spacer(height=-15),
            Markdown(str, width=500)
        ),
        Spacer(width=180),
        Column(
            HoloViews(DynamicMap),
            Button(name='Clear selection'),
            Spacer(height=-15)
        ),
        Markdown(str, width=80)
    ),
    Spacer(height=-50),
    Row(
        HoloViews(DynamicMap),
        HoloViews(DynamicMap)
    ),
    Row(
        HoloViews(DynamicMap),
        HoloViews(DynamicMap)
    )
)
```

- [x] Implements #125 