### PR TITLE
Interactive layout fixes

### DIFF
--- a/panel/interact.py
+++ b/panel/interact.py
@@ -140,7 +140,8 @@ class interactive(PaneBase):
         self._inner_layout = Row(self._pane)
         self.widget_box = WidgetBox(*(widget for _, widget in widgets
                                       if isinstance(widget, Widget)))
-        self.layout.objects = [self.widget_box, self]
+        self.layout.objects = [self.widget_box, self._inner_layout]
+        self._link_widgets()
 
     @property
     def kwargs(self):
@@ -170,10 +171,9 @@ class interactive(PaneBase):
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         layout = self._inner_layout._get_model(doc, root, parent, comm)
-        self._link_widgets(layout, doc, root, parent, comm)
         return layout
 
-    def _link_widgets(self, layout, doc, root, parent, comm):
+    def _link_widgets(self):
         if self.manual_update:
             widgets = [('manual', self._widgets['manual'])]
         else:
@@ -206,7 +206,7 @@ class interactive(PaneBase):
 
             pname = 'clicks' if name == 'manual' else 'value'
             watcher = widget.param.watch(update_pane, pname)
-            self._callbacks[layout.ref['id']].append(watcher)
+            self._callbacks['instance'].append(watcher)
 
     def _cleanup(self, model=None, final=False):
         self._inner_layout._cleanup(model, final)

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -199,6 +199,8 @@ class interactive(PaneBase):
                         new_object._cleanup(None, new_object._temporary)
                     else:
                         self._pane.object = new_object
+                    return
+
 
                 # Replace pane entirely
                 self._pane = Pane(new_object, _temporary=True)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -11,7 +11,7 @@ from bokeh.layouts import (Column as BkColumn, Row as BkRow,
 from bokeh.models import Box as BkBox
 from bokeh.models.widgets import Tabs as BkTabs, Panel as BkPanel
 
-from .util import push, abbreviated_repr
+from .util import param_reprs, push
 from .viewable import Reactive, Viewable
 
 
@@ -161,9 +161,7 @@ class Panel(Reactive):
     def __repr__(self, depth=0):
         spacer = '\n' + ('    ' * (depth+1))
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
-                  if v is not self.params(p).default and v not in ('', None)
-                  and p != 'objects' and not (p == 'name' and v.startswith(cls))]
+        params = param_reprs(self, ['objects'])
         objs = ['[%d] %s' % (i, obj.__repr__(depth+1)) for i, obj in enumerate(self.objects)]
         if not params and not objs:
             return super(Panel, self).__repr__(depth+1)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -15,6 +15,26 @@ from .util import push, abbreviated_repr
 from .viewable import Reactive, Viewable
 
 
+def no_height(layout):
+    """
+    Whether the supplied layout has no height
+    """
+    if isinstance(layout, BkBox):
+        for child in layout.children:
+            if isinstance(child, BkBox):
+                if no_height(child):
+                    return False
+
+            height = getattr(child, 'height', None)
+            if height is not None:
+                return False
+    elif isinstance(BkWidgetBox):
+        return False
+    elif getattr(child, 'height', None) is not None:
+        return False
+    return True
+
+
 class Panel(Reactive):
     """
     Abstract baseclass for a layout of Viewables.
@@ -118,8 +138,7 @@ class Panel(Reactive):
         objects = self._get_objects(model, [], doc, root, comm)
 
         # HACK ALERT: Insert Spacer if last item in Column has no height
-        if (isinstance(self, Column) and objects and not isinstance(objects[-1], (BkWidgetBox, BkBox))
-            and getattr(objects[-1], 'height', False) is None):
+        if (isinstance(self, Column) and objects and no_height(objects[-1])):
             objects.append(BkSpacer(height=50))
 
         props = dict(self._init_properties(), objects=objects)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -30,7 +30,7 @@ def no_height(layout):
                 return False
     elif isinstance(BkWidgetBox):
         return False
-    elif getattr(child, 'height', None) is not None:
+    elif getattr(child, 'height', False) is None:
         return False
     return True
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -15,24 +15,19 @@ from .util import push, abbreviated_repr
 from .viewable import Reactive, Viewable
 
 
-def no_height(layout):
+def has_height(obj):
     """
