### PR TITLE
Adding some more list methods for layout and tests

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -12,7 +12,7 @@ from bokeh.models.widgets import Tabs as BkTabs, Panel as BkPanel
 
 from .io import state
 from .util import param_name, param_reprs, push
-from .viewable import Reactive, Viewable
+from .viewable import Reactive
 
 
 class Panel(Reactive):
@@ -326,7 +326,6 @@ class Tabs(Panel):
         return new_models
 
     def __setitem__(self, index, panes):
-        from .pane import panel
         new_objects = list(self)
         if not isinstance(index, slice):
             if index > len(self.objects):

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -276,7 +276,7 @@ class Tabs(Panel):
         if isinstance(item, tuple):
             name, item = item
         else:
-            name = getattr(item, 'name')
+            name = getattr(item, 'name', None)
         pane = panel(item, name=name)
         name = param_name(pane.name) if name is None else name
         return pane, name

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -196,6 +196,15 @@ class Panel(Reactive):
         new_objects.append(panel(pane))
         self.objects = new_objects
 
+    def clear(self):
+        self.objects = []
+
+    def extend(self, panes):
+        from .pane import panel
+        new_objects = list(self)
+        new_objects.extend(list(map(panel, panes)))
+        self.objects = new_objects
+
     def insert(self, index, pane):
         from .pane import panel
         new_objects = list(self)
@@ -214,6 +223,10 @@ class Panel(Reactive):
         new_objects.remove(pane)
         self.objects = new_objects
 
+    def reverse(self):
+        new_objects = list(self)
+        new_objects.reverse()
+        self.objects = new_objects
 
 
 class Row(Panel):

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -267,21 +267,27 @@ class Tabs(Panel):
     _linked_props = ['active']
 
     def __init__(self, *items, **params):
-        from .pane import panel
-        objects, names = [], []
-        for pane in items:
-            if isinstance(pane, tuple):
-                name, pane = pane
-            elif isinstance(pane, Viewable):
-                name = pane.name
-            else:
-                name = None
-            objects.append(panel(pane, name=name))
-            name = param_name(objects[-1].name) if name is None else name
-            names.append(name)
-        self._names = names
+        objects, self._names = self._to_objects_and_names(items)
         super(Tabs, self).__init__(*objects, **params)
         self.param.watch(self._update_names, 'objects')
+
+    def _to_object_and_name(self, item):
+        from .pane import panel
+        if isinstance(item, tuple):
+            name, item = item
+        else:
+            name = getattr(item, 'name')
+        pane = panel(item, name=name)
+        name = param_name(pane.name) if name is None else name
+        return pane, name
+
+    def _to_objects_and_names(self, items):
+        objects, names = [], []
+        for item in items:
+            pane, name = self._to_object_and_name(item)
+            objects.append(pane)
+            names.append(name)
+        return objects, names
 
     def _update_names(self, event):
         if len(event.new) == len(self._names):
@@ -309,13 +315,13 @@ class Tabs(Panel):
                              'directly. Found %d names, expected %d.' %
                              (len(self._names), len(self)))
         for i, (name, pane) in enumerate(zip(self._names, self)):
-            pane = panel(pane)
+            pane = panel(pane, name=name)
             self.objects[i] = pane
             if pane in old_objects:
                 child = pane._models[root.ref['id']]
             else:
                 child = pane._get_model(doc, root, model, comm)
-            child = BkPanel(title=name, child=child)
+            child = BkPanel(title=name, name=pane.name, child=child)
             new_models.append(child)
         return new_models
 
@@ -353,34 +359,32 @@ class Tabs(Panel):
                                  'on the %s to match the supplied slice.' %
                                  (expected, type(self).__name__))
         for i, pane in zip(range(start, end), panes):
-            name = None
-            if isinstance(pane, tuple):
-                name, pane = pane
-            new_objects[i] = panel(pane, name=name)
-            name = param_name(new_objects[i].name) if name is None else name
-            self._names[i] = name
+            new_objects[i], self._names[i] = self._to_object_and_name(pane)
         self.objects = new_objects
 
     def append(self, pane):
-        from .pane import panel
-        name = None
-        if isinstance(pane, tuple):
-            name, pane = pane
+        new_object, new_name = self._to_object_and_name(pane)
         new_objects = list(self)
-        new_objects.append(panel(pane, name=name))
-        name = param_name(new_objects[-1].name) if name is None else name
-        self._names.append(name)
+        new_objects.append(new_object)
+        self._names.append(new_name)
         self.objects = new_objects
 
+    def clear(self):
+        self._names = []
+        self.objects = []
+
+    def extend(self, panes):
+        new_objects, new_names = self._to_objects_and_names(panes)
+        objects = list(self)
+        objects.extend(new_objects)
+        self._names.extend(new_names)
+        self.objects = objects
+
     def insert(self, index, pane):
