### PR TITLE
Param formatting via the new label property

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -266,8 +266,7 @@ class Param(PaneBase):
             widget_class = self.widgets[p_name]
         value = getattr(self.object, p_name)
 
-        kw = dict(value=value, disabled=p_obj.constant)
-        kw['name'] = p_obj.label
+        kw = dict(value=value, disabled=p_obj.constant, name=p_obj.label)
 
         if hasattr(p_obj, 'get_range'):
             options = p_obj.get_range()

--- a/panel/param.py
+++ b/panel/param.py
@@ -213,7 +213,7 @@ class Param(PaneBase):
                     pane = Param(parameterized, name=parameterized.name,
                                  _temporary=True, **kwargs)
                     if isinstance(self._expand_layout, Tabs):
-                        title = self.params(pname).label
+                        title = self.object.param[pname].label
                         pane = (title, pane)
                     self._expand_layout.append(pane)
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -22,7 +22,7 @@ from .layout import Row, Panel, Tabs, Column
 from .links import Link
 from .pane.base import Pane, PaneBase
 from .util import (
-    abbreviated_repr, default_label_formatter, full_groupby,
+    abbreviated_repr, full_groupby,
     get_method_owner, is_parameterized, param_name)
 from .viewable import Layoutable, Reactive
 from .widgets import (
@@ -90,9 +90,6 @@ class Param(PaneBase):
         User-supplied function that will be called on initialization,
         usually to update the default Parameter values of the
         underlying parameterized object.""")
-
-    label_formatter = param.Callable(default=default_label_formatter, allow_None=True,
-        doc="Callable used to format the parameter names into widget labels.")
 
     parameters = param.List(default=None, doc="""
         If set this serves as a whitelist of parameters to display on the supplied
@@ -216,7 +213,7 @@ class Param(PaneBase):
                     pane = Param(parameterized, name=parameterized.name,
                                  _temporary=True, **kwargs)
                     if isinstance(self._expand_layout, Tabs):
-                        title = pname if self.label_formatter is None else self.label_formatter(pname)
+                        title = self.params(pname).label
                         pane = (title, pane)
                     self._expand_layout.append(pane)
 
@@ -270,11 +267,7 @@ class Param(PaneBase):
         value = getattr(self.object, p_name)
 
         kw = dict(value=value, disabled=p_obj.constant)
-
-        if self.label_formatter is not None:
-            kw['name'] = self.label_formatter(p_name)
-        else:
-            kw['name'] = p_name
+        kw['name'] = p_obj.label
 
         if hasattr(p_obj, 'get_range'):
             options = p_obj.get_range()

--- a/panel/tests/test_util.py
+++ b/panel/tests/test_util.py
@@ -4,8 +4,7 @@ from bokeh.models import Div
 
 from panel.pane import PaneBase
 from panel.util import (
-    render_mimebundle, default_label_formatter, get_method_owner,
-    abbreviated_repr
+    render_mimebundle, get_method_owner,abbreviated_repr
 )
 
 
@@ -27,22 +26,6 @@ def test_render_mimebundle(document, comm):
     assert 'application/vnd.holoviews_exec.v0+json' in data
     assert 'text/html' in data
     assert data['application/vnd.holoviews_exec.v0+json'] == ''
-
-
-def test_default_label_formatter():
-    assert default_label_formatter('a_b_C') == 'A b C'
-
-
-def test_default_label_formatter_not_capitalized():
-    assert default_label_formatter.instance(capitalize=False)('a_b_C') == 'a b C'
-
-
-def test_default_label_formatter_not_replace_underscores():
-    assert default_label_formatter.instance(replace_underscores=False)('a_b_C') == 'A_b_C'
-
-
-def test_default_label_formatter_overrides():
-    assert default_label_formatter.instance(overrides={'a': 'b'})('a') == 'b'
 
 
 def test_abbreviated_repr_dict():

--- a/panel/util.py
+++ b/panel/util.py
@@ -191,28 +191,6 @@ def value_as_datetime(value):
     return value
 
 
-class default_label_formatter(param.ParameterizedFunction):
-    "Default formatter to turn parameter names into appropriate widget labels."
-
-    capitalize = param.Boolean(default=True, doc="""
-        Whether or not the label should be capitalized.""")
-
-    replace_underscores = param.Boolean(default=True, doc="""
-        Whether or not underscores should be replaced with spaces.""")
-
-    overrides = param.Dict(default={}, doc="""
-        Allows custom labels to be specified for specific parameter
-        names using a dictionary where key is the parameter name and the
-        value is the desired label.""")
-
-    def __call__(self, pname):
-        if pname in self.overrides:
-            return self.overrides[pname]
-        if self.replace_underscores:
-            pname = pname.replace('_',' ')
-        if self.capitalize:
-            pname = pname[:1].upper() + pname[1:]
-        return pname
 
 
 class StoppableThread(threading.Thread):

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ class CustomEggInfoCommand(egg_info):
 
 install_requires = [
     'bokeh >=1.1.0dev8',
-    'param >=1.9.0a1',
+    'param >=1.9.0a3',
     'pyviz_comms >=0.7.0',
     'markdown',
     'pyct >=0.4.4',


### PR DESCRIPTION
Now that https://github.com/pyviz/param/pull/319 is merged, there is no need for the label formatter in panel to format parameter names. Merging this PR will bump the param version requirements so I will update the pinning too.