### PR TITLE
Use parameter definition order for Python 3.6+

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -359,7 +359,8 @@ class Param(PaneBase):
                     if ((p.precedence is None) or (p.precedence >= self.display_threshold))]
         groups = itertools.groupby(filtered, key=key_fn)
         # Params preserve definition order in Python 3.6+
-        dict_ordered = sys.version_info.major == 3 and sys.version_info.minor >= 6
+        dict_ordered_py3 = (sys.version_info.major == 3 and sys.version_info.minor >= 6)
+        dict_ordered = dict_ordered_py3 or (sys.version_info.major > 3)
         ordered_groups = [list(grp) if dict_ordered else sorted(grp) for (k,grp) in groups]
         ordered_params = [el[0] for group in ordered_groups for el in group]
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -360,8 +360,8 @@ class Param(PaneBase):
         groups = itertools.groupby(filtered, key=key_fn)
         # Params preserve definition order in Python 3.6+
         ordered_params = sys.version_info.major == 3 and sys.version_info.minor >= 6
-        sorted_groups = [list(grp) if ordered_params else sorted(grp) for (k,grp) in groups]
-        ordered_params = [el[0] for group in sorted_groups for el in group]
+        ordered_groups = [list(grp) if ordered_params else sorted(grp) for (k,grp) in groups]
+        ordered_params = [el[0] for group in ordered_groups for el in group]
 
         # Format name specially
         ordered_params.pop(ordered_params.index('name'))

--- a/panel/param.py
+++ b/panel/param.py
@@ -5,6 +5,7 @@ set of widgets.
 from __future__ import absolute_import, division, unicode_literals
 
 import os
+import sys
 import json
 import types
 import inspect
@@ -357,7 +358,9 @@ class Param(PaneBase):
         filtered = [(k,p) for (k,p) in sorted_precedence
                     if ((p.precedence is None) or (p.precedence >= self.display_threshold))]
         groups = itertools.groupby(filtered, key=key_fn)
-        sorted_groups = [sorted(grp) for (k,grp) in groups]
+        # Params preserve definition order in Python 3.6+
+        ordered_params = sys.version_info.major == 3 and sys.version_info.minor >= 6
+        sorted_groups = [list(grp) if ordered_params else sorted(grp) for (k,grp) in groups]
         ordered_params = [el[0] for group in sorted_groups for el in group]
 
         # Format name specially

--- a/panel/param.py
+++ b/panel/param.py
@@ -359,8 +359,8 @@ class Param(PaneBase):
                     if ((p.precedence is None) or (p.precedence >= self.display_threshold))]
         groups = itertools.groupby(filtered, key=key_fn)
         # Params preserve definition order in Python 3.6+
-        ordered_params = sys.version_info.major == 3 and sys.version_info.minor >= 6
-        ordered_groups = [list(grp) if ordered_params else sorted(grp) for (k,grp) in groups]
+        dict_ordered = sys.version_info.major == 3 and sys.version_info.minor >= 6
+        ordered_groups = [list(grp) if dict_ordered else sorted(grp) for (k,grp) in groups]
         ordered_params = [el[0] for group in ordered_groups for el in group]
 
         # Format name specially


### PR DESCRIPTION
Since Python dictionaries preserve order since 3.6 (and it became part of the CPython spec in 3.7), you no longer have to use parameter precedence to order your widgets as they can appear in definition order. This PR implements this behavior for Python 3.6+.