-        from .pane import panel
-        name = None
-        if isinstance(pane, tuple):
-            name, pane = pane
+        new_object, new_name = self._to_object_and_name(pane)
         new_objects = list(self.objects)
-        new_objects.insert(index, panel(pane))
-        name = param_name(new_objects[index].name) if name is None else name
-        self._names[index] = name
+        new_objects.insert(index, new_object)
+        self._names.insert(index, new_name)
         self.objects = new_objects
 
     def pop(self, index):
@@ -397,6 +401,12 @@ class Tabs(Panel):
             index = new_objects.index(pane)
         new_objects.remove(pane)
         self._names.pop(index)
+        self.objects = new_objects
+
+    def reverse(self):
+        new_objects = list(self)
+        new_objects.reverse()
+        self._names.reverse()
         self.objects = new_objects
 
 

--- a/panel/links.py
+++ b/panel/links.py
@@ -7,7 +7,8 @@ import param
 import weakref
 import sys
 
-from .layout import Viewable, Panel
+from .viewable import Viewable
+from .layout import Panel
 from .pane.holoviews import HoloViews, generate_panel_bokeh_map, is_bokeh_element_plot
 from .util import unicode_repr
 
@@ -90,7 +91,7 @@ class Link(param.Parameterized):
         links = self.registry.get(self.source)
         if self in links:
             links.pop(links.index(self))
-    
+
     @classmethod
     def _process_links(cls, root_view, root_model):
         if not isinstance(root_view, Panel) or not root_model:

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -311,6 +311,19 @@ def test_layout_clear(panel, document, comm):
     assert p1._models == p2._models == {}
 
 
+def test_tabs_basic_constructor(document, comm):
+    tabs = Tabs('plain', 'text')
+
+    model = tabs._get_root(document, comm=comm)
+
+    assert isinstance(model, BkTabs)
+    assert len(model.tabs) == 2
+    assert all(isinstance(c, BkPanel) for c in model.tabs)
+    tab1, tab2 = model.tabs
+
+    assert 'plain' in tab1.child.text
+    assert 'text' in tab2.child.text
+
 def test_tabs_constructor(document, comm):
     div1 = Div()
     div2 = Div()

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -18,8 +18,8 @@ def tabs(document, comm):
 def assert_tab_is_similar(tab1, tab2):
     """Helper function to check tab match"""
     assert tab1.child is tab2.child
-    assert tab1.name is tab2.name
-    assert tab1.title is tab2.title
+    assert tab1.name == tab2.name
+    assert tab1.title == tab2.title
 
 def get_div(box):
     # Temporary utilities to unpack widget boxes
@@ -477,7 +477,7 @@ def test_tabs_append_with_tuple_and_unnamed_contents(document, comm, tabs):
     assert_tab_is_similar(tab2_before, tab2)
 
     assert tab3.child is div3
-    assert tab3.title is 'Div3'
+    assert tab3.title == 'Div3'
 
 
 def test_tabs_append_with_tuple_and_named_contents(document, comm, tabs):
@@ -493,7 +493,7 @@ def test_tabs_append_with_tuple_and_named_contents(document, comm, tabs):
     assert_tab_is_similar(tab2_before, tab2)
 
     assert tab3.child is div3
-    assert tab3.title is 'Tab3'
+    assert tab3.title == 'Tab3'
     assert tab3.name == p3.name == 'Div3'
 
 
@@ -542,9 +542,9 @@ def test_tabs_extend_with_tuple_and_unnamed_contents(document, comm, tabs):
     assert_tab_is_similar(tab2_before, tab2)
 
     assert tab3.child is div4
-    assert tab3.title is 'Div4'
+    assert tab3.title == 'Div4'
     assert tab4.child is div3
-    assert tab4.title is 'Div3'
+    assert tab4.title == 'Div3'
 
 
 def test_tabs_extend_with_tuple_and_named_contents(document, comm, tabs):
@@ -560,10 +560,10 @@ def test_tabs_extend_with_tuple_and_named_contents(document, comm, tabs):
     assert_tab_is_similar(tab2_before, tab2)
 
     assert tab3.child is div4
-    assert tab3.title is 'Tab4'
+    assert tab3.title == 'Tab4'
     assert tab3.name == p4.name == 'Div4'
     assert tab4.child is div3
-    assert tab4.title is 'Tab3'
+    assert tab4.title == 'Tab3'
     assert tab4.name == p3.name == 'Div3'
 
 
@@ -607,7 +607,7 @@ def test_tabs_insert_with_tuple_and_unnamed_contents(document, comm, tabs):
 
     assert_tab_is_similar(tab1_before, tab1)
     assert tab2.child is div3
-    assert tab2.title is 'Div3'
+    assert tab2.title == 'Div3'
     assert_tab_is_similar(tab2_before, tab3)
 
 
