### PR TITLE
Minor fixes to docs and website

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,10 +6,9 @@
 A high-level app and dashboarding solution for Python
 -----------------------------------------------------
 
+Panel is an `open-source <https://github.com/pyviz/panel/blob/master/LICENSE.txt>`_ Python library that lets you create custom interactive web apps and dashboards by connecting user-defined widgets to plots, images, tables, or text.
 
-Panel is an `open-source <https://github.com/pyviz/panel/blob/master/LICENSE.txt>`_ Python library.  
-
-Panel provides tools for easily composing widgets, plots, tables, and other viewable objects and controls into web-based control panels, apps, and dashboards. Panel works with visualizations from `Matplotlib <matplotlib.org>`__, `Bokeh <http://bokeh.pydata.org>`__, `HoloViews <http://holoviews.org>`__, and many other Python plotting libraries, making them instantly viewable either individually or when combined with interactive widgets that control them. 
+Compared to other approaches, Panel is novel in that it supports nearly all plotting libraries, works just as well in a Jupyter notebook as on a standalone secure web server, uses the same code for both those cases, supports both Python-backed and static HTML/JavaScript exported applications, and can be used to develop rich interactive applications without tying your domain-specific code to any particular GUI or web tools.
 
 Panel makes it simple to make:
 
@@ -21,16 +20,11 @@ Panel makes it simple to make:
 -  Data-rich Python-backed web servers
 -  and anything in between
 
-Panel objects are reactive, immediately updating to reflect changes to
-their state, which makes it simple to compose viewable objects and link
-them into simple, one-off apps to do a specific exploratory task. The
-same objects can then be reused in more complex combinations to build
-more ambitious apps, while always sharing the same code that works well
-on its own.
+Panel objects are reactive, immediately updating to reflect changes to their state, which makes it simple to compose viewable objects and link them into simple, one-off apps to do a specific exploratory task. The same objects can then be reused in more complex combinations to build more ambitious apps, while always sharing the same code that works well on its own.
 
-Compared to other tookits for building interactive web apps, Panel is unique in that lets you move the same code freely between an interactive `Jupyter Notebook <http://jupyter.org>`__ prompt and a fully deployable standalone server.  That way you can easily switch between exploring your data, building visualizations, adding custom interactivity, sharing with non-technical users, and back again at any point, using the same tools and the same code throughout. Panel thus helps support your entire workflow, so that you never have to commit to only one way of using your data and your analyses, and don't have to rewrite your code just to make it usable in a different way.
+Panel lets you move the same code freely between an interactive `Jupyter Notebook <http://jupyter.org>`__ prompt and a fully deployable standalone server.  That way you can easily switch between exploring your data, building visualizations, adding custom interactivity, sharing with non-technical users, and back again at any point, using the same tools and the same code throughout. Panel thus helps support your entire workflow, so that you never have to commit to only one way of using your data and your analyses, and don't have to rewrite your code just to make it usable in a different way.
 
-Some example Panel apps: (click on the title to see the code in each case)
+Some example Panel apps: (Click on the title to see the code, or the image to deploy on mybinder if it has resources available.)
 
 
 .. raw:: html
@@ -52,58 +46,51 @@ Using Panel for declarative, reactive programming
 
 Panel can also be used with the separate `Param <http://param.pyviz.org>`__ project to create interactively configurable objects with or without associated visualizations, in a fully declarative way. With this approach, you declare your configurable object using the pure-Python, zero-dependency ``param`` library, annotating your code with parameter ranges, documentation, and dependencies between parameters and your code. Using this information, you can make all of your domain-specific code be optionally configurable in a GUI, with optional visual displays and debugging information if you like, all with just a few lines of declarations. With this approach, you don't ever have to commit to whether your code will be used in a notebook, in a GUI app, or completely behind the scenes in batch processing or reports -- the same code can support all of these cases equally well, once you declare the associated parameters and constraints. This approach lets you completely separate your domain-specific code from anything to do with web browsers, GUI toolkits, or other volatile technologies that would otherwise make your hard work become obsolete as they change over time. 
 
