### PR TITLE
Added Audio model and widget

### DIFF
--- a/panel/models/audio.ts
+++ b/panel/models/audio.ts
@@ -1,0 +1,96 @@
+import * as p from "core/properties"
+import {div} from "core/dom"
+import {Widget, WidgetView} from "models/widgets/widget"
+
+export class AudioView extends WidgetView {
+  model: Audio
+
+  protected dialogEl: HTMLElement
+
+  initialize(options: any): void {
+    super.initialize(options)
+    this.render()
+  }
+
+  connect_signals(): void {
+    super.connect_signals()	
+    this.connect(this.model.change, () => this.render())
+    this.connect(this.model.properties.loop.change, () => this.set_loop())
+    this.connect(this.model.properties.paused.change, () => this.set_paused())
+    this.connect(this.model.properties.time.change, () => this.set_time())
+    this.connect(this.model.properties.value.change, () => this.render())
+    this.connect(this.model.properties.volume.change, () => this.set_volume())
+  }
+
+  render(): void {
+    if (this.audioEl) {
+      return
+    }
+    this.audioEl = document.createElement('audio')
+    this.audioEl.controls = true
+    this.audioEl.src = this.model.value
+    this.audioEl.currentTime = this.model.time
+    this.audioEl.loop = this.model.loop
+    if (this.model.volume != null)
+      this.audioEl.volume = this.model.volume/100
+    else
+      this.model.volume = this.audioEl.volume*100
+    this.audioEl.ontimeupdate = () => this.model.time = this.audioEl.currentTime
+	this.audioEl.onpause = () => this.model.paused = true
+    this.audioEl.onplay = () => this.model.play = true
+    this.audioEl.onvolumechange = () => this.model.volume = this.audioEl.volume*100
+    this.el.appendChild(this.audioEl)
+	if (!this.model.paused)
+	  this.audioEl.play()
+  }
+
+  set_loop(): void {
+    this.audioEl.loop = this.model.loop
+  }
+
+  set_paused(): void {
+    if (!this.audioEl.paused && this.model.paused)
+      this.audioEl.pause()
+    if (this.audioEl.paused && !this.model.paused)
+      this.audioEl.play()
+  }
+
+  set_volume(): void {
+    this.audioEl.volume = this.model.volume/100
+  }
+  
+  set_time(): void {
+    this.audioEl.currentTime = this.model.time
+  }
+}
+
+export namespace Audio {
+  export interface Attrs extends Widget.Attrs {}
+  export interface Props extends Widget.Props {}
+}
+
+export interface Audio extends Audio.Attrs {}
+
+export abstract class Audio extends Widget {
+
+  properties: Audio.Props
+
+  constructor(attrs?: Partial<Audio.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "Audio"
+    this.prototype.default_view = AudioView
+
+    this.define({
+      loop:   [ p.Bool, false  ],
+      paused: [ p.Bool, true   ],
+      time:   [ p.Number, 0    ],
+      value:  [ p.Any,    ''   ],
+      volume: [ p.Number, null ],
+    })
+  }
+}
+
+Audio.initClass()

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -47,7 +47,11 @@ class Audio(Widget):
 
     paused = Bool(False, help="""Whether the audio is paused""")
 
-    time = Float(0, help="""The current time stamp of the audio playback""")
+    time = Float(0, help="""
+        The current time stamp of the audio playback""")
+
+    throttle = Int(250, help="""
+        The frequency at which the time value is updated in milliseconds.""")
 
     value = Any(help="Encoded file data")
 

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -1,6 +1,6 @@
 import os
 
-from bokeh.core.properties import Int, Override, Enum, Any
+from bokeh.core.properties import Int, Float, Override, Enum, Any, Bool
 from bokeh.models import Widget
 
 from ..util import CUSTOM_MODELS
@@ -39,6 +39,21 @@ class FileInput(Widget):
     value = Any(help="Encoded file data")
 
 
+class Audio(Widget):
+
+    __implementation__ = os.path.join(os.path.dirname(__file__), 'audio.ts')
+
+    loop = Bool(False, help="""Whether the audio should loop""")
+
+    paused = Bool(False, help="""Whether the audio is paused""")
+
+    time = Float(0, help="""The current time stamp of the audio playback""")
+
+    value = Any(help="Encoded file data")
+
+    volume = Int(0, help="""The volume of the audio player.""")
+
+
 CUSTOM_MODELS['panel.models.widgets.Player'] = Player
 CUSTOM_MODELS['panel.models.widgets.FileInput'] = FileInput
-
+CUSTOM_MODELS['panel.models.widgets.Audio'] = Audio


### PR DESCRIPTION
Add ``Audio`` bokeh model and panel widget. The widget provides bidirectional control over:

* time
* volume
* pause/play state
* loop state

![screen shot 2019-01-23 at 5 55 19 pm](https://user-images.githubusercontent.com/1550771/51626713-14da6f00-1f38-11e9-816e-7fd4cc326740.png)


- [x] Implements https://github.com/pyviz/panel/issues/210