@@ -622,7 +622,7 @@ def test_tabs_insert_with_tuple_and_named_contents(document, comm, tabs):
 
     assert_tab_is_similar(tab1_before, tab1)
     assert tab2.child is div3
-    assert tab2.title is 'Tab3'
+    assert tab2.title == 'Tab3'
     assert tab2.name  == p3.name == 'Div3'
     assert_tab_is_similar(tab2_before, tab3)
 

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -8,6 +8,18 @@ from panel.layout import Column, Row, Tabs, Spacer
 from panel.pane import Bokeh, Pane
 from panel.param import Param
 
+@pytest.fixture
+def tabs(document, comm):
+    """Set up a tabs instance"""
+    div1, div2 = Div(), Div()
+
+    return Tabs(('Tab1', div1), ('Tab2', div2))
+
+def assert_tab_is_similar(tab1, tab2):
+    """Helper function to check tab match"""
+    assert tab1.child is tab2.child
+    assert tab1.name is tab2.name
+    assert tab1.title is tab2.title
 
 def get_div(box):
     # Temporary utilities to unpack widget boxes
@@ -331,9 +343,30 @@ def test_tabs_implicit_constructor(document, comm):
     assert all(isinstance(c, BkPanel) for c in model.tabs)
     tab1, tab2 = model.tabs
 
-    assert tab1.title == 'Div1'
+    assert tab1.title == tab1.name == p1.name == 'Div1'
     assert tab1.child is div1
-    assert tab2.title == 'Div2'
+    assert tab2.title == tab2.name == p2.name == 'Div2'
+    assert tab2.child is div2
+
+
+def test_tabs_constructor_with_named_objects(document, comm):
+    div1, div2 = Div(), Div()
+    p1 = Pane(div1, name='Div1')
+    p2 = Pane(div2, name='Div2')
+    tabs = Tabs(('Tab1', p1), ('Tab2', p2))
+
+    model = tabs._get_root(document, comm=comm)
+
+    assert isinstance(model, BkTabs)
+    assert len(model.tabs) == 2
+    assert all(isinstance(c, BkPanel) for c in model.tabs)
+    tab1, tab2 = model.tabs
+
+    assert tab1.title == 'Tab1'
+    assert tab1.name == p1.name == 'Div1'
+    assert tab1.child is div1
+    assert tab2.title == 'Tab2'
+    assert tab2.name == p2.name =='Div2'
     assert tab2.child is div2
 
 
@@ -354,11 +387,11 @@ def test_tabs_set_panes(document, comm):
     assert all(isinstance(c, BkPanel) for c in model.tabs)
     tab1, tab2, tab3 = model.tabs
 
-    assert tab1.title == 'Div1'
+    assert tab1.title == tab1.name == p1.name =='Div1'
     assert tab1.child is div1
-    assert tab2.title == 'Div2'
+    assert tab2.title == tab2.name == p2.name =='Div2'
     assert tab2.child is div2
-    assert tab3.title == 'Div3'
+    assert tab3.title == tab3.name == p3.name =='Div3'
     assert tab3.child is div3
 
 
@@ -373,41 +406,23 @@ def test_tabs_reverse(document, comm):
     tabs.reverse()
     tab1, tab2 = model.tabs
     assert tab1.child is div2
+    assert tab1.title == tab1.name == p2.name == 'Div2'
     assert tab2.child is div1
+    assert tab2.title == tab2.name == p1.name == 'Div1'
 
 
-def test_tabs_append(document, comm):
-    div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
-    tabs = Tabs(p1, p2)
-
+def test_tabs_append(document, comm, tabs):
     model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
 
     div3 = Div()
     tabs.append(div3)
+
     tab1, tab2, tab3 = model.tabs
-    assert tab1.child is div1
-    assert tab2.child is div2
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
     assert tab3.child is div3
-
-
-def test_tabs_extend(document, comm):
-    div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
-    tabs = Tabs(p1, p2)
-
-    model = tabs._get_root(document, comm=comm)
-
-    div3 = Div()
-    div4 = Div()
-    tabs.extend([div4, div3])
-    tab1, tab2, tab3, tab4 = model.tabs
-    assert tab1.child is div1
-    assert tab2.child is div2
-    assert tab3.child is div4
-    assert tab4.child is div3
 
 
 def test_empty_tabs_append(document, comm):
@@ -421,19 +436,182 @@ def test_empty_tabs_append(document, comm):
     assert model.tabs[0].title == 'test title'
 
 
-def test_tabs_insert(document, comm):
-    div1 = Div()
-    div2 = Div()
-    tabs = Tabs(div1, div2)
-
+def test_tabs_append_uses_object_name(document, comm, tabs):
     model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    p3 = Pane(div3, name='Div3')
