### PR TITLE
Refactored server handling

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -1,12 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
-import sys
-
 import param as _param
-from bokeh.document import Document as _Document
-from pyviz_comms import (
-    CommManager as _CommManager, JupyterCommManager as _JupyterCommManager,
-    extension as _pyviz_extension)
 
 from . import layout # noqa
 from . import links # noqa
@@ -16,100 +10,10 @@ from . import pipeline # noqa
 from . import widgets # noqa
 
 from .interact import interact # noqa
+from .io import panel_extension as extension, state # noqa
 from .layout import Row, Column, Tabs, Spacer # noqa
 from .pane import panel, Pane # noqa
 from .param import Param # noqa
-from .util import load_notebook as _load_nb
-from .viewable import Viewable
-
 
 __version__ = str(_param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
-
-
-class state(_param.Parameterized):
-    """
-    Holds global state associated with running apps, allowing running
-    apps to indicate their state to a user.
-    """
-
-    curdoc = _param.ClassSelector(class_=_Document, doc="""
-        The bokeh Document for which a server event is currently being
-        processed.""")
-
-    _comm_manager = _CommManager
-
-    # An index of all currently active views
-    _views = {}
-
-    # An index of all curently active servers
-    _servers = {}
-
-
-class extension(_pyviz_extension):
-    """
-    Initializes the pyviz notebook extension to allow plotting with
-    bokeh and enable comms.
-    """
-
-    inline = _param.Boolean(default=True, doc="""
-        Whether to inline JS and CSS resources.
-        If disabled, resources are loaded from CDN if one is available.""")
-
-    _loaded = False
-
-    def __call__(self, *args, **params):
-        # Abort if IPython not found
-        try:
-            ip = params.pop('ip', None) or get_ipython() # noqa (get_ipython)
-        except:
-            return
-
-        p = _param.ParamOverrides(self, params)
-        if hasattr(ip, 'kernel') and not self._loaded:
-            # TODO: JLab extension and pyviz_comms should be changed
-            #       to allow multiple cleanup comms to be registered
-            _JupyterCommManager.get_client_comm(self._process_comm_msg,
-                                                "hv-extension-comm")
-        _load_nb(p.inline)
-        self._loaded = True
-
-        Viewable._comm_manager = _JupyterCommManager
-
-        if 'holoviews' in sys.modules:
-            import holoviews as hv
-            if hv.extension._loaded:
-                return
-            import holoviews.plotting.bokeh # noqa
-            if hasattr(hv.Store, 'set_current_backend'):
-                hv.Store.set_current_backend('bokeh')
-            else:
-                hv.Store.current_backend = 'bokeh'
-
-
-def _cleanup_panel(msg_id):
-    """
-    A cleanup action which is called when a plot is deleted in the notebook
-    """
-    if msg_id not in state._views:
-        return
-    viewable, model = state._views.pop(msg_id)
-    viewable._cleanup(model)
-
-
-def _cleanup_server(server_id):
-    """
-    A cleanup action which is called when a server is deleted in the notebook
-    """
-    if server_id not in state._servers:
-        return
-    server, viewable, docs = state._servers.pop(server_id)
-    server.stop()
-    for doc in docs:
-        for root in doc.roots:
-            if root.ref['id'] in viewable._models:
-                viewable._cleanup(root)
-
-extension.add_delete_action(_cleanup_panel)
-if hasattr(extension, 'add_server_delete_action'):
-    extension.add_server_delete_action(_cleanup_server)

--- a/panel/io.py
+++ b/panel/io.py
@@ -2,6 +2,7 @@
 The io module defines utilities for loading the notebook extension
 and holding global state.
 """
+from __future__ import absolute_import, division, unicode_literals
 
 import sys
 

--- a/panel/io.py
+++ b/panel/io.py
@@ -1,0 +1,104 @@
+"""
+The io module defines utilities for loading the notebook extension
+and holding global state.
+"""
+
+import sys
+
+import param
+
+from bokeh.document import Document
+from pyviz_comms import (
+    CommManager as _CommManager, JupyterCommManager as _JupyterCommManager,
+    extension as _pyviz_extension)
+
+from .util import load_notebook
+
+
+class state(param.Parameterized):
+    """
+    Holds global state associated with running apps, allowing running
+    apps to indicate their state to a user.
+    """
+
+    curdoc = param.ClassSelector(class_=Document, doc="""
+        The bokeh Document for which a server event is currently being
+        processed.""")
+
+    _comm_manager = _CommManager
+
+    # An index of all currently active views
+    _views = {}
+
+    # An index of all curently active servers
+    _servers = {}
+
+
+class panel_extension(_pyviz_extension):
+    """
+    Initializes the pyviz notebook extension to allow plotting with
+    bokeh and enable comms.
+    """
+
+    inline = param.Boolean(default=True, doc="""
+        Whether to inline JS and CSS resources.
+        If disabled, resources are loaded from CDN if one is available.""")
+
+    _loaded = False
+
+    def __call__(self, *args, **params):
+        # Abort if IPython not found
+        try:
+            ip = params.pop('ip', None) or get_ipython() # noqa (get_ipython)
+        except:
+            return
+
+        p = param.ParamOverrides(self, params)
+        if hasattr(ip, 'kernel') and not self._loaded:
+            # TODO: JLab extension and pyviz_comms should be changed
+            #       to allow multiple cleanup comms to be registered
+            _JupyterCommManager.get_client_comm(self._process_comm_msg,
+                                                "hv-extension-comm")
+        load_notebook(p.inline)
+        self._loaded = True
+
+        state._comm_manager = _JupyterCommManager
+
+        if 'holoviews' in sys.modules:
+            import holoviews as hv
+            if hv.extension._loaded:
+                return
+            import holoviews.plotting.bokeh # noqa
+            if hasattr(hv.Store, 'set_current_backend'):
+                hv.Store.set_current_backend('bokeh')
+            else:
+                hv.Store.current_backend = 'bokeh'
+
+
+def _cleanup_panel(msg_id):
+    """
+    A cleanup action which is called when a plot is deleted in the notebook
+    """
+    if msg_id not in state._views:
+        return
+    viewable, model = state._views.pop(msg_id)
+    viewable._cleanup(model)
+
+
+def _cleanup_server(server_id):
+    """
+    A cleanup action which is called when a server is deleted in the notebook
+    """
+    if server_id not in state._servers:
+        return
+    server, viewable, docs = state._servers.pop(server_id)
+    server.stop()
+    for doc in docs:
+        for root in doc.roots:
+            if root.ref['id'] in viewable._models:
+                viewable._cleanup(root)
+
+
+panel_extension.add_delete_action(_cleanup_panel)
+if hasattr(panel_extension, 'add_server_delete_action'):
+    panel_extension.add_server_delete_action(_cleanup_server)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -10,6 +10,7 @@ from bokeh.models import (Column as BkColumn, Row as BkRow,
                           Spacer as BkSpacer)
 from bokeh.models.widgets import Tabs as BkTabs, Panel as BkPanel
 
+from .io import state
 from .util import param_name, param_reprs, push
 from .viewable import Reactive, Viewable
 
@@ -36,7 +37,6 @@ class Panel(Reactive):
         super(Panel, self).__init__(objects=objects, **params)
 
     def _link_params(self, model, params, doc, root, comm=None):
-        from . import state
         def set_value(*events):
             msg = {event.name: event.new for event in events}
             events = {event.name: event for event in events}

--- a/panel/models/plots.py
+++ b/panel/models/plots.py
@@ -35,5 +35,5 @@ class VegaPlot(LayoutDOM):
     data_sources = Dict(String, Instance(ColumnDataSource))
 
 
-CUSTOM_MODELS['panel.plotly.PlotlyPlot'] = PlotlyPlot
-CUSTOM_MODELS['panel.vega.VegaPlot'] = VegaPlot
+CUSTOM_MODELS['panel.models.plots.PlotlyPlot'] = PlotlyPlot
+CUSTOM_MODELS['panel.models.plots.VegaPlot'] = VegaPlot

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import param
 
+from ..io import state
 from ..layout import Panel, Row
 from ..viewable import Viewable, Reactive, Layoutable
 from ..util import param_reprs, push
@@ -138,7 +139,6 @@ class PaneBase(Reactive):
         Links the object parameter to the rendered Bokeh model, triggering
         an update when the object changes.
         """
-        from .. import state
         ref = root.ref['id']
 
         def update_pane(change):

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -9,6 +9,7 @@ from collections import OrderedDict, defaultdict
 
 import param
 
+from ..io import state
 from ..layout import Panel, Column
 from ..viewable import Viewable
 from ..widgets import Player
@@ -118,8 +119,6 @@ class HoloViews(PaneBase):
         return model
 
     def _link_widgets(self, pane, root, comm):
-        from .. import state
-
         def update_plot(change):
             from holoviews.core.util import cross_index
             from holoviews.plotting.bokeh.plot import BokehPlot

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1,0 +1,52 @@
+import param
+
+from bokeh.client import pull_session
+from bokeh.models import Div
+from panel.io import state
+from panel.pane import HTML
+
+
+def test_get_server():
+    html = HTML('<h1>Title</h1>')
+
+    server = html.get_server(port=5006)
+    assert server.port == 5006
+
+    url = "http://localhost:" + str(server.port) + "/"
+    session = pull_session(session_id='Test', url=url, io_loop=server.io_loop)
+    root = session.document.roots[0]
+    assert isinstance(root, Div)
+    assert root.text == '<h1>Title</h1>'
+    server.stop()
+
+
+def test_server_update():
+    html = HTML('<h1>Title</h1>')
+
+    server = html.get_server(port=5006)
+    url = "http://localhost:" + str(server.port) + "/"
+    session = pull_session(session_id='Test', url=url, io_loop=server.io_loop)
+
+    html.object = '<h1>New Title</h1>'
+
+    session.pull()
+    root = session.document.roots[0]
+    assert isinstance(root, Div)
+    assert root.text == '<h1>New Title</h1>'
+    server.stop()
+
+
+def test_server_change_io_state():
+    html = HTML('<h1>Title</h1>')
+
+    server = html.get_server(port=5006)
+    url = "http://localhost:" + str(server.port) + "/"
+    session = pull_session(session_id='Test', url=url, io_loop=server.io_loop)
+
+    def handle_event(event):
+        assert state.curdoc is session.document
+
+    html.param.watch(handle_event, 'object')
+    html._server_change(session.document, 'text', '<h1>Title</h1>', '<h1>New Title</h1>')
+
+    server.stop()

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1,5 +1,3 @@
-import param
-
 from bokeh.client import pull_session
 from bokeh.models import Div
 from panel.io import state

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -21,6 +21,7 @@ from bokeh.models import CustomJS
 from bokeh.server.server import Server
 from pyviz_comms import JS_CALLBACK, JupyterCommManager
 
+from .io import state
 from .util import (render_mimebundle, add_to_doc, push, param_reprs,
                    _origin_url, show_server)
 
@@ -255,8 +256,6 @@ class Viewable(Layoutable):
             hook(self, root)
 
     def _repr_mimebundle_(self, include=None, exclude=None):
-        from . import state
-
         state._comm_manager = JupyterCommManager
         doc = _Document()
         comm = state._comm_manager.get_server_comm()
@@ -277,7 +276,6 @@ class Viewable(Layoutable):
         Callback to handle FunctionHandler document creation.
         """
         if server_id:
-            from . import state
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc)
 
@@ -365,7 +363,6 @@ class Viewable(Layoutable):
         server : bokeh.server.server.Server
            Bokeh Server instance running this panel
         """
-        from . import state
         from tornado.ioloop import IOLoop
         opts = dict(kwargs)
         if loop:
@@ -632,8 +629,6 @@ class Reactive(Viewable):
         return GenericLink(self, target, properties=links, code=code)
 
     def _cleanup(self, root=None, final=False):
-        from . import state
-
         super(Reactive, self)._cleanup(root, final)
         if final:
             watchers = self._callbacks.pop('instance', [])
@@ -704,7 +699,6 @@ class Reactive(Viewable):
         return properties
 
     def _link_params(self, model, params, doc, root, comm=None):
-        from . import state
         def param_change(*events):
             msgs = []
             for event in events:
@@ -751,8 +745,6 @@ class Reactive(Viewable):
         self._callbacks[ref].append(watcher)
 
     def _link_props(self, model, properties, doc, root, comm=None):
-        from . import state
-
         if comm is None:
             for p in properties:
                 model.on_change(p, partial(self._server_change, doc))
@@ -777,7 +769,6 @@ class Reactive(Viewable):
             doc.add_timeout_callback(partial(self._change_event, doc), self._debounce)
 
     def _change_event(self, doc=None):
-        from . import state
         try:
             state.curdoc = doc
             self.set_param(**self._process_property_change(self._events))

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -13,15 +13,13 @@ from collections import defaultdict
 
 import param
 
-from bokeh.application.handlers import FunctionHandler
-from bokeh.application import Application
 from bokeh.document.document import Document as _Document, _combine_document_events
 from bokeh.document.events import ModelChangedEvent
-from bokeh.io import curdoc as _curdoc, export_png as _export_png, show as _show, save as _save
+from bokeh.io import curdoc as _curdoc, export_png as _export_png, save as _save
 from bokeh.resources import CDN as _CDN
 from bokeh.models import CustomJS
 from bokeh.server.server import Server
-from pyviz_comms import JS_CALLBACK, CommManager, JupyterCommManager
+from pyviz_comms import JS_CALLBACK, JupyterCommManager
 
 from .util import (render_mimebundle, add_to_doc, push, param_reprs,
                    _origin_url, show_server)


### PR DESCRIPTION
This PR refactors the server handling such that all existing methods that start a bokeh server simply call the new ``Viewable.get_server`` method and then publish the server session in different ways. This also means that we now take full control over embedding servers inline in the notebook, which makes it possible to automatically clean up server sessions as cells are deleted or re-executed.

Depends on new versions of both the JLab extension and pyviz_comms: https://github.com/pyviz/pyviz_comms/pull/28