### PR TITLE
Guard JS link property setter

### DIFF
--- a/panel/links.py
+++ b/panel/links.py
@@ -289,7 +289,7 @@ class GenericLinkCallback(LinkCallback):
             setattr(tgt_model, tgt_spec, getattr(src_model, src_spec))
         if tgt_model is None and not link.code:
             raise ValueError('Model could not be resolved on target '
-                             '%s and no custom code was specified.' % 
+                             '%s and no custom code was specified.' %
                              type(self.target).__name__)
 
     def _process_references(self, references):
@@ -302,7 +302,12 @@ class GenericLinkCallback(LinkCallback):
             references[k[7:]] = references.pop(k)
 
     def _get_code(self, link, source, src_spec, target, tgt_spec):
-        return 'target[%r] = source[%r]' % (tgt_spec, src_spec)
+        return ("value = source[{src_repr}];"
+                "try {{ property = target.properties[{tgt_repr}];"
+                "if (property !== undefined) {{ property.validate(value); }} }}"
+                "catch(err) {{ console.log('WARNING: Could not set {tgt} on target, raised error: ' + err); return; }}"
+                "target[{tgt_repr}] = value".format(
+                    tgt=tgt_spec, tgt_repr=repr(tgt_spec), src=src_spec, src_repr=repr(src_spec)))
 
     def _get_triggers(self, link, src_spec):
         return [src_spec[1]], []

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -34,7 +34,14 @@ def test_pnwidget_hvplot_links(document, comm):
     link_customjs = slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is slider
     assert link_customjs.args['target'] is scatter
-    assert link_customjs.code == "target['size'] = source['value']"
+
+    
+    code = ("value = source['value'];"
+            "try { property = target.properties['size'];"
+            "if (property !== undefined) { property.validate(value); } }"
+            "catch(err) { console.log('WARNING: Could not set size on target, raised error: ' + err); return; }"
+            "target['size'] = value")
+    assert link_customjs.code == code
 
 
 @hv_available
@@ -56,7 +63,13 @@ def test_bkwidget_hvplot_links(document, comm):
     link_customjs = slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is slider
     assert link_customjs.args['target'] is scatter
-    assert link_customjs.code == "target['size'] = source['value']"
+
+    code = ("value = source['value'];"
+            "try { property = target.properties['size'];"
+            "if (property !== undefined) { property.validate(value); } }"
+            "catch(err) { console.log('WARNING: Could not set size on target, raised error: ' + err); return; }"
+            "target['size'] = value")
+    assert link_customjs.code == code
 
 
 def test_bkwidget_bkplot_links(document, comm):
@@ -76,7 +89,12 @@ def test_bkwidget_bkplot_links(document, comm):
     link_customjs = slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is slider
     assert link_customjs.args['target'] is scatter.glyph
-    assert link_customjs.code == "target['size'] = source['value']"
+    code = ("value = source['value'];"
+            "try { property = target.properties['size'];"
+            "if (property !== undefined) { property.validate(value); } }"
+            "catch(err) { console.log('WARNING: Could not set size on target, raised error: ' + err); return; }"
+            "target['size'] = value")
+    assert link_customjs.code == code
 
 
 def test_link_with_customcode(document, comm):


### PR DESCRIPTION
Ensures that setting an invalid property does not break JS links.