### PR TITLE
 Fixed issue setting (Multi)Select value when options changed

### DIFF
--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -269,6 +269,22 @@ def test_select_mutables(document, comm):
     assert widget.value == 'A'
 
 
+def test_select_change_options(document, comm):
+    select = Select(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
+                         value='A', name='Select')
+
+    def set_options(event):
+        if event.new == 1:
+            select.options = OrderedDict([('D', 2), ('E', 'a')])
+    select.param.watch(set_options, 'value')
+
+    model = select._get_root(document, comm=comm)
+
+    select.value = 1
+    assert model.value == 'D'
+    assert model.options == ['D', 'E']
+
+
 def test_multi_select(document, comm):
     select = MultiSelect(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                          value=[object, 1], name='Select')
@@ -290,6 +306,22 @@ def test_multi_select(document, comm):
 
     select.value = [object, 'A']
     assert widget.value == ['C', 'A']
+
+
+def test_multi_select_change_options(document, comm):
+    select = MultiSelect(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
+                         value=[object, 1], name='Select')
+
+    def set_options(event):
+        if event.new == [1]:
+            select.options = OrderedDict([('D', 2), ('E', 'a')])
+    select.param.watch(set_options, 'value')
+
+    model = select._get_root(document, comm=comm)
+
+    select.value = [1]
+    assert model.value == []
+    assert model.options == ['D', 'E']
 
 
 def test_toggle_group_error_init(document, comm):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -44,8 +44,12 @@ class Select(Widget):
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
         mapping = {hashable(v): k for k, v in self.options.items()}
-        if msg.get('value') is not None and hashable(msg['value']) in mapping:
-            msg['value'] = mapping[hashable(msg['value'])]
+        if msg.get('value') is not None:
+            hash_val = hashable(msg['value'])
+            if hash_val in mapping:
+                msg['value'] = mapping[hash_val]
+            else:
+                msg['value'] = list(self.options)[0]
         if 'options' in msg:
             msg['options'] = list(msg['options'])
         return msg
@@ -53,7 +57,10 @@ class Select(Widget):
     def _process_property_change(self, msg):
         msg = super(Select, self)._process_property_change(msg)
         if 'value' in msg:
-            msg['value'] = self.options[msg['value']]
+            if msg['value'] is None:
+                msg['value'] = None
+            else:
+                msg['value'] = self.options[msg['value']]
         msg.pop('options', None)
         return msg
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -44,7 +44,7 @@ class Select(Widget):
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
         mapping = {hashable(v): k for k, v in self.options.items()}
-        if msg.get('value') is not None:
+        if msg.get('value') is not None and hashable(msg['value']) in mapping:
             msg['value'] = mapping[hashable(msg['value'])]
         if 'options' in msg:
             msg['options'] = list(msg['options'])
@@ -72,7 +72,8 @@ class MultiSelect(Select):
         msg = super(Select, self)._process_param_change(msg)
         mapping = {hashable(v): k for k, v in self.options.items()}
         if 'value' in msg:
-            msg['value'] = [hashable(mapping[v]) for v in msg['value']]
+            msg['value'] = [hashable(mapping[v]) for v in msg['value']
+                            if v in mapping]
         if 'options' in msg:
             msg['options'] = list(msg['options'])
         return msg


### PR DESCRIPTION
This fixes callbacks set on a MultiSelect widget which change the values. Due to the ordering of the watchers it can happen that the options change before the value change event has been propagated to the underlying bokeh model. Ideally we would have a way to elevate the precedence of watch calls which would allow us to order the watchers appropriately.

This PR simply addresses the symptom by skipping values that aren't found.