### PR TITLE
Renamed precedence to priority and deleted trailing whitespace

### DIFF
--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -34,7 +34,7 @@ class HoloViews(PaneBase):
         A mapping from dimension name to a widget instance which will
         be used to override the default widgets.""")
 
-    precedence = 0.8
+    priority = 0.8
 
     def __init__(self, object, **params):
         super(HoloViews, self).__init__(object, **params)

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -82,10 +82,10 @@ class PaneBase(Reactive):
         The object being wrapped, which will be converted into a Bokeh model.""")
 
     # When multiple Panes apply to an object, the one with the highest
-    # numerical precedence is selected. The default is an intermediate value.
-    # If set to None, applies method will be called to get a precedence
+    # numerical priority is selected. The default is an intermediate value.
+    # If set to None, applies method will be called to get a priority
     # value for a specific object type.
-    precedence = 0.5
+    priority = 0.5
 
     # Declares whether Pane supports updates to the Bokeh model
     _updates = False
@@ -96,8 +96,8 @@ class PaneBase(Reactive):
     def applies(cls, obj):
         """
         Given the object return a boolean indicating whether the Pane
-        can render the object. If the precedence of the pane is set to
-        None, this method may also be used to define a precedence
+        can render the object. If the priority of the pane is set to
+        None, this method may also be used to define a priority
         depending on the object being rendered.
         """
         return None
@@ -108,16 +108,16 @@ class PaneBase(Reactive):
             return type(obj)
         descendents = []
         for p in param.concrete_descendents(PaneBase).values():
-            precedence = p.applies(obj) if p.precedence is None else p.precedence
-            if isinstance(precedence, bool) and precedence:
-                raise ValueError('If a Pane declares no precedence '
+            priority = p.applies(obj) if p.priority is None else p.priority
+            if isinstance(priority, bool) and priority:
+                raise ValueError('If a Pane declares no priority '
                                  'the applies method should return a '
-                                 'precedence value specific to the '
+                                 'priority value specific to the '
                                  'object type or False, but the %s pane '
-                                 'declares no precedence.' % p.__name__)
-            elif precedence is None or precedence is False:
+                                 'declares no priority.' % p.__name__)
+            elif priority is None or priority is False:
                 continue
-            descendents.append((precedence, p))
+            descendents.append((priority, p))
         pane_types = reversed(sorted(descendents, key=lambda x: x[0]))
         for _, pane_type in pane_types:
             applies = pane_type.applies(obj)
@@ -203,7 +203,7 @@ class Bokeh(PaneBase):
     Bokeh panes allow including any Bokeh model in a panel.
     """
 
-    precedence = 0.8
+    priority = 0.8
 
     @classmethod
     def applies(cls, obj):
@@ -505,8 +505,8 @@ class LaTeX(PNG):
     See https://matplotlib.org/users/mathtext.html for what is supported.
     """
 
-    # Precedence is dependent on the data type
-    precedence = None
+    # Priority is dependent on the data type
+    priority = None
 
     size = param.Number(default=25, bounds=(1, 100), doc="""
         Size of the rendered equation.""")
@@ -580,8 +580,8 @@ class HTML(DivPaneBase):
     allow room for whatever is being wrapped.
     """
 
-    # Precedence is dependent on the data type
-    precedence = None
+    # Priority is dependent on the data type
+    priority = None
 
     @classmethod
     def applies(cls, obj):
@@ -604,12 +604,12 @@ class Str(DivPaneBase):
     """
     A Str pane renders any object for which `str()` can be called,
     escaping any HTML markup and then wrapping the resulting string in
-    a bokeh Div model.  Set to a low precedence because generally one
+    a bokeh Div model.  Set to a low priority because generally one
     will want a better representation, but allows arbitrary objects to
     be used as a Pane (numbers, arrays, objects, etc.).
     """
 
-    precedence = 0
+    priority = 0
 
     @classmethod
     def applies(cls, obj):
@@ -624,12 +624,12 @@ class Markdown(DivPaneBase):
     """
     A Markdown pane renders the markdown markup language to HTML and
     displays it inside a bokeh Div model. It has no explicit
-    precedence since it cannot be easily be distinguished from a
+    priority since it cannot be easily be distinguished from a
     standard string, therefore it has to be invoked explicitly.
     """
 
-    # Precedence depends on the data type
-    precedence = None
+    # Priority depends on the data type
+    priority = None
 
     @classmethod
     def applies(cls, obj):
@@ -660,7 +660,7 @@ class YT(HTML):
     provide additional space.
     """
 
-    precedence = 0.5
+    priority = 0.5
 
     @classmethod
     def applies(cls, obj):

--- a/panel/param.py
+++ b/panel/param.py
@@ -104,7 +104,7 @@ class Param(PaneBase):
         Dictionary of widget overrides, mapping from parameter name
         to widget class.""")
 
-    precedence = 0.1
+    priority = 0.1
 
     _mapping = {
         param.Action:         Button,

--- a/panel/plotly.py
+++ b/panel/plotly.py
@@ -37,7 +37,7 @@ class Plotly(PaneBase):
 
     _updates = True
 
-    precedence = 0.8
+    priority = 0.8
 
     def __init__(self, object, layout=None, **params):
         super(Plotly, self).__init__(self._to_figure(object, layout),

--- a/panel/tests/test_pipeline.py
+++ b/panel/tests/test_pipeline.py
@@ -13,15 +13,15 @@ if LooseVersion(param.__version__) < '1.8.2':
     pytest.skip("skipping if param version < 1.8.2", allow_module_level=True)
 
 class Stage1(param.Parameterized):
-    
+
     a = param.Number(default=5, bounds=(0, 10))
 
     b = param.Number(default=5, bounds=(0, 10))
-    
+
     @param.output(c=param.Number)
     def output(self):
         return self.a * self.b
-    
+
     @param.depends('a', 'b')
     def view(self):
         return '%s * %s = %s' % (self.a, self.b, self.output())
@@ -31,11 +31,11 @@ class Stage1(param.Parameterized):
 
 
 class Stage2(param.Parameterized):
-    
+
     c = param.Number(default=5, precedence=-1, bounds=(0, None))
 
     exp = param.Number(default=0.1, bounds=(0, 3))
-    
+
     @param.depends('c', 'exp')
     def view(self):
         return '%s^%s=%.3f' % (self.c, self.exp, self.c**self.exp)
@@ -46,7 +46,7 @@ class Stage2(param.Parameterized):
 @hv_available
 def test_pipeline_from_classes():
     import holoviews as hv
-    
+
     pipeline = Pipeline([('Stage 1', Stage1), ('Stage 2', Stage2)])
 
     layout = pipeline.layout
@@ -197,6 +197,6 @@ def test_pipeline_getitem():
 def test_pipeline_repr():
     pipeline = Pipeline()
     pipeline.add_stage('Stage 1', Stage1)
-    
+
     pipeline.add_stage('Stage 2', Stage2)
     assert repr(pipeline) == 'Pipeline:\n    [0] Stage 1: Stage1()\n    [1] Stage 2: Stage2()'

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -46,8 +46,8 @@ class Vega(PaneBase):
     the figure on bokeh server and via Comms.
     """
 
-    precedence = 0.8
-    
+    priority = 0.8
+
     _updates = True
 
     def __init__(self, object, **params):


### PR DESCRIPTION
PR title says it all. I find using `precedence` for panes horribly confusing:

1) Panel uses parameters with defined precedence internally.
2) Panel sorts on parameter precedence when building widgets for parameterized objects.
3) Panel applies panes according to its own notion of precedence.

Now if you grep for `precedence`, you know that the only concept there relates to parameters.