+    tabs.append(p3)
+
+    tab1, tab2, tab3 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div3
+    assert tab3.title == tab3.name == p3.name == 'Div3'
+
+
+def test_tabs_append_with_tuple_and_unnamed_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    tabs.append(('Div3', div3))
+
+    tab1, tab2, tab3 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div3
+    assert tab3.title is 'Div3'
+
+
+def test_tabs_append_with_tuple_and_named_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    p3 = Pane(div3, name='Div3')
+    tabs.append(('Tab3', p3))
+
+    tab1, tab2, tab3 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div3
+    assert tab3.title is 'Tab3'
+    assert tab3.name == p3.name == 'Div3'
+
+
+def test_tabs_extend(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3, div4 = Div(), Div()
+    tabs.extend([div4, div3])
+
+    tab1, tab2, tab3, tab4 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div4
+    assert tab4.child is div3
+
+
+def test_tabs_extend_uses_object_name(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3, div4 = Div(), Div()
+    p3, p4 = Pane(div3, name='Div3'), Pane(div4, name='Div4')
+    tabs.extend([p4, p3])
+
+    tab1, tab2, tab3, tab4 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div4
+    assert tab3.title == p4.name == 'Div4'
+    assert tab4.child is div3
+    assert tab4.title  == p3.name == 'Div3'
+
+
+def test_tabs_extend_with_tuple_and_unnamed_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3, div4 = Div(), Div()
+    tabs.extend([('Div4', div4), ('Div3', div3)])
+
+    tab1, tab2, tab3, tab4 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div4
+    assert tab3.title is 'Div4'
+    assert tab4.child is div3
+    assert tab4.title is 'Div3'
+
+
+def test_tabs_extend_with_tuple_and_named_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3, div4 = Div(), Div()
+    p3, p4 = Pane(div3, name='Div3'), Pane(div4, name='Div4')
+    tabs.extend([('Tab4', p4), ('Tab3', p3)])
+
+    tab1, tab2, tab3, tab4 = model.tabs
+    assert_tab_is_similar(tab1_before, tab1)
+    assert_tab_is_similar(tab2_before, tab2)
+
+    assert tab3.child is div4
+    assert tab3.title is 'Tab4'
+    assert tab3.name == p4.name == 'Div4'
+    assert tab4.child is div3
+    assert tab4.title is 'Tab3'
+    assert tab4.name == p3.name == 'Div3'
+
+
+def test_tabs_insert(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
 
     div3 = Div()
     tabs.insert(1, div3)
+
     tab1, tab2, tab3 = model.tabs
-    assert tab1.child is div1
+
+    assert_tab_is_similar(tab1_before, tab1)
     assert tab2.child is div3
-    assert tab3.child is div2
+    assert_tab_is_similar(tab2_before, tab3)
+
+
+def test_tabs_insert_uses_object_name(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    p3 = Pane(div3, name='Div3')
+    tabs.insert(1, p3)
+
+    tab1, tab2, tab3 = model.tabs
+
+    assert_tab_is_similar(tab1_before, tab1)
+    assert tab2.child is div3
+    assert tab2.title == tab2.name == p3.name == 'Div3'
+    assert_tab_is_similar(tab2_before, tab3)
+
+
+def test_tabs_insert_with_tuple_and_unnamed_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    tabs.insert(1, ('Div3', div3))
+    tab1, tab2, tab3 = model.tabs
+
+    assert_tab_is_similar(tab1_before, tab1)
+    assert tab2.child is div3
+    assert tab2.title is 'Div3'
+    assert_tab_is_similar(tab2_before, tab3)
+
+
+def test_tabs_insert_with_tuple_and_named_contents(document, comm, tabs):
+    model = tabs._get_root(document, comm=comm)
+    tab1_before, tab2_before = model.tabs
+
+    div3 = Div()
+    p3 = Pane(div3, name='Div3')
+    tabs.insert(1, ('Tab3', p3))
+    tab1, tab2, tab3 = model.tabs
+
+    assert_tab_is_similar(tab1_before, tab1)
+    assert tab2.child is div3
+    assert tab2.title is 'Tab3'
+    assert tab2.name  == p3.name == 'Div3'
+    assert_tab_is_similar(tab2_before, tab3)
 
 
 def test_tabs_setitem(document, comm):
@@ -601,6 +779,7 @@ def test_tabs_clear(document, comm):
     model = tabs._get_root(document, comm=comm)
 
     tabs.clear()
+    assert tabs._names == []
     assert len(model.tabs) == 0
     assert p1._callbacks == p2._callbacks == {}
     assert p1._models == p2._models == {}


### PR DESCRIPTION
Closes #278  (adding `extend`) and adds `clear` and `reverse` as well. I think the only other missing list methods are copy, count, index, and sort of which only sort affects the list in-place. Sort doesn't work on most panel objects and probably doesn't make much sense (might later if we wanted to compare names or something).