### PR TITLE
Extended parser to support pyct commands

### DIFF
--- a/panel/cli.py
+++ b/panel/cli.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
     main()
 
 def main(args=None):
+    """Special case: Allow Bokeh to handle the `serve` command; rest is handled by pyct."""
     if len(sys.argv) > 1 and 'serve' == sys.argv[1]:
         sys.argv = transform_cmds(sys.argv)
         bokeh_entry_point()

--- a/panel/cli.py
+++ b/panel/cli.py
@@ -8,7 +8,7 @@ from bokeh.__main__ import main as bokeh_entry_point
 
 def transform_cmds(argv):
     """
-    Allows usage with anaconda-project by remapping the argv list provided 
+    Allows usage with anaconda-project by remapping the argv list provided
     into arguments accepted by Bokeh 0.12.7 or later.
     """
     replacements = {'--anaconda-project-host':'--allow-websocket-origin',
@@ -32,7 +32,17 @@ def transform_cmds(argv):
             transformed.append(arg)
     return transformed
 
+if __name__ == "__main__":
+    main()
 
-def main():
-    sys.argv = transform_cmds(sys.argv)
-    bokeh_entry_point()
+def main(args=None):
+    if len(sys.argv) > 1 and 'serve' == sys.argv[1]:
+        sys.argv = transform_cmds(sys.argv)
+        bokeh_entry_point()
+    else:
+        try:
+            import pyct.cmd
+        except ImportError:
+            print("install pyct to enable this command (e.g. `conda install -c pyviz pyct` or `pip install pyct[cmd]`)")
+            sys.exit(1)
+        pyct.cmd.substitute_main('panel',args=args)

--- a/panel/cli.py
+++ b/panel/cli.py
@@ -32,8 +32,6 @@ def transform_cmds(argv):
             transformed.append(arg)
     return transformed
 
-if __name__ == "__main__":
-    main()
 
 def main(args=None):
     """Special case: Allow Bokeh to handle the `serve` command; rest is handled by pyct."""
@@ -47,3 +45,6 @@ def main(args=None):
             print("install pyct to enable this command (e.g. `conda install -c pyviz pyct` or `pip install pyct[cmd]`)")
             sys.exit(1)
         pyct.cmd.substitute_main('panel',args=args)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ class CustomInstallCommand(install):
         except ImportError as e:
             print("Custom model compilation failed with: %s" % e)
         install.run(self)
-        
+
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
 # until pyproject.toml/equivalent is widely supported (setup_requires


### PR DESCRIPTION
Addresses #109. It isn't obvious how to do the right thing here but this seems to me like the easiest way to splice together two external parsers. It does mean if you mistype 'serve', then it is the pyct parser that will complain.