### PR TITLE
Improved behavior for fixed widths and heights

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -35,12 +35,6 @@ class Panel(Reactive):
         objects = [panel(pane) for pane in objects]
         super(Panel, self).__init__(objects=objects, **params)
 
-    def _init_properties(self):
-        properties = {k: v for k, v in self.param.get_param_values()
-                      if v is not None}
-        del properties['objects']
-        return self._process_param_change(properties)
-
     def _link_params(self, model, params, doc, root, comm=None):
         def set_value(*events):
             msg = {event.name: event.new for event in events}
@@ -329,11 +323,6 @@ class Spacer(Reactive):
 
     _bokeh_model = BkSpacer
 
-    def _init_properties(self):
-        properties = {k: v for k, v in self.param.get_param_values()
-                      if v not in [None, 'name']}
-        return self._process_param_change(properties)
-
     def _get_root(self, doc, comm=None):
         root = BkRow()
         model = self._get_model(doc, root, root, comm=comm)
@@ -342,7 +331,7 @@ class Spacer(Reactive):
         return root
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
-        model = self._bokeh_model(**self._init_properties())
+        model = self._bokeh_model(**self._process_param_change(self._init_properties()))
         self._models[root.ref['id']] = model
         self._link_params(model, ['width', 'height'], doc, root, comm)
         return model

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -40,7 +40,7 @@ def test_param_rename():
     assert params == {'a': 1}
 
     properties = obj._process_param_change({'a': 1})
-    assert properties == {'b': 1}
+    assert properties == {'b': 1, 'min_width': None, 'min_height': None}
 
 
 def test_link_params_nb(document, comm):

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -56,11 +56,14 @@ def test_widget_triggers_events(document, comm):
     with block_comm():
         text.value = '123'
 
-    assert len(document._held_events) == 1
-    event = document._held_events[0]
-    assert event.model is widget
-    assert event.attr == 'value'
-    assert event.new == '123'
+    assert len(document._held_events) == 3
+    event_found = False
+    for event in document._held_events:
+        if event.attr == 'value':
+            assert event.model is widget
+            assert event.new == '123'
+            event_found = True
+    assert event_found
 
 
 def test_static_text(document, comm):

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -58,11 +58,6 @@ class Widget(Reactive):
             params['name'] = ''
         super(Widget, self).__init__(**params)
 
-    def _init_properties(self):
-        properties = {k: v for k, v in self.param.get_param_values()
-                      if v is not None}
-        return self._process_param_change(properties)
-
     def _get_root(self, doc, comm=None):
         root = _BkColumn()
         model = self._get_model(doc, root, root, comm=comm)
@@ -74,7 +69,7 @@ class Widget(Reactive):
         root = parent if root is None else root
         if root is None:
             root = _BkColumn()
-        model = self._widget_type(**self._init_properties())
+        model = self._widget_type(**self._process_param_change(self._init_properties()))
 
         # Link parameters and bokeh model
         params = [p for p in self.params()]
@@ -657,7 +652,7 @@ class DiscreteSlider(Widget):
         model = _BkColumn()
         parent = parent or model
         root = root or parent
-        msg = self._init_properties()
+        msg = self._process_param_change(self._init_properties())
         div = _BkDiv(text=msg['text'])
         slider = _BkSlider(start=msg['start'], end=msg['end'], value=msg['value'],
                            title=None, step=1, show_value=False, tooltips=None)


### PR DESCRIPTION
This PR forces a fixed height to be respected if specified either by setting sizing_mode='fixed' or by setting the corresponding `min_width` or `min_height` property at the same time.

Fixes https://github.com/pyviz/panel/issues/23