-
 The `User Guide <user_guide>`_ explains how to use Panel.  Panel is currently in prerelease status, which means that it is available for public use but has an API that is expected to change with each new release without detailed notice. 
 
 If you have any `issues <https://github.com/pyviz/panel/issues>`_ or wish to `contribute code <https://help.github.com/articles/about-pull-requests>`_, you can visit our `GitHub site <https://github.com/pyviz/panel>`_ or chat with the developers on `gitter <https://gitter.im/ioam/holoviews>`_.
 
 
 Installation
-____________
+------------
 
 |CondaPkg|_ |PyPI|_ |License|_
 
 
-Panel works with `Python 2.7 and Python 3 <https://travis-ci.org/pyviz/panel>`_ on Linux, Windows, or Mac, and provides optional extensions for working with `Jupyter Notebook and Jupyter Lab <http://jupyter.org>`_.
-
-The recommended way to install Panel is using the `conda <http://conda.pydata.org/docs/>`_ command provided by `Anaconda <http://docs.continuum.io/anaconda/install>`_ or `Miniconda <http://conda.pydata.org/miniconda.html>`_::
+Panel works with `Python 2.7 and Python 3 <https://travis-ci.org/pyviz/panel>`_ on Linux, Windows, or Mac.  The recommended way to install Panel is using the `conda <http://conda.pydata.org/docs/>`_ command provided by `Anaconda <http://docs.continuum.io/anaconda/install>`_ or `Miniconda <http://conda.pydata.org/miniconda.html>`_::
 
   conda install -c pyviz panel
 
-or simply using PyPI::
+or using PyPI::
 
   pip install panel
+
+Support for classic Jupyter Notebook is included with Panel. If you want to work with JupyterLab, you will also need to install the optional PyViz JupyterLab extension::
+
+  conda install -c conda-forge jupyterlab
+  jupyter labextension install @pyviz/jupyterlab_pyviz
+
+  
+Getting Started
+---------------
+
+Once you've installed Panel, you can get your own copy of all the examples shown on this website::
+
+  panel examples
+  cd panel-examples
+
+And then you can launch Jupyter to explore them yourself using either Jupyter Notebook or JupyterLab::
+
+  jupyter notebook
+  jupyter lab
+
 
 PyViz
 -----
 
 Panel is part of the PyViz family of tools.  The `PyViz website <http://pyviz.org>`_
 shows how to use Panel together with other libraries to solve complex problems,
-including detailed tutorials and examples.
-
-
-Usage
------
-
-Once you've installed Panel, you can get a copy of all the examples shown on this website::
-
-  panel examples
-  cd panel-examples
-
-And then you can launch Jupyter Notebook to explore them::
-
-  jupyter notebook
-
-To work with JupyterLab you will also need the PyViz JupyterLab
-extension::
-
-  conda install -c conda-forge jupyterlab
-  jupyter labextension install @pyviz/jupyterlab_pyviz
-
-Once you have installed JupyterLab and the extension launch it with::
-
-  jupyter-lab
-
+with detailed tutorials and examples.
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/panel.svg

--- a/examples/user_guide/Introduction.ipynb
+++ b/examples/user_guide/Introduction.ipynb
@@ -34,11 +34,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we wanted to try out lots of combinations of these values to understand how frequency and amplitude affect this plot, we could reevaluate the above cell lots of times, but that would be a slow and painful process, and is only really appropriate for some users comfortable with editing Python code. \n",
+    "If we wanted to try out lots of combinations of these values to understand how frequency and amplitude affect this plot, we could reevaluate the above cell lots of times, but that would be a slow and painful process, and is only really appropriate for users who are comfortable with editing Python code. \n",
     "\n",
     "## Interactive Panels\n",
     "\n",