-    Whether the supplied layout has no height
+    Whether the supplied layout has a height
     """
-    if isinstance(layout, BkBox):
-        for child in layout.children:
-            if isinstance(child, BkBox):
-                if no_height(child):
-                    return False
-
-            height = getattr(child, 'height', None)
-            if height is not None:
-                return False
-    elif isinstance(BkWidgetBox):
-        return False
-    elif getattr(child, 'height', False) is None:
-        return False
-    return True
+    if isinstance(obj, BkBox):
+        for child in obj.children:
+            if has_height(child):
+                return True
+    elif isinstance(obj, BkWidgetBox):
+        return True
+    elif getattr(obj, 'height', None) is not None:
+        return True
+    return False
 
 
 class Panel(Reactive):
@@ -138,7 +133,7 @@ class Panel(Reactive):
         objects = self._get_objects(model, [], doc, root, comm)
 
         # HACK ALERT: Insert Spacer if last item in Column has no height
-        if (isinstance(self, Column) and objects and no_height(objects[-1])):
+        if (isinstance(self, Column) and objects and not has_height(objects[-1])):
             objects.append(BkSpacer(height=50))
 
         props = dict(self._init_properties(), objects=objects)

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -20,7 +20,7 @@ from bokeh.layouts import WidgetBox as _BkWidgetBox
 from bokeh.models import LayoutDOM, CustomJS, Widget as _BkWidget, Div as _BkDiv
 
 from .layout import Panel, Row
-from .util import Div, basestring, push, remove_root, abbreviated_repr
+from .util import Div, basestring, param_reprs, push, remove_root
 from .viewable import Reactive, Viewable
 
 
@@ -125,9 +125,7 @@ class PaneBase(Reactive):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
-                  if v is not self.params(p).default and v not in ('', None, {}, [])
-                  and p != 'object' and not (p == 'name' and v.startswith(cls))]
+        params = param_reprs(self, ['object'])
         obj = type(self.object).__name__
         template = '{cls}({obj}, {params})' if params else '{cls}({obj})'
         return template.format(cls=cls, params=', '.join(params), obj=obj)

--- a/panel/param.py
+++ b/panel/param.py
@@ -17,8 +17,8 @@ from param.parameterized import classlist
 from .pane import Pane, PaneBase
 from .layout import WidgetBox, Row, Panel, Tabs, Column
 from .util import (
-    default_label_formatter, is_parameterized, get_method_owner,
-    full_groupby, abbreviated_repr
+    abbreviated_repr, basestring, default_label_formatter, full_groupby,
+    get_method_owner, is_parameterized
 )
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
@@ -141,11 +141,15 @@ class Param(PaneBase):
     def __repr__(self, depth=0):
         cls = type(self).__name__
         obj_cls = type(self.object).__name__
-        params = [k for k in self.object.params() if k != 'name']
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
-                  if v is not self.params(p).default and v not in ('', None, {}, [])
-                  and p != 'object' and not (p == 'name' and v.startswith(obj_cls))
-                  and not (p == 'parameters' and v == params)]
+        parameters = [k for k in self.object.params() if k != 'name']
+        params = []
+        for p, v in sorted(self.get_param_values()):
+            if v is self.params(p).default: continue
+            elif v is None: continue
+            elif isinstance(v, basestring) and v == '': continue
+            elif p == 'object' or (p == 'name' and v.startswith(obj_cls)): continue
+            elif p == 'parameters' and v == parameters: continue
+            params.append('%s=%s' % (p, abbreviated_repr(v)))
         obj = type(self.object).__name__
         template = '{cls}({obj}, {params})' if params else '{cls}({obj})'
         return template.format(cls=cls, params=', '.join(params), obj=obj)

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -1,5 +1,4 @@
-from bokeh.models import (Div as BkDiv, Column as BkColumn,
-                          WidgetBox as BkWidgetBox, Paragraph as BkParagraph)
+from bokeh.models import Div as BkDiv, Column as BkColumn, WidgetBox as BkWidgetBox
 
 from panel.interact import interactive
 from panel import widgets
@@ -166,7 +165,7 @@ def test_interact_replaces_panel(document, comm):
 
 def test_interact_replaces_model(document, comm):
     def test(a):
-        return BkParagraph(text='Pre Test') if a else BkDiv(text='Test')
+        return 'ABC' if a else BkDiv(text='Test')
 
     interact_pane = interactive(test, a=False)
     pane = interact_pane._pane
@@ -181,20 +180,20 @@ def test_interact_replaces_model(document, comm):
     div = box.children[0]
     assert isinstance(div, BkDiv)
     assert div.text == 'Test'
-    assert column.children[1].ref['id'] in interact_pane._callbacks
+    assert len(interact_pane._callbacks['instance']) == 1
     assert box.ref['id'] in pane._callbacks
     
     widget.value = True
     assert box.ref['id'] not in pane._callbacks
     assert pane._callbacks == {}
     new_pane = interact_pane._pane
-    new_box = column.children[1].children[0]
-    pre = new_box.children[0]
-    assert isinstance(pre, BkParagraph)
-    assert pre.text == 'Pre Test'
-    assert column.children[1].ref['id'] in interact_pane._callbacks
-    assert new_box.ref['id'] in new_pane._callbacks
+    assert new_pane is not pane
+    new_div = column.children[1].children[0]
+    assert isinstance(new_div, BkDiv)
+    assert new_div.text == '<p>ABC</p>'
+    assert len(interact_pane._callbacks['instance']) == 1
+    assert new_div.ref['id'] in new_pane._callbacks
 
     interact_pane._cleanup(column.children[1])
-    assert interact_pane._callbacks == {}
+    assert len(interact_pane._callbacks) == 1
     assert pane._callbacks == {}

--- a/panel/util.py
+++ b/panel/util.py
@@ -116,6 +116,24 @@ def abbreviated_repr(value, max_length=25, natural_breaks=(',', ' ')):
     return vrepr
 
 
+def param_reprs(parameterized, skip=[]):
+    """
+    Returns a list of reprs for parameters on the parameterized object.
+    Skips default and empty values.
+    """
+    cls = type(parameterized).__name__
+    param_reprs = []
+    for p, v in sorted(parameterized.get_param_values()):
+        if v is parameterized.params(p).default: continue
+        elif v is None: continue
+        elif isinstance(v, basestring) and v == '': continue
+        elif isinstance(v, list) and v == []: continue
+        elif isinstance(v, dict) and v == {}: continue
+        elif p in skip or (p == 'name' and v.startswith(cls)): continue
+        param_reprs.append('%s=%s' % (p, abbreviated_repr(v)))
+    return param_reprs
+
+
 def full_groupby(l, key=lambda x: x):
     """
     Groupby implementation which does not require a prior sort

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -48,9 +48,8 @@ class Viewable(param.Parameterized):
         self._documents = {}
 
     def __repr__(self, depth=0):
