### PR TITLE
Refactor model and root handling

### DIFF
--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -104,7 +104,7 @@ class HoloViews(PaneBase):
         self._plots[root.ref['id']] = plot
         return plot
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         """
         Should return the Bokeh model to be rendered.
         """

--- a/panel/holoviews.py
+++ b/panel/holoviews.py
@@ -104,10 +104,9 @@ class HoloViews(PaneBase):
         self._plots[root.ref['id']] = plot
         return plot
 
-    def _get_model(self, doc, root, parent, comm=None):
-        """
-        Should return the Bokeh model to be rendered.
-        """
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        if root is None:
+            return self._get_root(doc, comm)
         ref = root.ref['id']
         plot = self._render(doc, comm, root)
         child_pane = Pane(plot.state, _temporary=True)

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -179,9 +179,8 @@ class interactive(PaneBase):
                 new_kwargs.append((name, value, default))
         return new_kwargs
 
-    def _get_model(self, doc, root, parent, comm=None):
-        layout = self._inner_layout._get_model(doc, root, parent, comm)
-        return layout
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        return self._inner_layout._get_model(doc, root, parent, comm)
 
     def _link_widgets(self):
         if self.manual_update:

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -179,7 +179,7 @@ class interactive(PaneBase):
                 new_kwargs.append((name, value, default))
         return new_kwargs
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         layout = self._inner_layout._get_model(doc, root, parent, comm)
         return layout
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -110,7 +110,8 @@ class Panel(Reactive):
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         model = self._bokeh_model()
-        root = model if root is None else root
+        if root is None:
+            root = model
         objects = self._get_objects(model, [], doc, root, comm)
         props = dict(self._init_properties(), objects=objects)
         model.update(**self._process_param_change(props))
@@ -326,14 +327,7 @@ class Spacer(Reactive):
 
     _bokeh_model = BkSpacer
 
-    def _get_root(self, doc, comm=None):
-        root = BkRow()
-        model = self._get_model(doc, root, root, comm=comm)
-        root.children.append(model)
-        self._preprocess(root)
-        return root
-
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         model = self._bokeh_model(**self._process_param_change(self._init_properties()))
         self._models[root.ref['id']] = model
         self._link_params(model, ['width', 'height'], doc, root, comm)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -336,7 +336,7 @@ class Spacer(Reactive):
         return model
 
 
-class VSpacer(Reactive):
+class VSpacer(Spacer):
     """
     Spacer which automatically fills all available vertical space.
     """
@@ -344,7 +344,7 @@ class VSpacer(Reactive):
     sizing_mode = param.Parameter(default='stretch_height', readonly=True)
 
 
-class HSpacer(Reactive):
+class HSpacer(Spacer):
     """
     Spacer which automatically fills all available horizontal space.
     """

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -327,8 +327,10 @@ class Spacer(Reactive):
 
     _bokeh_model = BkSpacer
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         model = self._bokeh_model(**self._process_param_change(self._init_properties()))
+        if root is None:
+            root = model
         self._models[root.ref['id']] = model
         self._link_params(model, ['width', 'height'], doc, root, comm)
         return model

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -150,7 +150,10 @@ class PaneBase(Reactive):
         return self.layout[index]
 
     def _get_root(self, doc, comm=None):
-        root = self.layout._get_model(doc, comm=comm)
+        if self._updates:
+            root = self._get_model(doc, comm=comm)
+        else:
+            root = self.layout._get_model(doc, comm=comm)
         self._preprocess(root)
         return root
 
@@ -220,10 +223,10 @@ class Bokeh(PaneBase):
     def applies(cls, obj):
         return isinstance(obj, LayoutDOM)
 
-    def _get_model(self, doc, root, parent, comm=None):
-        """
-        Should return the Bokeh model to be rendered.
-        """
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        if root is None:
+            return self._get_root(doc, comm)
+
         model = self.object
         ref = root.ref['id']
         for js in model.select({'type': CustomJS}):
@@ -259,8 +262,10 @@ class DivPaneBase(PaneBase):
         return {p : getattr(self,p) for p in list(Layoutable.param) + ['style']
                 if getattr(self, p) is not None}
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         model = _BkDiv(**self._get_properties())
+        if root is None:
+            root = model
         self._models[root.ref['id']] = model
         self._link_object(doc, root, parent, comm)
         return model

--- a/panel/pane.py
+++ b/panel/pane.py
@@ -16,8 +16,7 @@ except:
 
 import param
 
-from bokeh.models import (LayoutDOM, CustomJS, Widget as _BkWidget,
-                          Div as _BkDiv, Column as _BkColumn)
+from bokeh.models import LayoutDOM, CustomJS, Div as _BkDiv
 
 from .layout import Panel, Row
 from .util import basestring, param_reprs, push, remove_root

--- a/panel/param.py
+++ b/panel/param.py
@@ -146,11 +146,11 @@ class Param(PaneBase):
             self._expand_layout = layout
             self.layout = self._widget_box
         elif isinstance(self._widget_box, layout):
-            self.layout = self._widget_box
-            self._expand_layout = self.layout
+            self.layout = Column(self._widget_box)
+            self._expand_layout = self._widget_box
         elif isinstance(layout, type) and issubclass(layout, Panel):