-    "Instead of editing code, it's much quicker and more straightforward to use sliders to adjust the values interactively.  You can easily make a Panel app to explore a function's parameters using `pn.interact`:"
+    "Instead of editing code, it's much quicker and more straightforward to use sliders to adjust the values interactively.  You can easily make a Panel app to explore a function's parameters using `pn.interact`, which is similar to the [ipywidgets interact function](https://ipywidgets.readthedocs.io/en/stable/examples/Using%20Interact.html):"
    ]
   },
   {
@@ -110,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Panel widgets are reactive, so they will update even if you set the values by hand:"
+    "Also note that Panel widgets are reactive, so they will update even if you set the values by hand:"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "source": [
     "## Deploying Panels\n",
     "\n",
-    "The above panels all work in the notebook cell, but unlike other approaches such as ipywidgets, Panel apps work just the same in a standalone server. For instance, the app above can be launched as its own web server on your machine by uncommenting and running the following cell:"
+    "The above panels all work in the notebook cell (if you have a live Jupyter kernel running), but unlike other approaches such as ipywidgets, Panel apps work just the same in a standalone server. For instance, the app above can be launched as its own web server on your machine by uncommenting and running the following cell:"
    ]
   },
   {
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Sine` class and the `sine_obj` instance have no dependency on Panel, jupyter, or any other GUI or web toolkit; they simply declare facts about a certain domain (such as that sine waves take frequency and amplitude parameters, and that amplitude is a number greater than or equal to zero).  This information is then enough for Panel to create an editable and viewable representation for this object without having to specify anything else:"
+    "The `Sine` class and the `sine_obj` instance have no dependency on Panel, jupyter, or any other GUI or web toolkit; they simply declare facts about a certain domain (such as that sine waves take frequency and amplitude parameters, and that amplitude is a number greater than or equal to zero).  This information is then enough for Panel to create an editable and viewable representation for this object without having to specify anything that depends on the domain-specific details encapsulated in `sine_obj`:"
    ]
   },
   {
@@ -238,7 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this way you can make even a large codebase be displayable and editable with Panel, without making it dependent on or tied to any particular gui library."
+    "In this way you can make even a large codebase be displayable and editable with Panel, without making it dependent on or tied to any particular GUI library."
    ]
   },
   {
@@ -313,15 +313,20 @@
    "source": [
     "## Exploring further\n",
     "\n",
-    "The other sections in this user guide expand on each of the topics above, explaining in detail how to do various tasks and use various types of functionality from Panel:\n",
+    "As you have seen above, Panel can be used in several different ways, each appropriate for different applications:\n",
     "\n",
-    "- [Interact](Interact.ipynb): More detailed and advanced usage of `interact()`, including controlling ranges\n",
+    "- [Interact](Interact.ipynb): Instant GUI, given a function with arguments\n",
+    "- [Widgets](Widgets.ipynb): Explicitly instantiating widgets and linking them to actions\n",
+    "- [Parameters](Parameters.ipynb): Capturing parameters and their links to actions declaratively\n",
+    "\n",
+    "Just pick the style that seems most appropriate for the task you want to do, then study that section of the user guide. Regardless of which approach you take, you'll want to learn more about Panel's panes and layouts:\n",
+    "\n",
     "- [Panes](Panes.ipynb): Types of panes supported (Matplotlib, SVG, HTML, etc.) and how to use them in panels\n",
-    "- [Widgets](Widgets.ipynb): Types of widgets supported and how to link them to actions\n",
     "- [Layouts](Layouts.ipynb): Composing panes and widgets into panels\n",
-    "- [Parameters](Parameters.ipynb): Capturing parameters and their links to actions declaratively for complex apps\n",
-    "- [Pipelines](Pipelines.ipynb): Making multi-stage processing pipelines in notebooks and as deployed apps\n",
-    "- [Demos](Demos.ipynb): Example apps and dashboards for various topic areas"
+    "\n",
+    "Finally, if you are building a complex multi-stage application, you can consider our preliminary support for organizing and navigating between pages (still a work in progress!):\n",
+    "\n",
+    "- [Pipelines](Pipelines.ipynb): Making multi-stage processing pipelines in notebooks and as deployed apps"
    ]
   }
  ],


### PR DESCRIPTION
The Installation section on http://panel.pyviz.org was being formatted at the wrong level:

![image](https://user-images.githubusercontent.com/1695496/53281127-41290d00-36e9-11e9-8b5f-a68dfff305bc.png)

Also cleaned up some wording and clarified in the intro that there are three completely different ways of using Panel, and that users should pick one of them for any particular application.