-        cls = type(self).__name__
-        params = param_reprs(self)
-        return '{cls}({params})'.format(cls=type(self).__name__, params=', '.join(params))
+        return '{cls}({params})'.format(cls=type(self).__name__,
+                                        params=', '.join(param_reprs(self)))
 
     def __str__(self):
         return self.__repr__()

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -22,7 +22,7 @@ from bokeh.models import CustomJS
 from bokeh.server.server import Server
 from pyviz_comms import JS_CALLBACK, CommManager, JupyterCommManager
 
-from .util import render_mimebundle, add_to_doc, push, abbreviated_repr
+from .util import render_mimebundle, add_to_doc, push, param_reprs
 
 
 class Viewable(param.Parameterized):
@@ -49,9 +49,7 @@ class Viewable(param.Parameterized):
 
     def __repr__(self, depth=0):
         cls = type(self).__name__
-        params = ['%s=%s' % (p, abbreviated_repr(v)) for p, v in sorted(self.get_param_values())
-                  if v is not self.params(p).default and v not in ('', None)
-                  and not (p == 'name' and v.startswith(cls))]
+        params = param_reprs(self)
         return '{cls}({params})'.format(cls=type(self).__name__, params=', '.join(params))
 
     def __str__(self):


### PR DESCRIPTION
The interactive layout was previously self-referential which causes issues when trying to display the plot/display component on its own. Additionally this ensures that a small fixes to assign a minimal height when no height is specified for the last item in a Column.