-            self.layout = layout(self._widget_box, **kwargs)
-            self._expand_layout = self.layout
+            self._expand_layout = layout(self._widget_box, **kwargs)
+            self.layout = Column(self._expand_layout)
         else:
             raise ValueError('expand_layout expected to be a panel.layout.Panel'
                              'type or instance, found %s type.' %

--- a/panel/param.py
+++ b/panel/param.py
@@ -384,7 +384,7 @@ class Param(PaneBase):
         self._models[root.ref['id']] = root
         return root
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         model = self.layout._get_model(doc, root, parent, comm)
         self._models[root.ref['id']] = model
         return model
@@ -448,7 +448,11 @@ class ParamMethod(PaneBase):
             # Try updating existing pane
             new_object = self.object()
             pane_type = self.get_pane_type(new_object)
-            if type(self._pane) is pane_type and not Link.registry.get(new_object):
+            try:
+                links = Link.registry.get(new_object)
+            except TypeError:
+                links = []
+            if type(self._pane) is pane_type and not links:
                 if isinstance(new_object, Reactive):
                     pvals = dict(self._pane.get_param_values())
                     new_params = {k: v for k, v in new_object.get_param_values()
@@ -476,7 +480,10 @@ class ParamMethod(PaneBase):
             watcher = pobj.param.watch(update_pane, ps, p.what)
             self._callbacks[ref].append(watcher)
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        if root is None:
+            return self._get_root(doc, comm)
+
         ref = root.ref['id']
         if ref in self._callbacks:
             self._cleanup(root)

--- a/panel/plotly.py
+++ b/panel/plotly.py
@@ -57,7 +57,7 @@ class Plotly(PaneBase):
             fig = go.Figure(data=data, layout=layout)
         return fig
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         """
         Should return the bokeh model to be rendered.
         """
@@ -72,6 +72,8 @@ class Plotly(PaneBase):
                     data[key] = trace.pop(key)
             sources.append(ColumnDataSource(data))
         model = PlotlyPlot(data=json, data_sources=sources)
+        if root is None:
+            root = model
         self._models[root.ref['id']] = model
         self._link_object(doc, root, parent, comm)
         return model

--- a/panel/plotly.py
+++ b/panel/plotly.py
@@ -57,7 +57,7 @@ class Plotly(PaneBase):
             fig = go.Figure(data=data, layout=layout)
         return fig
 
-    def _get_model(self, doc, root, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         """
         Should return the bokeh model to be rendered.
         """

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -175,17 +175,15 @@ def test_interact_replaces_model(document, comm):
 
     column = interact_pane.layout._get_model(document, comm=comm)
     assert isinstance(column, BkColumn)
-    box = column.children[1].children[0]
-    assert isinstance(box, BkColumn)
-    div = box.children[0]
+    div = column.children[1].children[0]
     assert isinstance(div, BkDiv)
     assert div.text == 'Test'
     assert len(interact_pane._callbacks['instance']) == 1
     assert column.ref['id'] in pane._callbacks
-    assert pane._models[column.ref['id']] is box
+    assert pane._models[column.ref['id']] is div
     
     widget.value = True
-    assert box.ref['id'] not in pane._callbacks
+    assert column.ref['id'] not in pane._callbacks
     assert pane._callbacks == {}
     new_pane = interact_pane._pane
     assert new_pane is not pane

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -74,17 +74,15 @@ def test_layout_select_by_function(panel):
 
 
 @pytest.mark.parametrize(['panel', 'model_type'], [(Column, BkColumn), (Row, BkRow)])
-def test_layout_get_model(panel, model_type, document, comm):
+def test_layout_get_root(panel, model_type, document, comm):
     div1 = Div()
     div2 = Div()
     layout = panel(div1, div2)
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     assert isinstance(model, model_type)
-    children = model.children
-    assert get_divs(children[0].children) == [div1]
-    assert get_divs(children[1].children) == [div2]
+    assert model.children == [div1, div2]
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
@@ -93,13 +91,11 @@ def test_layout_append(panel, document, comm):
     div2 = Div()
     layout = panel(div1, div2)
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     div3 = Div()
     layout.append(div3)
-    assert get_divs(model.children[0].children) == [div1]
-    assert get_divs(model.children[1].children) == [div2]
-    assert get_divs(model.children[2].children) == [div3]
+    assert model.children == [div1, div2, div3]
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
@@ -108,13 +104,11 @@ def test_layout_insert(panel, document, comm):
     div2 = Div()
     layout = panel(div1, div2)
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     div3 = Div()
     layout.insert(1, div3)
-    assert get_divs(model.children[0].children) == [div1]
-    assert get_divs(model.children[1].children) == [div3]
-    assert get_divs(model.children[2].children) == [div2]
+    assert model.children == [div1, div3, div2]
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
@@ -124,14 +118,13 @@ def test_layout_setitem(panel, document, comm):
     layout = panel(div1, div2)
     p1, p2 = layout.objects
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     assert model.ref['id'] in p1._callbacks
     assert p1._models[model.ref['id']] is model.children[0]
     div3 = Div()
     layout[0] = div3
-    assert get_divs(model.children[0].children) == [div3]
-    assert get_divs(model.children[1].children) == [div2]
+    assert model.children == [div3, div2]
     assert p1._callbacks == {}
     assert p1._models == {}
 
@@ -143,12 +136,12 @@ def test_layout_pop(panel, document, comm):
     layout = panel(div1, div2)
     p1, p2 = layout.objects
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     assert model.ref['id'] in p1._callbacks
     assert p1._models[model.ref['id']] is model.children[0]
     layout.pop(0)
-    assert get_divs(model.children[0].children) == [div2]
+    assert model.children == [div2]
     assert p1._callbacks == {}
     assert p1._models == {}
 
@@ -160,12 +153,12 @@ def test_layout_remove(panel, document, comm):
     layout = panel(div1, div2)
     p1, p2 = layout.objects
 
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     assert model.ref['id'] in p1._callbacks
     assert p1._models[model.ref['id']] is model.children[0]
     layout.remove(p1)
-    assert get_divs(model.children[0].children) == [div2]
+    assert model.children == [div2]
     assert p1._callbacks == {}
     assert p1._models == {}
 
@@ -176,7 +169,7 @@ def test_tabs_constructor(document, comm):
     tabs = Tabs(('Div1', div1), ('Div2', div2))
     p1, p2 = tabs.objects
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     assert isinstance(model, BkTabs)
     assert len(model.tabs) == 2
@@ -184,9 +177,9 @@ def test_tabs_constructor(document, comm):
     tab1, tab2 = model.tabs
 
     assert tab1.title == 'Div1'
-    assert get_div(tab1.child.children[0]) is div1
+    assert tab1.child is div1
     assert tab2.title == 'Div2'
-    assert get_div(tab2.child.children[0]) is div2
+    assert tab2.child is div2
 
 
 def test_tabs_implicit_constructor(document, comm):
@@ -195,7 +188,7 @@ def test_tabs_implicit_constructor(document, comm):
     p2 = Pane(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     assert isinstance(model, BkTabs)
     assert len(model.tabs) == 2
@@ -203,9 +196,9 @@ def test_tabs_implicit_constructor(document, comm):
     tab1, tab2 = model.tabs
 
     assert tab1.title == 'Div1'
-    assert get_div(tab1.child.children[0]) is div1
+    assert tab1.child is div1
     assert tab2.title == 'Div2'
-    assert get_div(tab2.child.children[0]) is div2
+    assert tab2.child is div2
 
 
 def test_tabs_set_panes(document, comm):
@@ -214,7 +207,7 @@ def test_tabs_set_panes(document, comm):
     p2 = Pane(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     div3 = Div()
     p3 = Pane(div3, name='Div3')
@@ -226,11 +219,11 @@ def test_tabs_set_panes(document, comm):
     tab1, tab2, tab3 = model.tabs
 
     assert tab1.title == 'Div1'
-    assert get_div(tab1.child.children[0]) is div1
+    assert tab1.child is div1
     assert tab2.title == 'Div2'
-    assert get_div(tab2.child.children[0]) is div2
+    assert tab2.child is div2
     assert tab3.title == 'Div3'
-    assert get_div(tab3.child.children[0]) is div3
+    assert tab3.child is div3
 
 
 def test_tabs_append(document, comm):
@@ -239,7 +232,7 @@ def test_tabs_append(document, comm):
     p2 = Pane(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     div3 = Div()
     tabs.append(div3)
@@ -251,14 +244,14 @@ def test_tabs_insert(document, comm):
     div2 = Div()
     tabs = Tabs(div1, div2)
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     div3 = Div()
     tabs.insert(1, div3)
     tab1, tab2, tab3 = model.tabs
-    assert get_div(tab1.child.children[0]) is div1
-    assert get_div(tab2.child.children[0]) is div3
-    assert get_div(tab3.child.children[0]) is div2
+    assert tab1.child is div1
+    assert tab2.child is div3
+    assert tab3.child is div2
 
 
 def test_tabs_setitem(document, comm):
@@ -267,7 +260,7 @@ def test_tabs_setitem(document, comm):
     tabs = Tabs(div1, div2)
     p1, p2 = tabs.objects
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     tab1, tab2 = model.tabs
     assert model.ref['id'] in p1._callbacks
@@ -275,8 +268,8 @@ def test_tabs_setitem(document, comm):
     div3 = Div()
     tabs[0] = div3
     tab1, tab2 = model.tabs
-    assert get_div(tab1.child.children[0]) is div3
-    assert get_div(tab2.child.children[0]) is div2
+    assert tab1.child is div3
+    assert tab2.child is div2
     assert p1._callbacks == {}
     assert p1._models == {}
 
@@ -287,7 +280,7 @@ def test_tabs_pop(document, comm):
     tabs = Tabs(div1, div2)
     p1, p2 = tabs.objects
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     tab1 = model.tabs[0]
     assert model.ref['id'] in p1._callbacks
@@ -295,7 +288,7 @@ def test_tabs_pop(document, comm):
     tabs.pop(0)
     assert len(model.tabs) == 1
     tab1 = model.tabs[0]
-    assert get_div(tab1.child.children[0]) is div2
+    assert tab1.child is div2
     assert p1._callbacks == {}
     assert p1._models == {}
 
@@ -306,7 +299,7 @@ def test_tabs_remove(document, comm):
     tabs = Tabs(div1, div2)
     p1, p2 = tabs.objects
 
-    model = tabs._get_model(document, comm=comm)
+    model = tabs._get_root(document, comm=comm)
 
     tab1 = model.tabs[0]
     assert model.ref['id'] in p1._callbacks
@@ -314,18 +307,16 @@ def test_tabs_remove(document, comm):
     tabs.remove(p1)
     assert len(model.tabs) == 1
     tab1 = model.tabs[0]
-    assert get_div(tab1.child.children[0]) is div2
+    assert tab1.child is div2
     assert p1._callbacks == {}
     assert p1._models == {}
 
 
 def test_spacer(document, comm):
-
     spacer = Spacer(width=400, height=300)
 
-    root = spacer._get_root(document, comm=comm)
-    model = root.children[0]
-    
+    model = spacer._get_root(document, comm=comm)
+
     assert isinstance(model, spacer._bokeh_model)
     assert model.width == 400
     assert model.height == 300
@@ -349,7 +340,7 @@ def test_layout_with_param_setitem(document, comm):
             self._layout[-1] = self.select
         
     test = TestClass()
-    model = test._layout._get_model(document, comm=comm)
+    model = test._layout._get_root(document, comm=comm)
     test.select = 1
     assert model.children[1].text == '<pre>1</pre>'
-    
+

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -83,27 +83,20 @@ def test_matplotlib_pane(document, comm):
     pane = Pane(mpl_figure())
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    assert row.ref['id'] in pane._callbacks
-    model = row.children[0]
-    div = get_div(model)
-    assert '<img' in div.text
-    text = div.text
-    assert pane._models[row.ref['id']] is model
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert '<img' in model.text
+    text = model.text
+    assert pane._models[model.ref['id']] is model
 
     # Replace Pane.object
     pane.object = mpl_figure()
-    model = row.children[0]
-    div2 = get_div(model)
-    assert div is div2
-    assert div.text != text
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
+    assert model.text != text
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
     assert pane._models == {}
 
@@ -118,25 +111,19 @@ def test_markdown_pane(document, comm):
     pane = Pane("**Markdown**")
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    div = get_div(model)
-    assert div.text == "<p><strong>Markdown</strong></p>"
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<p><strong>Markdown</strong></p>"
 
     # Replace Pane.object
     pane.object = "*Markdown*"
-    model = row.children[0]
-    assert div is get_div(model)
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    assert div.text == "<p><em>Markdown</em></p>"
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<p><em>Markdown</em></p>"
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
     assert pane._models == {}
 
@@ -145,25 +132,19 @@ def test_html_pane(document, comm):
     pane = HTML("<h1>Test</h1>")
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    div = get_div(model)
-    assert div.text == "<h1>Test</h1>"
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<h1>Test</h1>"
 
     # Replace Pane.object
     pane.object = "<h2>Test</h2>"
-    model = row.children[0]
-    assert div is get_div(model)
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    assert div.text == "<h2>Test</h2>"
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<h2>Test</h2>"
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
     assert pane._models == {}
 
@@ -174,19 +155,15 @@ def test_latex_pane(document, comm):
     pane = LaTeX(r"$\frac{p^3}{q}$")
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    div = get_div(model)
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
     # Just checks for a PNG, not a specific rendering, to avoid
     # false alarms when formatting of the PNG changes
-    assert div.text[0:32] == "<img src='data:image/png;base64,"
+    assert model.text[0:32] == "<img src='data:image/png;base64,"
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
 
 
@@ -194,25 +171,19 @@ def test_string_pane(document, comm):
     pane = Str("<h1>Test</h1>")
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    div = get_div(model)
-    assert div.text == "<pre>&lt;h1&gt;Test&lt;/h1&gt;</pre>"
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<pre>&lt;h1&gt;Test&lt;/h1&gt;</pre>"
 
     # Replace Pane.object
     pane.object = "<h2>Test</h2>"
-    model = row.children[0]
-    assert div is get_div(model)
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    assert div.text == "<pre>&lt;h2&gt;Test&lt;/h2&gt;</pre>"
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text == "<pre>&lt;h2&gt;Test&lt;/h2&gt;</pre>"
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
     assert pane._models == {}
 
@@ -226,15 +197,11 @@ def test_svg_pane(document, comm):
     pane = SVG(rect)
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    div = get_div(model)
-    assert div.text.startswith('<img')
-    assert b64encode(rect.encode('utf-8')).decode('utf-8') in div.text
+    model = pane._get_root(document, comm=comm)
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text.startswith('<img')
+    assert b64encode(rect.encode('utf-8')).decode('utf-8') in model.text
 
     # Replace Pane.object
     circle = """
@@ -243,15 +210,13 @@ def test_svg_pane(document, comm):
     </svg>
     """
     pane.object = circle
-    model = row.children[0]
-    assert div is get_div(model)
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
-    assert div.text.startswith('<img')
-    assert b64encode(circle.encode('utf-8')).decode('utf-8') in div.text
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
+    assert model.text.startswith('<img')
+    assert b64encode(circle.encode('utf-8')).decode('utf-8') in model.text
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
     assert pane._models == {}
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -75,14 +75,14 @@ def test_param_pane_repr_with_params(document, comm):
     assert repr(Pane(Test(), parameters=['a'])) == "Param(Test, parameters=['a'])"
 
 
-def test_get_model(document, comm):
+def test_get_root(document, comm):
 
     class Test(param.Parameterized):
         pass
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     assert isinstance(model, BkColumn)
     assert len(model.children) == 1
@@ -92,14 +92,14 @@ def test_get_model(document, comm):
     assert div.text == '<b>'+test.name[:-5]+'</b>'
 
 
-def test_get_model_tabs(document, comm):
+def test_get_root_tabs(document, comm):
 
     class Test(param.Parameterized):
         pass
 
     test = Test()
     test_pane = Pane(test, expand_layout=Tabs, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     assert isinstance(model, BkTabs)
     assert len(model.tabs) == 1
@@ -115,7 +115,7 @@ def test_number_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
     assert isinstance(slider, Slider)
@@ -155,7 +155,7 @@ def test_boolean_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     checkbox = model.children[1]
     assert isinstance(checkbox, CheckboxGroup)
@@ -186,7 +186,7 @@ def test_range_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     widget = model.children[1]
     assert isinstance(widget, RangeSlider)
@@ -223,7 +223,7 @@ def test_integer_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
     assert isinstance(slider, Slider)
@@ -263,7 +263,7 @@ def test_object_selector_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
     assert isinstance(slider, Select)
@@ -299,7 +299,7 @@ def test_list_selector_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
     assert isinstance(slider, MultiSelect)
@@ -336,7 +336,7 @@ def test_action_param(document, comm):
 
     test = Test()
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
     assert isinstance(slider, Button)
@@ -349,7 +349,7 @@ def test_explicit_params(document, comm):
 
     test = Test()
     test_pane = Pane(test, parameters=['a'], _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     assert len(model.children) == 2
     assert isinstance(model.children[1], CheckboxGroup)
@@ -377,7 +377,7 @@ def test_expand_param_subobject(document, comm):
 
     test = Test(a=Test(name='Nested'))
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
     assert isinstance(toggle, Toggle)
@@ -411,7 +411,7 @@ def test_switch_param_subobject(document, comm):
     Test.param['a'].objects = [o1, o2, 3]
     test = Test(a=o1, name='Nested')
     test_pane = Pane(test, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
     assert isinstance(toggle, Toggle)
@@ -454,7 +454,7 @@ def test_expand_param_subobject_into_row(document, comm):
     row = Row()
     test_pane = Pane(test, expand_layout=row, _temporary=True)
     layout = Row(test_pane, row)
-    model = layout._get_model(document, comm=comm)
+    model = layout._get_root(document, comm=comm)
 
     toggle = model.children[0].children[2]
     assert isinstance(toggle, Toggle)
@@ -486,7 +486,7 @@ def test_expand_param_subobject_expand(document, comm):
 
     test = Test(a=Test(name='Nested'))
     test_pane = Pane(test, _temporary=True, expand=True, expand_button=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
     assert isinstance(toggle, Toggle)
@@ -515,7 +515,7 @@ def test_param_subobject_expand_no_toggle(document, comm):
     test = Test(a=Test(name='Nested'))
     test_pane = Pane(test, _temporary=True, expand=True,
                      expand_button=False)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     # Assert no toggle was added
     assert len(model.children) == 3
@@ -534,7 +534,7 @@ def test_expand_param_subobject_tabs(document, comm):
 
     test = Test(a=Test(name='Nested'), name='A')
     test_pane = Pane(test, expand_layout=Tabs, _temporary=True)
-    model = test_pane._get_model(document, comm=comm)
+    model = test_pane._get_root(document, comm=comm)
 
     toggle = model.tabs[0].child.children[1]
     assert isinstance(toggle, Toggle)

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -10,7 +10,6 @@ except:
 plotly_available = pytest.mark.skipif(plotly is None, reason="requires plotly")
 
 import numpy as np
-from bokeh.models import Row as BkRow
 from panel.pane import Pane, PaneBase
 from panel.plotly import Plotly, PlotlyPlot
 
@@ -40,13 +39,10 @@ def test_plotly_pane_single_trace(document, comm):
     pane = Pane(trace, layout={'width': 350})
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
+    model = pane._get_root(document, comm=comm)
     assert isinstance(model, PlotlyPlot)
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'scatter'
     assert model.data['data'][0]['x'] == [0, 1]
@@ -58,7 +54,6 @@ def test_plotly_pane_single_trace(document, comm):
     # Replace Pane.object
     new_trace = go.Bar(x=[2, 3], y=[4, 5])
     pane.object = new_trace
-    assert row.children[0] is model
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'bar'
     assert model.data['data'][0]['x'] == [2, 3]
@@ -66,11 +61,11 @@ def test_plotly_pane_single_trace(document, comm):
     assert model.data['layout'] == {'width': 350}
     assert len(model.data_sources) == 1
     assert model.data_sources[0].data == {}
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is model
+    assert model.ref['id'] in pane._callbacks
+    assert pane._models[model.ref['id']] is model
 
     # Cleanup
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
 
 
@@ -80,12 +75,9 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     pane = Pane(trace, layout={'width': 350})
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
+    model = pane._get_root(document, comm=comm)
     assert isinstance(model, PlotlyPlot)
-    assert row.ref['id'] in pane._callbacks
+    assert model.ref['id'] in pane._callbacks
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'scatter'
     assert 'x' not in model.data['data'][0]
@@ -100,7 +92,6 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     new_trace = [go.Scatter(x=np.array([5, 6]), y=np.array([6, 7])),
                  go.Bar(x=np.array([2, 3]), y=np.array([4, 5]))]
     pane.object = new_trace
-    assert row.children[0] is model
     assert len(model.data['data']) == 2
     assert model.data['data'][0]['type'] == 'scatter'
     assert 'x' not in model.data['data'][0]
@@ -116,8 +107,8 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     cds2 = model.data_sources[1]
     assert np.array_equal(cds2.data['x'], np.array([2, 3]))
     assert np.array_equal(cds2.data['y'], np.array([4, 5]))
-    assert row.ref['id'] in pane._callbacks
+    assert model.ref['id'] in pane._callbacks
 
     # Cleanup
-    pane._cleanup(row, True)
+    pane._cleanup(model, True)
     assert pane._callbacks == {}

--- a/panel/tests/test_vega.py
+++ b/panel/tests/test_vega.py
@@ -9,7 +9,6 @@ except:
 altair_available = pytest.mark.skipif(alt is None, reason="requires altair")
 
 import numpy as np
-from bokeh.models import Row as BkRow
 from panel.pane import Pane, PaneBase
 from panel.vega import Vega, VegaPlot
 
@@ -34,10 +33,7 @@ def test_vega_pane(document, comm):
     pane = Pane(vega_example)
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
+    model = pane._get_root(document, comm=comm)
     assert isinstance(model, VegaPlot)
 
     expected = dict(vega_example, data={})
@@ -56,7 +52,7 @@ def test_vega_pane(document, comm):
     assert np.array_equal(cds_data['x'], np.array(['C', 'B', 'C', 'D', 'E'])) 
     assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
 
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}
 
 
@@ -84,10 +80,7 @@ def test_altair_pane(document, comm):
     pane = Pane(altair_example())
 
     # Create pane
-    row = pane._get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
-    assert len(row.children) == 1
-    model = row.children[0]
+    model = pane._get_root(document, comm=comm)
     assert isinstance(model, VegaPlot)
 
     expected = dict(vega_example, data={})
@@ -108,5 +101,5 @@ def test_altair_pane(document, comm):
     assert np.array_equal(cds_data['x'], np.array(['C', 'B', 'C', 'D', 'E'])) 
     assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
 
-    pane._cleanup(row)
+    pane._cleanup(model)
     assert pane._callbacks == {}

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -20,11 +20,8 @@ def test_text_input(document, comm):
 
     text = TextInput(value='ABC', name='Text:')
 
-    box = text._get_root(document, comm=comm)
+    widget = text._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, text._widget_type)
     assert widget.value == 'ABC'
     assert widget.title == 'Text:'
@@ -43,9 +40,8 @@ def test_widget_triggers_events(document, comm):
     """
     text = TextInput(value='ABC', name='Text:')
 
-    box = text._get_root(document, comm=comm)
-    widget = box.children[0]
-    document.add_root(box)
+    widget = text._get_root(document, comm=comm)
+    document.add_root(widget)
     document.hold()
 
     # Simulate client side change
@@ -70,11 +66,8 @@ def test_static_text(document, comm):
 
     text = StaticText(value='ABC', name='Text:')
 
-    box = text._get_root(document, comm=comm)
+    widget = text._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, text._widget_type)
     assert widget.text == '<b>Text:</b>: ABC'
 
@@ -87,11 +80,8 @@ def test_float_slider(document, comm):
 
     slider = FloatSlider(start=0.1, end=0.5, value=0.4, name='Slider')
 
-    box = slider._get_root(document, comm=comm)
+    widget = slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, slider._widget_type)
     assert widget.title == 'Slider'
     assert widget.step == 0.1
@@ -111,11 +101,8 @@ def test_int_slider(document, comm):
 
     slider = IntSlider(start=0, end=3, value=1, name='Slider')
 
-    box = slider._get_root(document, comm=comm)
+    widget = slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, slider._widget_type)
     assert widget.title == 'Slider'
     assert widget.step == 1
@@ -135,11 +122,8 @@ def test_range_slider(document, comm):
 
     slider = RangeSlider(start=0., end=3, value=(0, 3), name='Slider')
 
-    box = slider._get_root(document, comm=comm)
+    widget = slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, slider._widget_type)
     assert widget.title == 'Slider'
     assert widget.step == 0.1
@@ -159,11 +143,8 @@ def test_literal_input(document, comm):
 
     literal = LiteralInput(value={}, type=dict, name='Literal')
 
-    box = literal._get_root(document, comm=comm)
+    widget = literal._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, literal._widget_type)
     assert widget.title == 'Literal'
     assert widget.value == '{}'
@@ -194,11 +175,8 @@ def test_datetime_input(document, comm):
                              end=datetime(2018, 1, 10),
                              name='Datetime')
 
-    box = dt_input._get_root(document, comm=comm)
+    widget = dt_input._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, dt_input._widget_type)
     assert widget.title == 'Datetime'
     assert widget.value == '2018-01-01 00:00:00'
@@ -227,11 +205,8 @@ def test_checkbox(document, comm):
 
     checkbox = Checkbox(value=True, name='Checkbox')
 
-    box = checkbox._get_root(document, comm=comm)
+    widget = checkbox._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, checkbox._widget_type)
     assert widget.labels == ['Checkbox']
     assert widget.active == [0]
@@ -253,11 +228,8 @@ def test_select(document, comm):
     opts = {'A': 'a', '1': 1}
     select = Select(options=opts, value=opts['1'], name='Select')
 
-    box = select._get_root(document, comm=comm)
+    widget = select._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
     assert widget.value == '1'
@@ -279,11 +251,8 @@ def test_select_mutables(document, comm):
     opts = OrderedDict([('A', [1,2,3]), ('B', [2,4,6]), ('C', dict(a=1,b=2))])
     select = Select(options=opts, value=opts['B'], name='Select')
 
-    box = select._get_root(document, comm=comm)
+    widget = select._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
     assert widget.value == 'B'
@@ -305,11 +274,8 @@ def test_multi_select(document, comm):
     select = MultiSelect(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                          value=[object, 1], name='Select')
 
-    box = select._get_root(document, comm=comm)
+    widget = select._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
     assert widget.value == ['C', '1']
@@ -331,11 +297,8 @@ def test_toggle_buttons(document, comm):
     select = ToggleButtons(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                            value=[1, object], name='ToggleButtons')
 
-    box = select._get_root(document, comm=comm)
+    widget = select._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, select._widget_type)
     assert widget.active == [1, 2]
     assert widget.labels == ['A', '1', 'C']
@@ -384,11 +347,8 @@ def test_toggle_group_check(document, comm):
                                value=[1, object], name='CheckButtonGroup',
                                widget_type=widget_type, behavior='check')
         
-        box = select._get_root(document, comm=comm)
+        widget = select._get_root(document, comm=comm)
     
-        assert isinstance(box, Column)
-    
-        widget = box.children[0]
         assert isinstance(widget, select._widget_type)
         assert widget.active == [1, 2]
         assert widget.labels == ['A', '1', 'C']
@@ -416,11 +376,8 @@ def test_toggle_group_radio(document, comm):
                                value=1, name='RadioButtonGroup',
                                widget_type=widget_type, behavior='radio')
         
-        box = select._get_root(document, comm=comm)
-    
-        assert isinstance(box, Column)
-    
-        widget = box.children[0]
+        widget = select._get_root(document, comm=comm)
+
         assert isinstance(widget, select._widget_type)
         assert widget.active == 1
         assert widget.labels == ['A', '1', 'C']
@@ -437,11 +394,8 @@ def test_radio_buttons(document, comm):
     select = RadioButtons(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                           value=[1, object], name='RadioButtons')
 
-    box = select._get_root(document, comm=comm)
+    widget = select._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, select._widget_type)
     assert widget.active == [1, 2]
     assert widget.labels == ['A', '1', 'C']
@@ -461,11 +415,8 @@ def test_radio_buttons(document, comm):
 def test_button(document, comm):
     button = Button(name='Button')
 
-    box = button._get_root(document, comm=comm)
+    widget = button._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, button._widget_type)
     assert widget.clicks == 0
     assert widget.label == 'Button'
@@ -478,11 +429,8 @@ def test_button(document, comm):
 def test_toggle(document, comm):
     toggle = Toggle(name='Toggle', active=True)
 
-    box = toggle._get_root(document, comm=comm)
+    widget = toggle._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, toggle._widget_type)
     assert widget.active == True
     assert widget.label == 'Toggle'
@@ -499,11 +447,8 @@ def test_date_picker(document, comm):
     date_picker = DatePicker(name='DatePicker', value=datetime(2018, 9, 2),
                              start=datetime(2018, 9, 1), end=datetime(2018, 9, 10))
 
-    box = date_picker._get_root(document, comm=comm)
+    widget = date_picker._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, date_picker._widget_type)
     assert widget.title == 'DatePicker'
     assert widget.value == datetime(2018, 9, 2)
@@ -523,11 +468,8 @@ def test_date_range_slider(document, comm):
                                   value=(datetime(2018, 9, 2), datetime(2018, 9, 4)),
                                   start=datetime(2018, 9, 1), end=datetime(2018, 9, 10))
 
-    box = date_slider._get_root(document, comm=comm)
+    widget = date_slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, date_slider._widget_type)
     assert widget.title == 'DateRangeSlider'
     assert widget.value == (datetime(2018, 9, 2), datetime(2018, 9, 4))
@@ -551,11 +493,8 @@ def test_discrete_slider(document, comm):
 
     box = discrete_slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-    subbox = box.children[0]
-
-    label = subbox.children[0]
-    widget = subbox.children[1]
+    label = box.children[0]
+    widget = box.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -583,10 +522,9 @@ def test_discrete_date_slider(document, comm):
     box = discrete_slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
-    subbox = box.children[0]
 
-    label = subbox.children[0]
-    widget = subbox.children[1]
+    label = box.children[0]
+    widget = box.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -613,11 +551,8 @@ def test_discrete_slider_options_dict(document, comm):
 
     box = discrete_slider._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-    subbox = box.children[0]
-
-    label = subbox.children[0]
-    widget = subbox.children[1]
+    label = box.children[0]
+    widget = box.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -680,11 +615,8 @@ def test_discrete_player(document, comm):
     discrete_player = DiscretePlayer(name='DiscretePlayer', value=1,
                                      options=[0.1, 1, 10, 100])
 
-    box = discrete_player._get_root(document, comm=comm)
+    widget = discrete_player._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, BkPlayer)
     assert widget.value == 1
     assert widget.start == 0
@@ -702,11 +634,8 @@ def test_discrete_player(document, comm):
 def test_file_input(document, comm):
     file_input = FileInput()
 
-    box = file_input._get_root(document, comm=comm)
+    widget = file_input._get_root(document, comm=comm)
 
-    assert isinstance(box, Column)
-
-    widget = box.children[0]
     assert isinstance(widget, BkFileInput)
 
     file_input._comm_change({'value': 'data:text/plain;base64,U29tZSB0ZXh0Cg=='})

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -20,7 +20,7 @@ def test_text_input(document, comm):
 
     text = TextInput(value='ABC', name='Text:')
 
-    box = text._get_model(document, comm=comm)
+    box = text._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -70,7 +70,7 @@ def test_static_text(document, comm):
 
     text = StaticText(value='ABC', name='Text:')
 
-    box = text._get_model(document, comm=comm)
+    box = text._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -87,7 +87,7 @@ def test_float_slider(document, comm):
 
     slider = FloatSlider(start=0.1, end=0.5, value=0.4, name='Slider')
 
-    box = slider._get_model(document, comm=comm)
+    box = slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -111,7 +111,7 @@ def test_int_slider(document, comm):
 
     slider = IntSlider(start=0, end=3, value=1, name='Slider')
 
-    box = slider._get_model(document, comm=comm)
+    box = slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -135,7 +135,7 @@ def test_range_slider(document, comm):
 
     slider = RangeSlider(start=0., end=3, value=(0, 3), name='Slider')
 
-    box = slider._get_model(document, comm=comm)
+    box = slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -159,7 +159,7 @@ def test_literal_input(document, comm):
 
     literal = LiteralInput(value={}, type=dict, name='Literal')
 
-    box = literal._get_model(document, comm=comm)
+    box = literal._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -194,7 +194,7 @@ def test_datetime_input(document, comm):
                              end=datetime(2018, 1, 10),
                              name='Datetime')
 
-    box = dt_input._get_model(document, comm=comm)
+    box = dt_input._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -227,7 +227,7 @@ def test_checkbox(document, comm):
 
     checkbox = Checkbox(value=True, name='Checkbox')
 
-    box = checkbox._get_model(document, comm=comm)
+    box = checkbox._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -253,7 +253,7 @@ def test_select(document, comm):
     opts = {'A': 'a', '1': 1}
     select = Select(options=opts, value=opts['1'], name='Select')
 
-    box = select._get_model(document, comm=comm)
+    box = select._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -279,7 +279,7 @@ def test_select_mutables(document, comm):
     opts = OrderedDict([('A', [1,2,3]), ('B', [2,4,6]), ('C', dict(a=1,b=2))])
     select = Select(options=opts, value=opts['B'], name='Select')
 
-    box = select._get_model(document, comm=comm)
+    box = select._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -305,7 +305,7 @@ def test_multi_select(document, comm):
     select = MultiSelect(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                          value=[object, 1], name='Select')
 
-    box = select._get_model(document, comm=comm)
+    box = select._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -331,7 +331,7 @@ def test_toggle_buttons(document, comm):
     select = ToggleButtons(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                            value=[1, object], name='ToggleButtons')
 
-    box = select._get_model(document, comm=comm)
+    box = select._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -384,7 +384,7 @@ def test_toggle_group_check(document, comm):
                                value=[1, object], name='CheckButtonGroup',
                                widget_type=widget_type, behavior='check')
         
-        box = select._get_model(document, comm=comm)
+        box = select._get_root(document, comm=comm)
     
         assert isinstance(box, Column)
     
@@ -416,7 +416,7 @@ def test_toggle_group_radio(document, comm):
                                value=1, name='RadioButtonGroup',
                                widget_type=widget_type, behavior='radio')
         
-        box = select._get_model(document, comm=comm)
+        box = select._get_root(document, comm=comm)
     
         assert isinstance(box, Column)
     
@@ -437,7 +437,7 @@ def test_radio_buttons(document, comm):
     select = RadioButtons(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                           value=[1, object], name='RadioButtons')
 
-    box = select._get_model(document, comm=comm)
+    box = select._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -461,7 +461,7 @@ def test_radio_buttons(document, comm):
 def test_button(document, comm):
     button = Button(name='Button')
 
-    box = button._get_model(document, comm=comm)
+    box = button._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -478,7 +478,7 @@ def test_button(document, comm):
 def test_toggle(document, comm):
     toggle = Toggle(name='Toggle', active=True)
 
-    box = toggle._get_model(document, comm=comm)
+    box = toggle._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -499,7 +499,7 @@ def test_date_picker(document, comm):
     date_picker = DatePicker(name='DatePicker', value=datetime(2018, 9, 2),
                              start=datetime(2018, 9, 1), end=datetime(2018, 9, 10))
 
-    box = date_picker._get_model(document, comm=comm)
+    box = date_picker._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -523,7 +523,7 @@ def test_date_range_slider(document, comm):
                                   value=(datetime(2018, 9, 2), datetime(2018, 9, 4)),
                                   start=datetime(2018, 9, 1), end=datetime(2018, 9, 10))
 
-    box = date_slider._get_model(document, comm=comm)
+    box = date_slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -549,12 +549,13 @@ def test_discrete_slider(document, comm):
     discrete_slider = DiscreteSlider(name='DiscreteSlider', value=1,
                                      options=[0.1, 1, 10, 100])
 
-    box = discrete_slider._get_model(document, comm=comm)
+    box = discrete_slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
+    subbox = box.children[0]
 
-    label = box.children[0]
-    widget = box.children[1]
+    label = subbox.children[0]
+    widget = subbox.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -579,12 +580,13 @@ def test_discrete_date_slider(document, comm):
     discrete_slider = DiscreteSlider(name='DiscreteSlider', value=dates['2016-01-02'],
                                      options=dates)
 
-    box = discrete_slider._get_model(document, comm=comm)
+    box = discrete_slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
+    subbox = box.children[0]
 
-    label = box.children[0]
-    widget = box.children[1]
+    label = subbox.children[0]
+    widget = subbox.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -609,12 +611,13 @@ def test_discrete_slider_options_dict(document, comm):
     discrete_slider = DiscreteSlider(name='DiscreteSlider', value=1,
                                      options=options)
 
-    box = discrete_slider._get_model(document, comm=comm)
+    box = discrete_slider._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
+    subbox = box.children[0]
 
-    label = box.children[0]
-    widget = box.children[1]
+    label = subbox.children[0]
+    widget = subbox.children[1]
     assert isinstance(label, BkDiv)
     assert isinstance(widget, BkSlider)
     assert widget.value == 1
@@ -677,7 +680,7 @@ def test_discrete_player(document, comm):
     discrete_player = DiscretePlayer(name='DiscretePlayer', value=1,
                                      options=[0.1, 1, 10, 100])
 
-    box = discrete_player._get_model(document, comm=comm)
+    box = discrete_player._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 
@@ -699,7 +702,7 @@ def test_discrete_player(document, comm):
 def test_file_input(document, comm):
     file_input = FileInput()
 
-    box = file_input._get_model(document, comm=comm)
+    box = file_input._get_root(document, comm=comm)
 
     assert isinstance(box, Column)
 

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -93,7 +93,7 @@ class Vega(PaneBase):
         if data:
             sources['data'] = ColumnDataSource(data=ds_as_cds(data))
 
-    def _get_model(self, doc, root, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         """
         Should return the Bokeh model to be rendered.
         """

--- a/panel/vega.py
+++ b/panel/vega.py
@@ -93,15 +93,14 @@ class Vega(PaneBase):
         if data:
             sources['data'] = ColumnDataSource(data=ds_as_cds(data))
 
-    def _get_model(self, doc, root, parent, comm=None):
-        """
-        Should return the Bokeh model to be rendered.
-        """
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         json = self._to_json(self.object)
         json['data'] = dict(json['data'])
         sources = {}
         self._get_sources(json, sources)
         model = VegaPlot(data=json, data_sources=sources)
+        if root is None:
+            root = model
         self._models[root.ref['id']] = model
         self._link_object(doc, root, parent, comm)
         return model

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -58,11 +58,10 @@ class Widget(Reactive):
             params['name'] = ''
         super(Widget, self).__init__(**params)
 
-    def _get_root(self, doc, comm=None):
-        return Column(self)._get_root(doc, comm)
-
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         model = self._widget_type(**self._process_param_change(self._init_properties()))
+        if root is None:
+            root = model
         # Link parameters and bokeh model
         params = list(self.param)
         values = dict(self.get_param_values())
@@ -637,8 +636,10 @@ class DiscreteSlider(Widget):
     def values(self):
         return list(self.options.values()) if isinstance(self.options, dict) else self.options
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         model = _BkColumn()
+        if root is None:
+            root = model
         msg = self._process_param_change(self._init_properties())
         div = _BkDiv(text=msg['text'])
         slider = _BkSlider(start=msg['start'], end=msg['end'], value=msg['value'],

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -25,7 +25,7 @@ from bokeh.models.widgets import (
     RadioButtonGroup as _BkRadioButtonGroup, RadioGroup as _BkRadioBoxGroup
 )
 
-from .layout import Column, Row, Spacer # noqa
+from .layout import Column, Row, VSpacer
 from .models.widgets import (
     Player as _BkPlayer, FileInput as _BkFileInput, Audio as _BkAudio)
 from .viewable import Reactive
@@ -885,18 +885,18 @@ class CrossSelector(MultiSelect):
 
         # Define search
         self._search = {
-            False: TextInput(placeholder='Filter available options'),
-            True: TextInput(placeholder='Filter selected options')
+            False: TextInput(placeholder='Filter available options', width=width),
+            True: TextInput(placeholder='Filter selected options', width=width)
         }
         self._search[False].param.watch(self._filter_options, 'value')
         self._search[True].param.watch(self._filter_options, 'value')
 
         # Define Layout
-        blacklist = Column(self._search[False], self._lists[False], width=width+10)
-        whitelist = Column(self._search[True], self._lists[True], width=width+10)
+        blacklist = Column(self._search[False], self._lists[False])
+        whitelist = Column(self._search[True], self._lists[True])
         buttons = Column(self._buttons[True], self._buttons[False], width=70)
 
-        self._layout = Row(blacklist, Column(Spacer(height=110), buttons), whitelist)
+        self._layout = Row(blacklist, Column(VSpacer(), buttons, VSpacer()), whitelist)
 
         self.param.watch(self._update_options, 'options')
         self.param.watch(self._update_value, 'value')
@@ -980,5 +980,5 @@ class CrossSelector(MultiSelect):
         self.value = [self.options[o] for o in self._lists[True].options if o != '']
         self._apply_filters()
 
-    def _get_model(self, doc, root, parent, comm=None):
+    def _get_model(self, doc, root=None, parent=None, comm=None):
         return self._layout._get_model(doc, root, parent, comm)

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -866,7 +866,7 @@ class CrossSelector(MultiSelect):
         unselected = [k for k in self.options if k not in selected]
 
         # Define whitelist and blacklist
-        width = int((self.width-100)/2)
+        width = int((self.width-50)/2)
         self._lists = {
             False: MultiSelect(options=unselected, size=self.size,
                                height=self.height-50, width=width),
@@ -894,7 +894,7 @@ class CrossSelector(MultiSelect):
         # Define Layout
         blacklist = Column(self._search[False], self._lists[False])
         whitelist = Column(self._search[True], self._lists[True])
-        buttons = Column(self._buttons[True], self._buttons[False], width=70)
+        buttons = Column(self._buttons[True], self._buttons[False], width=50)
 
         self._layout = Row(blacklist, Column(VSpacer(), buttons, VSpacer()), whitelist)
 

--- a/panel/widgets.py
+++ b/panel/widgets.py
@@ -59,28 +59,17 @@ class Widget(Reactive):
         super(Widget, self).__init__(**params)
 
     def _get_root(self, doc, comm=None):
-        root = _BkColumn()
-        model = self._get_model(doc, root, root, comm=comm)
-        root.children.append(model)
-        self._preprocess(root)
-        return root
+        return Column(self)._get_root(doc, comm)
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
-        root = parent if root is None else root
-        if root is None:
-            root = _BkColumn()
+    def _get_model(self, doc, root, parent, comm=None):
         model = self._widget_type(**self._process_param_change(self._init_properties()))
-
         # Link parameters and bokeh model
-        params = [p for p in self.param]
-        properties = list(self._process_param_change(dict(self.get_param_values())))
+        params = list(self.param)
+        values = dict(self.get_param_values())
+        properties = list(self._process_param_change(values))
         self._models[root.ref['id']] = model
         self._link_params(model, params, doc, root, comm)
         self._link_props(model, properties, doc, root, comm)
-        if parent is None:
-            root.children.append(model)
-            return root
-
         return model
 
 
@@ -648,10 +637,8 @@ class DiscreteSlider(Widget):
     def values(self):
         return list(self.options.values()) if isinstance(self.options, dict) else self.options
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         model = _BkColumn()
-        parent = parent or model
-        root = root or parent
         msg = self._process_param_change(self._init_properties())
         div = _BkDiv(text=msg['text'])
         slider = _BkSlider(start=msg['start'], end=msg['end'], value=msg['value'],
@@ -992,5 +979,5 @@ class CrossSelector(MultiSelect):
         self.value = [self.options[o] for o in self._lists[True].options if o != '']
         self._apply_filters()
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc, root, parent, comm=None):
         return self._layout._get_model(doc, root, parent, comm)


### PR DESCRIPTION
This PR tries to minimize the amount of nesting widgets and panes use, i.e. objects that can be updated inplace do not need to be nested inside a container. Only objects where the bokeh model is not well defined and therefore may need to be replaced entirely need to be nested. 

This makes testing simpler, makes the bokeh model structure match the panel structure more closely and makes things easier for bokeh's layouts.