### PR TITLE
Improved logic to avoid events boomeranging

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -304,14 +304,12 @@ class Param(PaneBase):
         else:
             def link_widget(change):
                 if self._updating:
-                    self._updating = False
                     return
-                self._updating = True
                 try:
+                    self._updating = True
                     self.object.set_param(**{p_name: change.new})
-                except:
+                finally:
                     self._updating = False
-                    raise
 
             widget.param.watch(link_widget, 'value')
             def link(change):
@@ -328,6 +326,7 @@ class Param(PaneBase):
                             if precedence(k) is None or precedence(k) >= self.display_threshold:
                                 widgets += ws
                         self._widget_box.objects = widgets
+                    return
                 elif change.what == 'objects':
                     updates['options'] = p_obj.get_range()
                 elif change.what == 'bounds':
@@ -335,17 +334,15 @@ class Param(PaneBase):
                     updates['start'] = start
                     updates['end'] = end
                 elif self._updating:
-                    self._updating = False
                     return
                 else:
-                    self._updating = True
                     updates['value'] = change.new
 
                 try:
+                    self._updating = True
                     widget.set_param(**updates)
-                except:
+                finally:
                     self._updating = False
-                    raise
 
             # Set up links to parameterized object
             watchers.append(self.object.param.watch(link, p_name, 'constant'))

--- a/panel/param.py
+++ b/panel/param.py
@@ -345,6 +345,7 @@ class Param(PaneBase):
                     widget.set_param(**updates)
                 except:
                     self._updating = False
+                    raise
 
             # Set up links to parameterized object
             watchers.append(self.object.param.watch(link, p_name, 'constant'))

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -538,7 +538,6 @@ class Reactive(Viewable):
         super(Reactive, self).__init__(**params)
         self._active = []
         self._events = {}
-        self._expecting = []
         self._callbacks = defaultdict(list)
 
     def link(self, target, callbacks=None, **links):
@@ -727,14 +726,8 @@ class Reactive(Viewable):
                     model.update(**update)
 
             if comm:
-                self._expecting += [m for _msg in msgs for m in _msg]
-                try:
-                    update_model()
-                    push(doc, comm)
-                except:
-                    raise
-                else:
-                    self._expecting = self._expecting[:-len(msg)]
+                update_model()
+                push(doc, comm)
             elif state.curdoc:
                 update_model()
             else:
@@ -755,11 +748,9 @@ class Reactive(Viewable):
                 model.js_on_change(p, customjs)
 
     def _comm_change(self, msg):
-        filtered = {k: v for k, v in msg.items() if k not in self._expecting}
-        self._expecting = [m for m in self._expecting if m not in msg]
-        if not filtered:
+        if not msg:
             return
-        self._events.update(filtered)
+        self._events.update(msg)
         self._active = list(self._events)
         self._change_event()
 


### PR DESCRIPTION
The ``_expecting`` flag which was an attempt to ensure that events don't bounce around was not actually doing anything. Additionally the bi-directional link between a Parameterized and a widget was also not handled correctly and is now replaced by a ``_updating`` flag on the ``Param`` pane.