### PR TITLE
Enable Widget links to Hv Bokeh plots

### DIFF
--- a/examples/user_guide/LinkWidgets.ipynb
+++ b/examples/user_guide/LinkWidgets.ipynb
@@ -17,7 +17,7 @@
     "import panel as pn\n",
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "from panel.widgetlinks import WidgetLink\n",
+    "from panel.links import WidgetLink\n",
     "\n",
     "pn.extension()"
    ]

--- a/examples/user_guide/LinkWidgets.ipynb
+++ b/examples/user_guide/LinkWidgets.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Based on philippjfr [notebook](https://anaconda.org/philippjfr/widgetlinks/notebook)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import param\n",
+    "import panel as pn\n",
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "from panel.widgetlinks import WidgetLink\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linking widgets to point size and color"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "size_widget = pn.widgets.FloatSlider(value=5, start=3, end=20, name='Size')\n",
+    "color_widget = pn.widgets.TextInput(value='black', name='Color')\n",
+    "\n",
+    "points = hv.Points(np.random.rand(10, 2)).options(padding=0.1)\n",
+    "WidgetLink(size_widget, points, target_model='glyph', target_property='size')\n",
+    "WidgetLink(color_widget, points, target_model='glyph', target_property='fill_color')\n",
+    "pn.Row(points, pn.layout.WidgetBox(size_widget, color_widget))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linking widgets to ranges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range_widget = pn.widgets.RangeSlider(value=(0, 1000), start=0, end=1000, name='x-axis range')\n",
+    "curve = hv.Curve(np.random.randn(1000).cumsum()).options(width=500)\n",
+    "\n",
+    "code = \"\"\"\n",
+    "x_range.start = source.value[0]\n",
+    "x_range.end = source.value[1]\n",
+    "\"\"\"\n",
+    "WidgetLink(range_widget, curve, code=code)\n",
+    "\n",
+    "pn.Row(curve, range_widget)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linking widgets to color mapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range_widget = pn.widgets.RangeSlider(value=(-2, 2), start=-2., end=2., name='color range')\n",
+    "ys, xs = np.mgrid[0:100, 0:100]/20\n",
+    "img = hv.Image(np.sin(xs*ys)+np.cos(xs*ys**2)).options(colorbar=True, width=400)\n",
+    "\n",
+    "code = \"\"\"\n",
+    "color_mapper.low = source.value[0]\n",
+    "color_mapper.high = source.value[1]\n",
+    "\"\"\"\n",
+    "WidgetLink(range_widget, img, code=code)\n",
+    "\n",
+    "pn.Row(img, range_widget)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Link widget to title"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "title_widget = pn.widgets.TextInput(value='A title', name='Type a new title here:')\n",
+    "points = hv.Points(np.random.rand(10, 2), label='A title').options(padding=0.1, size=5, color='black')\n",
+    "\n",
+    "code = \"\"\"\n",
+    "plot.title.text = source.value\n",
+    "\"\"\"\n",
+    "WidgetLink(title_widget, points, code=code)\n",
+    "\n",
+    "pn.Column(title_widget, points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Link Player to range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "player = pn.widgets.Player(length=800, loop_policy='reflect', interval=20)\n",
+    "curve = hv.Curve(np.random.randn(1000).cumsum()).options(width=500)\n",
+    "\n",
+    "code = \"\"\"\n",
+    "x_range.start = source.value\n",
+    "x_range.end = source.value+200\n",
+    "\"\"\"\n",
+    "WidgetLink(player, curve, code=code)\n",
+    "\n",
+    "pn.Column(curve, pn.Row(pn.Spacer(width=70), player))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select column using dropdown "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select = pn.widgets.Select(options=['A', 'B', 'C'])\n",
+    "curve = hv.Curve((np.arange(100), *np.random.randn(3, 100).cumsum(axis=1)), vdims=['A', 'B', 'C']).options(tools=['hover'])\n",
+    "\n",
+    "code=\"\"\"\n",
+    "glyph.y = {'field': source.value}\n",
+    "yaxis.axis_label = source.value\n",
+    "array = cds.data[source.value]\n",
+    "y_range.start = Math.min.apply(null, array)\n",
+    "y_range.end = Math.max.apply(null, array)\n",
+    "\"\"\"\n",
+    "WidgetLink(select, curve, code=code)\n",
+    "\n",
+    "pn.Row(curve, select)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -8,6 +8,7 @@ from . import pipeline # noqa
 from . import plotly # noqa
 from . import vega # noqa
 from . import widgets # noqa
+from . import widgetlinks #noqa
 
 from .interact import interact # noqa
 from .layout import Row, Column, Tabs, Spacer # noqa

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -8,7 +8,7 @@ from . import pipeline # noqa
 from . import plotly # noqa
 from . import vega # noqa
 from . import widgets # noqa
-from . import widgetlinks # noqa
+from . import links # noqa
 
 from .interact import interact # noqa
 from .layout import Row, Column, Tabs, Spacer # noqa

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -8,7 +8,7 @@ from . import pipeline # noqa
 from . import plotly # noqa
 from . import vega # noqa
 from . import widgets # noqa
-from . import widgetlinks #noqa
+from . import widgetlinks # noqa
 
 from .interact import interact # noqa
 from .layout import Row, Column, Tabs, Spacer # noqa

--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -214,20 +214,24 @@ class HoloViews(PaneBase):
 
 
 class PanelLink(HvLink):
-    """Link between HoloViews elements
     """
+    Link between HoloViews elements containing Bokeh plots
+    """
+    
     registry = weakref.WeakKeyDictionary()
+
 
 class RangeAxesLink(PanelLink):
     """
-    The RangeAxesLink sets up a link betweenthe axes of the source
+    The RangeAxesLink sets up a link between the axes of the source
     plot and the axes on the target plot. By default it will
     link along the x-axis but using the axes parameter both axes may
     be linked to the tool.
     """
 
-    axes = param.ListSelector(default=['x'], objects=['x', 'y'], doc="""
+    axes = param.ListSelector(default=['x', 'y'], objects=['x', 'y'], doc="""
         Which axes to link the tool to.""")
+
 
 class RangeAxesLinkCallback(param.Parameterized):
     """
@@ -249,6 +253,7 @@ def is_bokeh_element_plot(plot):
     from holoviews.plotting.plot import GenericElementPlot, GenericOverlayPlot
     return (plot.renderer.backend == 'bokeh' and isinstance(plot, GenericElementPlot)
             and not isinstance(plot, GenericOverlayPlot))
+
 
 def generate_hvelems_bkplots_map(root_model, hv_views):
     #mapping holoview element -> bokeh plot

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -7,7 +7,7 @@ from bokeh.plotting import Figure
 from panel.layout import Column, Row
 from panel.holoviews import HoloViews
 from panel.widgets import FloatSlider
-from panel.widgetlinks import WidgetLink 
+from panel.links import WidgetLink 
 
 try:
     import holoviews as hv
@@ -19,7 +19,7 @@ hv_available = pytest.mark.skipif(hv is None, reason="requires holoviews")
 
 @hv_available
 def test_holoviews_axes_range_link(document, comm):
-    from panel.holoviews import RangeAxesLink
+    from panel.links import RangeAxesLink
     
     c1 = hv.Curve([])
     c2 = hv.Curve([])

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+
+import pytest
+
+from bokeh.plotting import Figure
+
+from panel.layout import Column, Row
+from panel.holoviews import HoloViews
+from panel.widgets import FloatSlider
+from panel.widgetlinks import WidgetLink 
+
+try:
+    import holoviews as hv
+except:
+    hv = None
+hv_available = pytest.mark.skipif(hv is None, reason="requires holoviews")
+
+
+
+@hv_available
+def test_holoviews_axes_range_link(document, comm):
+    from panel.holoviews import RangeAxesLink
+    
+    c1 = hv.Curve([])
+    c2 = hv.Curve([])
+    c3 = hv.Curve([])
+    c4 = hv.Curve([])
+    c5 = hv.Curve([])
+    
+    RangeAxesLink(c1,c2) #across pane
+    hv_layout = c3+c4 #inner hv layout
+    RangeAxesLink(c4,c5) #inner outter
+    
+    layout = Column(Row(c1,c2), Row(hv_layout, c5))
+    column = layout._get_root(document, comm=comm)
+
+    assert len(column.children) == 3
+    r1, r2, _ = column.children
+
+    assert (len(list(r1.select({'type': Figure}))) == 2)
+    p1, p2 = r1.select({'type': Figure})
+    
+    assert p1.x_range == p2.x_range
+    assert p1.y_range == p2.y_range
+    
+    assert (len(list(r2.select({'type': Figure}))) == 3)
+    p3, p4, p5 = r2.select({'type': Figure})
+    
+    assert p3.x_range == p4.x_range == p5.x_range
+    assert p3.y_range == p4.y_range == p5.y_range
+
+
+@hv_available
+def test_widget_links(document, comm):
+    size_widget = FloatSlider(value=5, start=1, end=10)
+    points1 = hv.Points([1,2,3])
+    
+    WidgetLink(size_widget, points1, target_model='glyph', target_property='size')
+    
+    row = Row(points1, size_widget)
+    model = row._get_root(document, comm=comm)
+    hv_views = row.select(HoloViews)
+    widg_views = row.select(FloatSlider)
+    
+    assert len(hv_views) == 1
+    assert len(widg_views) == 1
+    slider = widg_views[0]._models[model.ref['id']]
+    scatter = hv_views[0]._plots[model.ref['id']].handles['glyph']
+    
+    assert len(slider.js_property_callbacks['change:value']) == 2
+    
+    widgetlink_customjs = slider.js_property_callbacks['change:value'][-1]
+    assert widgetlink_customjs.args['source'] is slider
+    assert widgetlink_customjs.args['target'] is scatter
+    assert widgetlink_customjs.args['target_model'] == 'glyph'
+    assert widgetlink_customjs.args['target_property'] == 'size'
+    
+    

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -100,7 +100,7 @@ class Viewable(param.Parameterized):
 
     def _preprocess(self, root):
         for hook in self._preprocessing_hooks:
-            root = hook(self, root)
+            hook(self, root)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         Viewable._comm_manager = JupyterCommManager

--- a/panel/widgetlinks.py
+++ b/panel/widgetlinks.py
@@ -78,10 +78,8 @@ class WidgetLinkCallback(param.Parameterized):
         pass
     
 def find_links(root_view, root_model):
-    if not isinstance(root_view, Panel):
+    if not isinstance(root_view, Panel) or not root_model:
         return
-    
-    from collections import defaultdict
     
     widget_views = root_view.select(Widget)
     hv_views = root_view.select(HoloViews)
@@ -89,6 +87,7 @@ def find_links(root_view, root_model):
         return
     
     #mapping holoview element -> bokeh plot
+    from collections import defaultdict
     map_hve_bk = defaultdict(list)
     for hv_view in hv_views:
         if root_model.ref['id'] in hv_view._plots: 

--- a/panel/widgetlinks.py
+++ b/panel/widgetlinks.py
@@ -1,0 +1,115 @@
+"""
+"""
+import param
+
+from .layout import Viewable, Panel
+from .widgets import Widget
+from .holoviews import HoloViews
+
+from holoviews.plotting.links import Link
+from bokeh.models import CustomJS
+
+
+class WidgetLink(Link):
+    """
+    Links a panel Widget value to the value on a target
+    object. Currently only links between Widgets and
+    HoloViews plots are supported.
+    
+    The `target_model` and `target_property` define the
+    bokeh model and property the widget value will be
+    linked to.
+    """
+    
+    code = param.String(default=None)
+    
+    target_model = param.String(default=None)
+    
+    target_property = param.String(default=None)
+
+class WidgetLinkCallback(param.Parameterized):
+
+    source_handles = []
+    target_handles = []
+
+    on_source_changes = ['value']
+
+    source_code = """
+       target['{value}'] = source.value
+    """
+
+    def __init__(self, root_model, link, source_plot, target_plot=None):
+        self.root_model = root_model
+        self.link = link
+        self.source_plot = source_plot
+        self.target_plot = target_plot
+        self.validate()
+
+        references = {k: v for k, v in link.get_param_values()
+                      if k not in ('source', 'target', 'name')}
+
+        src_model = source_plot._models[root_model.ref['id']]
+        references['source'] = src_model
+
+        if target_plot is not None:
+            if link.target_model:
+                if link.target_model in target_plot.handles:
+                    tgt_model = target_plot.handles[link.target_model]
+                else:
+                    tgt_model = getattr(target_plot.state, self.target_model)
+                references['target'] = tgt_model
+                if link.target_property:
+                    setattr(tgt_model, link.target_property, src_model.value)
+            else:
+                for k, v in target_plot.handles.items():
+                    #print(k, v)
+                    if k not in ('source', 'target', 'name', 'color_dim'):
+                        references[k] = v
+                    
+        if link.code:
+            code = link.code
+        else:
+            code = self.source_code.format(value=link.target_property)
+        src_cb = CustomJS(args=references, code=code)
+        for ch in self.on_source_changes:
+            src_model.js_on_change(ch, src_cb)
+                
+    def validate(self):
+        pass
+    
+def find_links(root_view, root_model):
+    if not isinstance(root_view, Panel):
+        return
+    
+    from collections import defaultdict
+    
+    widget_views = root_view.select(Widget)
+    hv_views = root_view.select(HoloViews)
+    if not widget_views or not hv_views:
+        return
+    
+    #mapping holoview element -> bokeh plot
+    map_hve_bk = defaultdict(list)
+    for hv_view in hv_views:
+        if root_model.ref['id'] in hv_view._plots: 
+            map_hve_bk[hv_view.object].append(hv_view._plots[root_model.ref['id']]) 
+                    
+    found = [(link, src_widget, tgt_bk) for src_widget in widget_views if src_widget in Link.registry
+             for link in Link.registry[src_widget]
+             for tgt_bk in map_hve_bk[link.target]]
+    
+    callbacks = []
+    for link, src_widget, tgt_bk in found:
+        cb = Link._callbacks['bokeh'][type(link)]
+        if src_widget is None or (getattr(link, '_requires_target', False)
+                                and tgt_bk is None):
+            continue
+        callbacks.append(cb(root_model, link, src_widget, tgt_bk))
+    return callbacks
+
+
+             
+WidgetLink.register_callback(backend='bokeh',
+                             callback = WidgetLinkCallback)
+
+Viewable._preprocessing_hooks.append(find_links)


### PR DESCRIPTION
This PR is a work in progress
It allows to enable links between panel widgets and holoviews plots with bokeh backend
It add examples in WidgetLinks user guide notebook based on https://anaconda.org/philippjfr/widgetlinks/notebook
Tests must be added
Doc must be extended
Discussion is opened on the organisation of codes
And even if tests passed I thin I breaked previous links between hv elements.