### PR TITLE
Refactor callbacks to be initialized on instantiation

### DIFF
--- a/panel/interact.py
+++ b/panel/interact.py
@@ -182,6 +182,9 @@ class interactive(PaneBase):
                 new_kwargs.append((name, value, default))
         return new_kwargs
 
+    def _synced_params(self):
+        return []
+
     def _get_model(self, doc, root=None, parent=None, comm=None):
         return self._inner_layout._get_model(doc, root, parent, comm)
 

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -214,7 +214,7 @@ class interactive(PaneBase):
 
             pname = 'clicks' if name == 'manual' else 'value'
             watcher = widget.param.watch(update_pane, pname)
-            self._callbacks['instance'].append(watcher)
+            self._callbacks.append(watcher)
 
     def _cleanup(self, root):
         self._inner_layout._cleanup(root)

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -203,12 +203,7 @@ class interactive(PaneBase):
                     if isinstance(new_object, (PaneBase, Panel)):
                         new_params = {k: v for k, v in new_object.get_param_values()
                                       if k != 'name'}
-                        try:
-                            self._pane.set_param(**new_params)
-                        except:
-                            raise
-                        finally:
-                            new_object._cleanup(final=new_object._temporary)
+                        self._pane.set_param(**new_params)
                     else:
                         self._pane.object = new_object
                     return
@@ -221,9 +216,9 @@ class interactive(PaneBase):
             watcher = widget.param.watch(update_pane, pname)
             self._callbacks['instance'].append(watcher)
 
-    def _cleanup(self, root=None, final=False):
-        self._inner_layout._cleanup(root, final)
-        super(interactive, self)._cleanup(root, final)
+    def _cleanup(self, root):
+        self._inner_layout._cleanup(root)
+        super(interactive, self)._cleanup(root)
 
     def widgets_from_abbreviations(self, seq):
         """Given a sequence of (name, abbrev, default) tuples, return a sequence of Widgets."""

--- a/panel/io.py
+++ b/panel/io.py
@@ -82,7 +82,7 @@ def _cleanup_panel(msg_id):
     """
     if msg_id not in state._views:
         return
-    viewable, model = state._views.pop(msg_id)
+    viewable, model, _, _ = state._views.pop(msg_id)
     viewable._cleanup(model)
 
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -65,6 +65,9 @@ class Panel(Reactive):
             else:
                 child = pane._get_model(doc, root, model, comm)
             new_models.append(child)
+        for obj in old_objects:
+            if obj not in self.objects:
+                obj._cleanup(root)
         return new_models
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
@@ -307,6 +310,9 @@ class Tabs(Panel):
                 child = pane._get_model(doc, root, model, comm)
             child = BkPanel(title=name, name=pane.name, child=child)
             new_models.append(child)
+        for obj in old_objects:
+            if obj not in self.objects:
+                obj._cleanup(root)
         return new_models
 
     def __setitem__(self, index, panes):

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -36,7 +36,6 @@ class Panel(Reactive):
         super(Panel, self).__init__(objects=objects, **params)
 
     def _update_model(self, events, msg, root, model, doc, comm=None):
-        print("MODEL", events)
         if self._rename['objects'] in msg:
             old = events['objects'].old
             msg[self._rename['objects']] = self._get_objects(model, old, doc, root, comm)
@@ -46,11 +45,10 @@ class Panel(Reactive):
         model.update(**msg)
         self._preprocess(root) #preprocess links between new elements
 
-    def _cleanup(self, root=None, final=False):
-        super(Panel, self)._cleanup(root, final)
-        if root is not None:
-            for p in self.objects:
-                p._cleanup(root, final)
+    def _cleanup(self, root):
+        super(Panel, self)._cleanup(root)
+        for p in self.objects:
+            p._cleanup(root)
 
     def _get_objects(self, model, old_objects, doc, root, comm=None):
         """

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -35,7 +35,7 @@ class Panel(Reactive):
         objects = [panel(pane) for pane in objects]
         super(Panel, self).__init__(objects=objects, **params)
 
-    def _update_model(self, events, msg, root, model, doc, comm):
+    def _update_model(self, events, msg, root, model, doc, comm=None):
         if self._rename['objects'] in msg:
             old = events['objects'].old
             msg[self._rename['objects']] = self._get_objects(model, old, doc, root, comm)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -36,6 +36,7 @@ class Panel(Reactive):
         super(Panel, self).__init__(objects=objects, **params)
 
     def _update_model(self, events, msg, root, model, doc, comm=None):
+        print("MODEL", events)
         if self._rename['objects'] in msg:
             old = events['objects'].old
             msg[self._rename['objects']] = self._get_objects(model, old, doc, root, comm)
@@ -252,6 +253,9 @@ class Tabs(Panel):
         objects, self._names = self._to_objects_and_names(items)
         super(Tabs, self).__init__(*objects, **params)
         self.param.watch(self._update_names, 'objects')
+        # ALERT: Ensure that name update happens first, should be
+        #        replaced by watch precedence support in param
+        self._param_watchers['objects']['value'].reverse()
 
     def _to_object_and_name(self, item):
         from .pane import panel

--- a/panel/links.py
+++ b/panel/links.py
@@ -180,7 +180,7 @@ class LinkCallback(param.Parameterized):
                     model_spec = None
                 model = obj.handles[handle_spec]
         elif isinstance(obj, Viewable):
-            model = obj._models[root_model.ref['id']]
+            model, _ = obj._models[root_model.ref['id']]
         elif isinstance(obj, BkModel):
             model = obj
         if model_spec is not None:

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -44,6 +44,8 @@ export class PlotlyPlotView extends HTMLBoxView {
   }
 
   _plot(): void {
+    if (this.model.data == null)
+      return
     for (let i = 0; i < this.model.data.data.length; i++) {
       const trace = this.model.data.data[i]
       const cds = this.model.data_sources[i]

--- a/panel/models/vega.ts
+++ b/panel/models/vega.ts
@@ -76,6 +76,8 @@ export class VegaPlotView extends HTMLBoxView {
   }
 
   _plot(): void {
+    if (this.model.data == null)
+      return
     if (!('datasets' in this.model.data)) {
       const datasets = this._fetch_datasets()
       if ('data' in datasets) {

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -62,9 +62,9 @@ class PaneBase(Reactive):
 
     __abstract = True
 
-    def __init__(self, object, **params):
+    def __init__(self, object=None, **params):
         applies = self.applies(object)
-        if isinstance(applies, bool) and not applies:
+        if (isinstance(applies, bool) and not applies) and object is not None :
             raise ValueError("%s pane does not support objects of type '%s'" %
                              (type(self).__name__, type(object).__name__))
 
@@ -76,7 +76,7 @@ class PaneBase(Reactive):
     def __repr__(self, depth=0):
         cls = type(self).__name__
         params = param_reprs(self, ['object'])
-        obj = type(self.object).__name__
+        obj = 'Empty' if self.object is None else type(self.object).__name__ 
         template = '{cls}({obj}, {params})' if params else '{cls}({obj})'
         return template.format(cls=cls, params=', '.join(params), obj=obj)
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -57,6 +57,9 @@ class PaneBase(Reactive):
     # Whether the Pane layout can be safely unpacked
     _unpack = True
 
+    # Object rerender properties
+    _rerender_params = ['object']
+
     __abstract = True
 
     def __init__(self, object, **params):
@@ -102,7 +105,8 @@ class PaneBase(Reactive):
         raise NotImplementedError
 
     def _synced_params(self):
-        return [p for p in self.param if p not in ['object', 'name']]
+        ignored_params = ['name', 'default_layout']+self._rerender_params
+        return [p for p in self.param if p not in ignored_params]
 
     def _update_object(self, old_model, doc, root, parent, comm):
         if self._updates:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -128,7 +128,7 @@ class PaneBase(Reactive):
                 if comm:
                     push(doc, comm)
             else:
-                cb = partial(self._update_model, model, doc, root, parent, comm)
+                cb = partial(self._update_object, model, doc, root, parent, comm)
                 doc.add_next_tick_callback(cb)
 
     #----------------------------------------------------------------

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -80,6 +80,8 @@ class LaTeX(PNG):
     dpi = param.Number(default=72, bounds=(1, 1900), doc="""
         Resolution per inch for the rendered equation.""")
 
+    _rerender_params = ['object', 'size', 'dpi']
+
     @classmethod
     def applies(cls, obj):
         if is_sympy_expr(obj) or hasattr(obj, '_repr_latex_'):

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -102,7 +102,7 @@ class LaTeX(PNG):
         return int(w*72), int(h*72)
 
     def _img(self):
-        obj=self.object # Default: LaTeX string
+        obj = self.object # Default: LaTeX string
 
         if hasattr(obj, '_repr_latex_'):
             obj = obj._repr_latex_()

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -248,7 +248,7 @@ def find_links(root_view, root_model):
         return
 
     hv_views = root_view.select(HoloViews)
-    root_plots = [plot for view in hv_views for plot in view._plots.values()
+    root_plots = [plot for view in hv_views for plot, _ in view._plots.values()
                   if getattr(plot, 'root', None) is root_model]
 
     if not root_plots:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -168,14 +168,16 @@ class HoloViews(PaneBase):
         from holoviews.core import Dimension
         from holoviews.core.util import isnumeric, unicode, datetime_types
         from holoviews.core.traversal import unique_dimkeys
+        from holoviews.plotting.util import get_dynamic_mode
         from ..widgets import Widget, DiscreteSlider, Select, FloatSlider, DatetimeInput
 
+        dynamic, bounded = get_dynamic_mode(object)
         dims, keys = unique_dimkeys(object)
         if dims == [Dimension('Frame')] and keys == [(0,)]:
             return [], {}
 
         nframes = 1
-        values = dict(zip(dims, zip(*keys)))
+        values = dict() if dynamic else dict(zip(dims, zip(*keys)))
         dim_values = OrderedDict()
         widgets = []
         for dim in dims:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -76,18 +76,17 @@ class HoloViews(PaneBase):
         for ref, (plot, pane) in self._plots.items():
             self._update_plot(plot, pane)
 
-    def _cleanup(self, root=None, final=False):
+    def _cleanup(self, root):
         """
         Traverses HoloViews object to find and clean up any streams
         connected to existing plots.
         """
-        if root is not None:
-            old_plot, old_pane = self._plots.pop(root.ref['id'], None)
-            if old_plot:
-                old_plot.cleanup()
-            if old_pane:
-                old_pane._cleanup(root)
-        super(HoloViews, self)._cleanup(root, final)
+        old_plot, old_pane = self._plots.pop(root.ref['id'], None)
+        if old_plot:
+            old_plot.cleanup()
+        if old_pane:
+            old_pane._cleanup(root)
+        super(HoloViews, self)._cleanup(root)
 
     def _render(self, doc, comm, root):
         from holoviews import Store, renderer

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -16,6 +16,8 @@ from ..layout import Panel, Column
 from ..viewable import Viewable
 from ..widgets import Player
 from .base import PaneBase, Pane
+from .plot import Bokeh, Matplotlib
+from .plotly import Plotly
 
 
 class HoloViews(PaneBase):
@@ -41,15 +43,20 @@ class HoloViews(PaneBase):
 
     _rerender_params = ['object', 'widgets', 'backend', 'widget_type']
 
+    _panes = {'bokeh': Bokeh, 'matplotlib': Matplotlib, 'plotly': Plotly}
+
     def __init__(self, object, **params):
         super(HoloViews, self).__init__(object, **params)
         self.widget_box = Column()
         self._update_widgets()
         self._plots = {}
-        self._panes = {}
+        self.param.watch(self._update_widgets, self._rerender_params)
 
-    @param.depends('object', 'widgets', watch=True)
-    def _update_widgets(self):
+    #----------------------------------------------------------------
+    # Callback API
+    #----------------------------------------------------------------
+
+    def _update_widgets(self, *events):
         if self.object is None:
             widgets, values = [], []
         else:
@@ -74,21 +81,49 @@ class HoloViews(PaneBase):
         elif not widgets and self.widget_box in self.layout.objects:
             self.layout.pop(self.widget_box)
 
+    def _update_plot(self, plot, pane, event):
+        from holoviews.core.util import cross_index
+        from holoviews.plotting.bokeh.plot import BokehPlot
+
+        widgets = self.widget_box.objects
+        if self.widget_type == 'scrubber':
+            key = cross_index([v for v in self._values.values()], widgets[0].value)
+        else:
+            key = tuple(w.value for w in widgets)
+
+        if isinstance(plot, BokehPlot):
+            if plot.comm or state.curdoc:
+                plot.update(key)
+                if plot.comm:
+                    plot.push()
+            else:
+                plot.document.add_next_tick_callback(partial(plot.update, key))
+        else:
+            plot.update(key)
+            pane.object = plot.state
+
     def _widget_callback(self, event):
         for ref, (plot, pane) in self._plots.items():
-            self._update_plot(plot, pane)
+            self._update_plot(plot, pane, event)
 
-    def _cleanup(self, root):
-        """
-        Traverses HoloViews object to find and clean up any streams
-        connected to existing plots.
-        """
-        old_plot, old_pane = self._plots.pop(root.ref['id'], None)
-        if old_plot:
+    #----------------------------------------------------------------
+    # Model API
+    #----------------------------------------------------------------
+
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        if root is None:
+            return self._get_root(doc, comm)
+        ref = root.ref['id']
+        plot = self._render(doc, comm, root)
+        child_pane = self._panes.get(self.backend, Pane)(plot.state)
+        model = child_pane._get_model(doc, root, parent, comm)
+        if ref in self._plots:
+            old_plot, old_pane = self._plots[ref]
+            old_plot.comm = None # Ensure comm does not cleaned up
             old_plot.cleanup()
-        if old_pane:
-            old_pane._cleanup(root)
-        super(HoloViews, self)._cleanup(root)
+        self._plots[ref] = (plot, child_pane)
+        self._models[ref] = (model, parent)
+        return model
 
     def _render(self, doc, comm, root):
         from holoviews import Store, renderer
@@ -105,40 +140,17 @@ class HoloViews(PaneBase):
             kwargs['comm'] = comm
         return renderer.get_plot(self.object, **kwargs)
 
-    def _update_plot(self, plot, pane, comm=None):
-        from holoviews.core.util import cross_index
-        from holoviews.plotting.bokeh.plot import BokehPlot
-
-        widgets = self.widget_box.objects
-        if self.widget_type == 'scrubber':
-            key = cross_index([v for v in self._values.values()], widgets[0].value)
-        else:
-            key = tuple(w.value for w in widgets)
-
-        if isinstance(plot, BokehPlot):
-            if comm or state.curdoc:
-                plot.update(key)
-                if plot.comm:
-                    plot.push()
-            else:
-                plot.document.add_next_tick_callback(partial(plot.update, key))
-        else:
-            plot.update(key)
-            pane.object = plot.state
-
-    def _get_model(self, doc, root=None, parent=None, comm=None):
-        if root is None:
-            return self._get_root(doc, comm)
-        ref = root.ref['id']
-        plot = self._render(doc, comm, root)
-        child_pane = Pane(plot.state, _temporary=True)
-        model = child_pane._get_model(doc, root, parent, comm)
-        if ref in self._plots:
-            old_plot, old_pane = self._plots[ref]
+    def _cleanup(self, root):
+        """
+        Traverses HoloViews object to find and clean up any streams
+        connected to existing plots.
+        """
+        old_plot, old_pane = self._plots.pop(root.ref['id'], None)
+        if old_plot:
             old_plot.cleanup()
-        self._plots[ref] = (plot, child_pane)
-        self._models[ref] = (model, parent)
-        return model
+        if old_pane:
+            old_pane._cleanup(root)
+        super(HoloViews, self)._cleanup(root)
 
     #----------------------------------------------------------------
     # Public API
@@ -184,7 +196,7 @@ class HoloViews(PaneBase):
                 else:
                     raise ValueError('Explicit widget definitions expected '
                                      'to be a widget instance or type, %s '
-                                     'dimension widget declared as %s.' % 
+                                     'dimension widget declared as %s.' %
                                      (dim, widget))
             if vals:
                 if all(isnumeric(v) or isinstance(v, datetime_types) for v in vals) and len(vals) > 1:
@@ -232,11 +244,11 @@ def generate_panel_bokeh_map(root_model, panel_views):
     """
     map_hve_bk = defaultdict(list)
     for pane in panel_views:
-        if root_model.ref['id'] in pane._models: 
+        if root_model.ref['id'] in pane._models:
             bk_plots = pane._plots[root_model.ref['id']][0].traverse(lambda x: x, [is_bokeh_element_plot])
             for plot in bk_plots:
                 for hv_elem in plot.link_sources:
-                    map_hve_bk[hv_elem].append(plot) 
+                    map_hve_bk[hv_elem].append(plot)
     return map_hve_bk
 
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -39,6 +39,8 @@ class HoloViews(PaneBase):
 
     priority = 0.8
 
+    _rerender_params = ['object', 'widgets', 'backend', 'widget_type']
+
     def __init__(self, object, **params):
         super(HoloViews, self).__init__(object, **params)
         self.widget_box = Column()
@@ -72,7 +74,7 @@ class HoloViews(PaneBase):
         elif not widgets and self.widget_box in self.layout.objects:
             self.layout.pop(self.widget_box)
 
-    def _widget_callback(self):
+    def _widget_callback(self, event):
         for ref, (plot, pane) in self._plots.items():
             self._update_plot(plot, pane)
 
@@ -224,7 +226,7 @@ def is_bokeh_element_plot(plot):
             and not isinstance(plot, GenericOverlayPlot))
 
 
-def generate_panel_bokeh_map(root_model, panel_views): # ALERT REVIEW THIS BEFORE MERGE
+def generate_panel_bokeh_map(root_model, panel_views):
     """
     mapping panel elements to its bokeh models
     """

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -56,15 +56,15 @@ class HoloViews(PaneBase):
         self._values = values
 
         # Clean up anything models listening to the previous widgets
-        for cb in self._callbacks['instance']:
+        for cb in list(self._callbacks):
             if cb.inst in self.widget_box.objects:
                 cb.inst.param.unwatch(cb)
-                self._callbacks['instance'].remove(cb)
+                self._callbacks.remove(cb)
 
         # Add new widget callbacks
         for widget in widgets:
             watcher = widget.param.watch(self._widget_callback, 'value')
-            self._callbacks['instance'].append(watcher)
+            self._callbacks.append(watcher)
 
         self.widget_box.objects = widgets
         if widgets and not self.widget_box in self.layout.objects:

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -58,6 +58,8 @@ class ImageBase(DivPaneBase):
 
     def _get_properties(self):
         p = super(ImageBase, self)._get_properties()
+        if self.object is None:
+            return dict(p, text='<img></img>')
         data = self._img()
         if isinstance(data, str):
             data = base64.b64decode(data)
@@ -144,6 +146,8 @@ class SVG(ImageBase):
 
     def _get_properties(self):
         p = super(ImageBase, self)._get_properties()
+        if self.object is None:
+            return dict(p, text='<img></img>')
         data = self._img()
         width, height = self._imgshape(data)
         if not isinstance(data, bytes):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -36,7 +36,7 @@ class DivPaneBase(PaneBase):
     _rename = {'object': 'text'}
 
     def _get_properties(self):
-        return {p : getattr(self,p) for p in list(Layoutable.param) + ['style']
+        return {p : getattr(self, p) for p in list(Layoutable.param) + ['style']
                 if getattr(self, p) is not None}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -36,7 +36,7 @@ class DivPaneBase(PaneBase):
     _rename = {'object': 'text'}
 
     def _get_properties(self):
-        return {p : getattr(self, p) for p in list(DivPaneBase.param)
+        return {p : getattr(self, p) for p in list(Layoutable.param) + ['style']
                 if getattr(self, p) is not None}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -36,7 +36,7 @@ class DivPaneBase(PaneBase):
     _rename = {'object': 'text'}
 
     def _get_properties(self):
-        return {p : getattr(self, p) for p in list(Layoutable.param) + ['style']
+        return {p : getattr(self, p) for p in list(DivPaneBase.param)
                 if getattr(self, p) is not None}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -73,9 +73,9 @@ class HTML(DivPaneBase):
 
     def _get_properties(self):
         properties = super(HTML, self)._get_properties()
-        text=self.object
+        text = '' if self.object is None else self.object
         if hasattr(text, '_repr_html_'):
-            text=text._repr_html_()
+            text = text._repr_html_()
         return dict(properties, text=text)
 
 
@@ -96,7 +96,11 @@ class Str(DivPaneBase):
 
     def _get_properties(self):
         properties = super(Str, self)._get_properties()
-        return dict(properties, text='<pre>'+escape(str(self.object))+'</pre>')
+        if self.object is None:
+            text = ''
+        else:
+            text = '<pre>'+escape(str(self.object))+'</pre>'
+        return dict(properties, text=text)
 
 
 class Markdown(DivPaneBase):
@@ -122,11 +126,12 @@ class Markdown(DivPaneBase):
     def _get_properties(self):
         import markdown
         data = self.object
-        if not isinstance(data, string_types):
+        if data is None:
+            data = ''
+        elif not isinstance(data, string_types):
             data = data._repr_markdown_()
         properties = super(Markdown, self)._get_properties()
         properties['style'] = properties.get('style', {})
         extensions = ['markdown.extensions.extra', 'markdown.extensions.smarty']
-        html = markdown.markdown(self.object, extensions=extensions,
-                                 output_format='html5')
+        html = markdown.markdown(data, extensions=extensions, output_format='html5')
         return dict(properties, text=html)

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -43,8 +43,7 @@ class DivPaneBase(PaneBase):
         model = _BkDiv(**self._get_properties())
         if root is None:
             root = model
-        self._models[root.ref['id']] = model
-        self._link_object(doc, root, parent, comm)
+        self._models[root.ref['id']] = (model, parent)
         return model
 
     def _update(self, model):

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -40,8 +40,7 @@ class Bokeh(PaneBase):
         if model._document and doc is not model._document:
             remove_root(model, doc)
 
-        self._models[ref] = model
-        self._link_object(doc, root, parent, comm)
+        self._models[ref] = (model, parent)
         return model
 
 

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -93,7 +93,7 @@ class RGGPlot(PNG):
 
     dpi = param.Integer(default=144, bounds=(1, None))
 
-    _rerender_params = ['object', 'dpi']
+    _rerender_params = ['object', 'dpi', 'width', 'height']
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -56,6 +56,8 @@ class Matplotlib(PNG):
     dpi = param.Integer(default=144, bounds=(1, None), doc="""
         Scales the dpi of the matplotlib figure.""")
 
+    _rerender_params = ['object', 'dpi']
+
     @classmethod
     def applies(cls, obj):
         if 'matplotlib' not in sys.modules:
@@ -90,6 +92,8 @@ class RGGPlot(PNG):
     width = param.Integer(default=400)
 
     dpi = param.Integer(default=144, bounds=(1, None))
+
+    _rerender_params = ['object', 'dpi']
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 import param
 
-from bokeh.models import LayoutDOM, CustomJS
+from bokeh.models import LayoutDOM, CustomJS, Spacer as BkSpacer
 
 from ..util import remove_root
 from .base import PaneBase
@@ -32,7 +32,10 @@ class Bokeh(PaneBase):
         if root is None:
             return self._get_root(doc, comm)
 
-        model = self.object
+        if self.object is None:
+            model = BkSpacer()
+        else:
+            model = self.object
         ref = root.ref['id']
         for js in model.select({'type': CustomJS}):
             js.code = js.code.replace(model.ref['id'], ref)
@@ -127,6 +130,8 @@ class YT(HTML):
 
     def _get_properties(self):
         p = super(YT, self)._get_properties()
+        if self.object is None:
+            return p
 
         width = height = 0
         if self.width  is None or self.height is None:

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -26,6 +26,8 @@ class Plotly(PaneBase):
 
     _updates = True
 
+    _rerender_params = ['object', 'plotly_layout']
+
     priority = 0.8
 
     def __init__(self, object, layout=None, **params):

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -34,16 +34,15 @@ class Plotly(PaneBase):
     def _to_figure(self, obj):
         import plotly.graph_objs as go
         if isinstance(obj, go.Figure):
-            fig = obj
+            return obj
         elif isinstance(obj, dict):
-            fig = go.Figure(data=obj['data'], layout=obj['layout'])
+            data, layout = obj['data'], obj['layout']
         elif isinstance(obj, tuple):
             data, layout = obj
-            fig = go.Figure(data=data, layout=layout)
         else:
-            data = obj if isinstance(obj, list) else [obj]
-            fig = go.Figure(data=data)
-        return fig
+            data, layout = obj, {}
+        data = data if isinstance(data, list) else [data]
+        return go.Figure(data=data, layout=layout)
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         """
@@ -66,7 +65,7 @@ class Plotly(PaneBase):
         return model
 
     def _update(self, model):
-        fig = self._to_figure(self.object, self.plotly_layout)
+        fig = self._to_figure(self.object)
         json = fig.to_plotly_json()
         traces = json['data']
         new_sources = []

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -4,7 +4,6 @@ bokeh model.
 """
 from __future__ import absolute_import, division, unicode_literals
 
-import param
 import numpy as np
 
 from bokeh.models import ColumnDataSource

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -63,8 +63,7 @@ class Plotly(PaneBase):
         model = PlotlyPlot(data=json, data_sources=sources)
         if root is None:
             root = model
-        self._models[root.ref['id']] = model
-        self._link_object(doc, root, parent, comm)
+        self._models[root.ref['id']] = (model, parent)
         return model
 
     def _update(self, model):

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -37,9 +37,6 @@ class Vega(PaneBase):
 
     _updates = True
 
-    def __init__(self, object, **params):
-        super(Vega, self).__init__(object, **params)
-
     @classmethod
     def is_altair(cls, obj):
         if 'altair' in sys.modules:
@@ -81,10 +78,13 @@ class Vega(PaneBase):
             sources['data'] = ColumnDataSource(data=ds_as_cds(data))
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
-        json = self._to_json(self.object)
-        json['data'] = dict(json['data'])
         sources = {}
-        self._get_sources(json, sources)
+        if self.object is None:
+            json = None
+        else:
+            json = self._to_json(self.object)
+            json['data'] = dict(json['data'])
+            self._get_sources(json, sources)
         model = VegaPlot(data=json, data_sources=sources)
         if root is None:
             root = model
@@ -92,7 +92,10 @@ class Vega(PaneBase):
         return model
 
     def _update(self, model):
-        json = self._to_json(self.object)
-        self._get_sources(json, model.data_sources)
+        if self.object is None:
+            json = self._to_json(self.object)
+            self._get_sources(json, model.data_sources)
+        else:
+            json = None
         model.data = json
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -93,9 +93,9 @@ class Vega(PaneBase):
 
     def _update(self, model):
         if self.object is None:
+            json = None
+        else:
             json = self._to_json(self.object)
             self._get_sources(json, model.data_sources)
-        else:
-            json = None
         model.data = json
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -88,8 +88,7 @@ class Vega(PaneBase):
         model = VegaPlot(data=json, data_sources=sources)
         if root is None:
             root = model
-        self._models[root.ref['id']] = model
-        self._link_object(doc, root, parent, comm)
+        self._models[root.ref['id']] = (model, parent)
         return model
 
     def _update(self, model):

--- a/panel/param.py
+++ b/panel/param.py
@@ -206,8 +206,7 @@ class Param(PaneBase):
                 if existing:
                     old_panel = existing[0]
                     if not change.new:
-                        old_panel._cleanup(final=old_panel._temporary)
-                        self._expand_layout.pop(old_panel)
+                        self._expand_layout.remove(old_panel)
                 elif change.new:
                     kwargs = {k: v for k, v in self.get_param_values()
                               if k not in ['name', 'object', 'parameters']}
@@ -357,9 +356,9 @@ class Param(PaneBase):
         else:
             return [widget]
 
-    def _cleanup(self, root=None, final=False):
-        self.layout._cleanup(root, final)
-        super(Param, self)._cleanup(root, final)
+    def _cleanup(self, root):
+        self.layout._cleanup(root)
+        super(Param, self)._cleanup(root)
 
     def _get_widgets(self):
         """Return name,widget boxes for all parameters (i.e., a property sheet)"""
@@ -468,12 +467,7 @@ class ParamMethod(PaneBase):
                     pvals = dict(self._pane.get_param_values())
                     new_params = {k: v for k, v in new_object.get_param_values()
                                   if k != 'name' and v is not pvals[k]}
-                    try:
-                        self._pane.set_param(**new_params)
-                    except:
-                        raise
-                    finally:
-                        new_object._cleanup(final=new_object._temporary)
+                    self._pane.set_param(**new_params)
                 else:
                     self._pane.object = new_object
                 return
@@ -496,16 +490,16 @@ class ParamMethod(PaneBase):
             return self._get_root(doc, comm)
 
         ref = root.ref['id']
-        if ref in self._callbacks:
+        if ref in self._models:
             self._cleanup(root)
         model = self._inner_layout._get_model(doc, root, parent, comm)
         self._link_object_params(doc, root, parent, comm)
         self._models[ref] = (model, parent)
         return model
 
-    def _cleanup(self, root=None, final=False):
-        self._inner_layout._cleanup(root, final)
-        super(ParamMethod, self)._cleanup(root, final)
+    def _cleanup(self, root=None):
+        self._inner_layout._cleanup(root)
+        super(ParamMethod, self)._cleanup(root)
 
 
 class JSONInit(param.Parameterized):

--- a/panel/param.py
+++ b/panel/param.py
@@ -18,6 +18,7 @@ import param
 
 from param.parameterized import classlist
 
+from .io import state
 from .layout import Row, Panel, Tabs, Column
 from .links import Link
 from .pane.base import Pane, PaneBase
@@ -389,12 +390,14 @@ class Param(PaneBase):
 
     def _get_root(self, doc, comm=None):
         root = self.layout._get_root(doc, comm)
-        self._models[root.ref['id']] = root
+        ref = root.ref['id']
+        self._models[ref] = (root, None)
+        state._views[ref] = (self, root, doc, comm)
         return root
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         model = self.layout._get_model(doc, root, parent, comm)
-        self._models[root.ref['id']] = model
+        self._models[root.ref['id']] = (model, parent)
         return model
 
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -500,7 +500,7 @@ class ParamMethod(PaneBase):
             self._cleanup(root)
         model = self._inner_layout._get_model(doc, root, parent, comm)
         self._link_object_params(doc, root, parent, comm)
-        self._models[ref] = model
+        self._models[ref] = (model, parent)
         return model
 
     def _cleanup(self, root=None, final=False):

--- a/panel/tests/test_holoviews.py
+++ b/panel/tests/test_holoviews.py
@@ -6,7 +6,8 @@ from collections import OrderedDict
 import pytest
 
 from bokeh.models import (Row as BkRow, Column as BkColumn, GlyphRenderer,
-                          Scatter, Line, GridBox)
+                          Scatter, Line, GridBox, Select as BkSelect,
+                          Slider as BkSlider)
 from bokeh.plotting import Figure
 
 from panel.layout import Column, Row
@@ -162,6 +163,23 @@ def test_holoviews_with_widgets(document, comm):
 
 
 @hv_available
+def test_holoviews_updates_widgets(document, comm):
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
+
+    hv_pane = HoloViews(hmap)
+    layout = hv_pane._get_root(document, comm)
+
+    hv_pane.widgets = {'X': Select}
+    assert isinstance(hv_pane.widget_box[0], Select)
+    assert isinstance(layout.children[1].children[0], BkSelect)
+
+    hv_pane.widgets = {'X': DiscreteSlider}
+    assert isinstance(hv_pane.widget_box[0], DiscreteSlider)
+    assert isinstance(layout.children[1].children[0], BkColumn)
+    assert isinstance(layout.children[1].children[0].children[1], BkSlider)
+
+
+@hv_available
 def test_holoviews_with_widgets_not_shown(document, comm):
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
@@ -181,7 +199,7 @@ def test_holoviews_with_widgets_not_shown(document, comm):
     assert hv_pane.widget_box.objects[0].name == 'A'
     assert hv_pane.widget_box.objects[1].name == 'B'
 
-    
+
 @hv_available
 def test_holoviews_widgets_from_holomap():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])

--- a/panel/tests/test_holoviews.py
+++ b/panel/tests/test_holoviews.py
@@ -42,7 +42,7 @@ def test_holoviews_pane_mpl_renderer(document, comm):
     assert len(row.children) == 1
     assert len(pane._callbacks) == 1
     model = row.children[0]
-    assert pane._models[row.ref['id']] is model
+    assert pane._models[row.ref['id']][0] is model
     div = get_div(model)
     assert '<img' in div.text
 
@@ -55,7 +55,6 @@ def test_holoviews_pane_mpl_renderer(document, comm):
 
     # Cleanup
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -72,7 +71,7 @@ def test_holoviews_pane_bokeh_renderer(document, comm):
     assert len(pane._callbacks) == 1
     model = row.children[0]
     assert isinstance(model, Figure)
-    assert pane._models[row.ref['id']] is model
+    assert pane._models[row.ref['id']][0] is model
     renderers = [r for r in model.renderers if isinstance(r, GlyphRenderer)]
     assert len(renderers) == 1
     assert isinstance(renderers[0].glyph, Line)
@@ -86,11 +85,10 @@ def test_holoviews_pane_bokeh_renderer(document, comm):
     assert len(renderers) == 1
     assert isinstance(renderers[0].glyph, Scatter)
     assert len(pane._callbacks) == 1
-    assert pane._models[row.ref['id']] is model
+    assert pane._models[row.ref['id']][0] is model
 
     # Cleanup
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -132,12 +130,12 @@ def test_holoviews_widgets_from_dynamicmap(document, comm):
 
     assert isinstance(widgets[3], Select)
     assert widgets[3].name == 'D'
-    assert widgets[3].options == OrderedDict(zip(value_dim.values, value_dim.values))
+    assert widgets[3].options == value_dim.values
     assert widgets[3].value == value_dim.values[0]
 
     assert isinstance(widgets[4], Select)
     assert widgets[4].name == 'E'
-    assert widgets[4].options == OrderedDict(zip(value_default_dim.values, value_default_dim.values))
+    assert widgets[4].options == value_default_dim.values
     assert widgets[4].value == value_default_dim.default
 
     assert isinstance(widgets[5], DiscreteSlider)
@@ -157,8 +155,7 @@ def test_holoviews_with_widgets(document, comm):
     assert hv_pane.widget_box.objects[0].name == 'X'
     assert hv_pane.widget_box.objects[1].name == 'Y'
 
-    assert layout.ref['id'] in hv_pane._callbacks
-    assert hv_pane._models[layout.ref['id']] is model
+    assert hv_pane._models[layout.ref['id']][0] is model
 
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['A', 'B'])
     hv_pane.object = hmap
@@ -179,12 +176,10 @@ def test_holoviews_with_widgets_not_shown(document, comm):
     assert hv_pane.widget_box.objects[0].name == 'X'
     assert hv_pane.widget_box.objects[1].name == 'Y'
 
-    assert layout.ref['id'] in hv_pane._callbacks
-    assert hv_pane._models[layout.ref['id']] is model
+    assert hv_pane._models[layout.ref['id']][0] is model
 
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['A', 'B'])
     hv_pane.object = hmap
-    assert model.ref['id'] not in hv_pane._callbacks
     assert len(hv_pane.widget_box.objects) == 2
     assert hv_pane.widget_box.objects[0].name == 'A'
     assert hv_pane.widget_box.objects[1].name == 'B'
@@ -203,7 +198,7 @@ def test_holoviews_widgets_from_holomap():
 
     assert isinstance(widgets[1], Select)
     assert widgets[1].name == 'Y'
-    assert widgets[1].options == OrderedDict([(i, i) for i in ['A', 'B', 'C']])
+    assert widgets[1].options == ['A', 'B', 'C']
     assert widgets[1].value == 'A'
 
 

--- a/panel/tests/test_holoviews.py
+++ b/panel/tests/test_holoviews.py
@@ -40,7 +40,6 @@ def test_holoviews_pane_mpl_renderer(document, comm):
     row = pane._get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    assert len(pane._callbacks) == 1
     model = row.children[0]
     assert pane._models[row.ref['id']][0] is model
     div = get_div(model)
@@ -68,7 +67,6 @@ def test_holoviews_pane_bokeh_renderer(document, comm):
     row = pane._get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    assert len(pane._callbacks) == 1
     model = row.children[0]
     assert isinstance(model, Figure)
     assert pane._models[row.ref['id']][0] is model
@@ -84,7 +82,6 @@ def test_holoviews_pane_bokeh_renderer(document, comm):
     renderers = [r for r in model.renderers if isinstance(r, GlyphRenderer)]
     assert len(renderers) == 1
     assert isinstance(renderers[0].glyph, Scatter)
-    assert len(pane._callbacks) == 1
     assert pane._models[row.ref['id']][0] is model
 
     # Cleanup

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -190,7 +190,7 @@ def test_interact_replaces_model(document, comm):
     assert div.text == 'Test'
     assert len(interact_pane._callbacks['instance']) == 1
     assert column.ref['id'] in pane._callbacks
-    assert pane._models[column.ref['id']] is div
+    assert pane._models[column.ref['id']][0] is div
     
     widget.value = True
     assert column.ref['id'] not in pane._callbacks
@@ -202,7 +202,7 @@ def test_interact_replaces_model(document, comm):
     assert new_div.text == '<p>ABC</p>'
     assert len(interact_pane._callbacks['instance']) == 1
     assert column.ref['id'] in new_pane._callbacks
-    assert new_pane._models[column.ref['id']] is new_div
+    assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
     assert len(interact_pane._callbacks) == 1

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -124,7 +124,7 @@ def test_string_list_interact():
     widget = interact_pane._widgets['a']
     assert isinstance(widget, widgets.Select)
     assert widget.value == 'A'
-    assert widget.options == dict(zip(options, options))
+    assert widget.options == options
 
 def test_manual_interact():
     def test(a):
@@ -145,11 +145,11 @@ def test_interact_updates_panel(document, comm):
     assert isinstance(widget, widgets.Checkbox)
     assert widget.value == False
 
-    column = interact_pane.layout._get_model(document, comm=comm)
+    column = interact_pane.layout._get_root(document, comm=comm)
     assert isinstance(column, BkColumn)
     div = column.children[1].children[0]
     assert div.text == '<pre>False</pre>'
-    
+
     widget.value = True
     assert div.text == '<pre>True</pre>'
 
@@ -163,14 +163,13 @@ def test_interact_replaces_panel(document, comm):
     assert isinstance(widget, widgets.Checkbox)
     assert widget.value == False
 
-    column = interact_pane.layout._get_model(document, comm=comm)
+    column = interact_pane.layout._get_root(document, comm=comm)
     assert isinstance(column, BkColumn)
-    div = get_div(column.children[1].children[0])
+    div = column.children[1].children[0]
     assert div.text == 'Test'
-    
+
     widget.value = True
-    assert pane._callbacks == {}
-    div = get_div(column.children[1].children[0])
+    div = column.children[1].children[0]
     assert div.text == '<pre>True</pre>'
 
 def test_interact_replaces_model(document, comm):
@@ -183,27 +182,20 @@ def test_interact_replaces_model(document, comm):
     assert isinstance(widget, widgets.Checkbox)
     assert widget.value == False
 
-    column = interact_pane.layout._get_model(document, comm=comm)
+    column = interact_pane.layout._get_root(document, comm=comm)
     assert isinstance(column, BkColumn)
     div = column.children[1].children[0]
     assert isinstance(div, BkDiv)
     assert div.text == 'Test'
-    assert len(interact_pane._callbacks['instance']) == 1
-    assert column.ref['id'] in pane._callbacks
     assert pane._models[column.ref['id']][0] is div
-    
+
     widget.value = True
-    assert column.ref['id'] not in pane._callbacks
-    assert pane._callbacks == {}
     new_pane = interact_pane._pane
     assert new_pane is not pane
     new_div = column.children[1].children[0]
     assert isinstance(new_div, BkDiv)
     assert new_div.text == '<p>ABC</p>'
-    assert len(interact_pane._callbacks['instance']) == 1
-    assert column.ref['id'] in new_pane._callbacks
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
     assert len(interact_pane._callbacks) == 1
-    assert pane._callbacks == {}

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -4,8 +4,6 @@ from panel.interact import interactive
 from panel.pane import HTML
 from panel import widgets
 
-from .test_layout import get_div
-
 
 def test_interact_title():
     def test(a):
@@ -158,7 +156,6 @@ def test_interact_replaces_panel(document, comm):
         return a if a else BkDiv(text='Test')
 
     interact_pane = interactive(test, a=False)
-    pane = interact_pane._pane
     widget = interact_pane._widgets['a']
     assert isinstance(widget, widgets.Checkbox)
     assert widget.value == False

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -623,7 +623,7 @@ def test_tabs_setitem(document, comm):
     model = tabs._get_root(document, comm=comm)
 
     tab1, tab2 = model.tabs
-    assert p1._models[model.ref['id']] is tab1.child
+    assert p1._models[model.ref['id']][0] is tab1.child
     div3 = Div()
     tabs[0] = ('C', div3)
     tab1, tab2 = model.tabs

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -32,6 +32,63 @@ def get_divs(children):
     return [get_div(c) for c in children]
 
 
+@pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])
+def test_layout_properties(layout, document, comm):
+
+    l = layout()
+
+    model = l._get_root(document, comm)
+
+    l.background = '#ffffff'
+    assert model.background == '#ffffff'
+
+    l.css_classes = ['custom_class']
+    assert model.css_classes == ['custom_class']
+
+    l.width = 500
+    assert model.width == 500
+
+    l.height = 450
+    assert model.height == 450
+
+    l.min_height = 300
+    assert model.min_height == 300
+
+    l.min_width = 250
+    assert model.min_width == 250
+
+    l.max_height = 600
+    assert model.max_height == 600
+
+    l.max_width = 550
+    assert model.max_width == 550
+
+    l.margin = 10
+    assert model.margin == (10, 10, 10, 10)
+
+    l.sizing_mode = 'stretch_width'
+    assert model.sizing_mode == 'stretch_width'
+
+    l.width_policy = 'max'
+    assert model.width_policy == 'max'
+
+    l.height_policy = 'min'
+    assert model.height_policy == 'min'
+
+
+@pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])
+def test_layout_model_cache_cleanup(layout, document, comm):
+    l = layout()
+
+    model = l._get_root(document, comm)
+
+    assert model.ref['id'] in l._models
+    assert l._models[model.ref['id']] == (model, None)
+
+    l._cleanup(model)
+    assert l._models == {}
+
+
 @pytest.mark.parametrize('panel', [Column, Row])
 def test_layout_constructor(panel):
     div1 = Div()

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -21,16 +21,6 @@ def assert_tab_is_similar(tab1, tab2):
     assert tab1.name == tab2.name
     assert tab1.title == tab2.title
 
-def get_div(box):
-    # Temporary utilities to unpack widget boxes
-    if isinstance(box, Div):
-        return box
-    return box.children[0]
-
-
-def get_divs(children):
-    return [get_div(c) for c in children]
-
 
 @pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])
 def test_layout_properties(layout, document, comm):

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -8,6 +8,7 @@ from panel.layout import Column, Row, Tabs, Spacer
 from panel.pane import Bokeh, Pane
 from panel.param import Param
 
+
 @pytest.fixture
 def tabs(document, comm):
     """Set up a tabs instance"""
@@ -20,50 +21,6 @@ def assert_tab_is_similar(tab1, tab2):
     assert tab1.child is tab2.child
     assert tab1.name == tab2.name
     assert tab1.title == tab2.title
-
-
-@pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])
-def test_layout_properties(layout, document, comm):
-
-    l = layout()
-
-    model = l._get_root(document, comm)
-
-    l.background = '#ffffff'
-    assert model.background == '#ffffff'
-
-    l.css_classes = ['custom_class']
-    assert model.css_classes == ['custom_class']
-
-    l.width = 500
-    assert model.width == 500
-
-    l.height = 450
-    assert model.height == 450
-
-    l.min_height = 300
-    assert model.min_height == 300
-
-    l.min_width = 250
-    assert model.min_width == 250
-
-    l.max_height = 600
-    assert model.max_height == 600
-
-    l.max_width = 550
-    assert model.max_width == 550
-
-    l.margin = 10
-    assert model.margin == (10, 10, 10, 10)
-
-    l.sizing_mode = 'stretch_width'
-    assert model.sizing_mode == 'stretch_width'
-
-    l.width_policy = 'max'
-    assert model.width_policy == 'max'
-
-    l.height_policy = 'min'
-    assert model.height_policy == 'min'
 
 
 @pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -158,12 +158,10 @@ def test_layout_setitem(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     div3 = Div()
     layout[0] = div3
     assert model.children == [div3, div2]
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -188,15 +186,12 @@ def test_layout_setitem_replace_all(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     div3 = Div()
     div4 = Div()
     layout[:] = [div3, div4]
     assert model.children == [div3, div4]
-    assert p1._callbacks == {}
     assert p1._models == {}
-    assert p2._callbacks == {}
     assert p2._models == {}
 
 
@@ -222,15 +217,12 @@ def test_layout_setitem_replace_slice(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     div3 = Div()
     div4 = Div()
     layout[1:] = [div3, div4]
     assert model.children == [div1, div3, div4]
-    assert p2._callbacks == {}
     assert p2._models == {}
-    assert p3._callbacks == {}
     assert p3._models == {}
 
 
@@ -269,11 +261,9 @@ def test_layout_pop(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     layout.pop(0)
     assert model.children == [div2]
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -286,11 +276,9 @@ def test_layout_remove(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     layout.remove(p1)
     assert model.children == [div2]
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -303,11 +291,9 @@ def test_layout_clear(panel, document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.children[0]
+    assert p1._models[model.ref['id']][0] is model.children[0]
     layout.clear()
     assert model.children == []
-    assert p1._callbacks == p2._callbacks == {}
     assert p1._models == p2._models == {}
 
 
@@ -323,6 +309,7 @@ def test_tabs_basic_constructor(document, comm):
 
     assert 'plain' in tab1.child.text
     assert 'text' in tab2.child.text
+
 
 def test_tabs_constructor(document, comm):
     div1 = Div()
@@ -636,7 +623,6 @@ def test_tabs_setitem(document, comm):
     model = tabs._get_root(document, comm=comm)
 
     tab1, tab2 = model.tabs
-    assert model.ref['id'] in p1._callbacks
     assert p1._models[model.ref['id']] is tab1.child
     div3 = Div()
     tabs[0] = ('C', div3)
@@ -644,7 +630,6 @@ def test_tabs_setitem(document, comm):
     assert tab1.child is div3
     assert tab1.title == 'C'
     assert tab2.child is div2
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -667,8 +652,7 @@ def test_tabs_setitem_replace_all(document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.tabs[0].child
+    assert p1._models[model.ref['id']][0] is model.tabs[0].child
     div3 = Div()
     div4 = Div()
     layout[:] = [('B', div3), ('C', div4)]
@@ -677,9 +661,7 @@ def test_tabs_setitem_replace_all(document, comm):
     assert tab1.title == 'B'
     assert tab2.child is div4
     assert tab2.title == 'C'
-    assert p1._callbacks == {}
     assert p1._models == {}
-    assert p2._callbacks == {}
     assert p2._models == {}
 
 
@@ -703,8 +685,7 @@ def test_tabs_setitem_replace_slice(document, comm):
 
     model = layout._get_root(document, comm=comm)
 
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is model.tabs[0].child
+    assert p1._models[model.ref['id']][0] is model.tabs[0].child
     div3 = Div()
     div4 = Div()
     layout[1:] = [('D', div3), ('E', div4)]
@@ -715,9 +696,7 @@ def test_tabs_setitem_replace_slice(document, comm):
     assert tab2.title == 'D'
     assert tab3.child is div4
     assert tab3.title == 'E'
-    assert p2._callbacks == {}
     assert p2._models == {}
-    assert p3._callbacks == {}
     assert p3._models == {}
 
 
@@ -754,13 +733,11 @@ def test_tabs_pop(document, comm):
     model = tabs._get_root(document, comm=comm)
 
     tab1 = model.tabs[0]
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is tab1.child
+    assert p1._models[model.ref['id']][0] is tab1.child
     tabs.pop(0)
     assert len(model.tabs) == 1
     tab1 = model.tabs[0]
     assert tab1.child is div2
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -773,13 +750,11 @@ def test_tabs_remove(document, comm):
     model = tabs._get_root(document, comm=comm)
 
     tab1 = model.tabs[0]
-    assert model.ref['id'] in p1._callbacks
-    assert p1._models[model.ref['id']] is tab1.child
+    assert p1._models[model.ref['id']][0] is tab1.child
     tabs.remove(p1)
     assert len(model.tabs) == 1
     tab1 = model.tabs[0]
     assert tab1.child is div2
-    assert p1._callbacks == {}
     assert p1._models == {}
 
 
@@ -794,7 +769,6 @@ def test_tabs_clear(document, comm):
     tabs.clear()
     assert tabs._names == []
     assert len(model.tabs) == 0
-    assert p1._callbacks == p2._callbacks == {}
     assert p1._models == p2._models == {}
 
 

--- a/panel/tests/test_layoutable.py
+++ b/panel/tests/test_layoutable.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+import pytest
+
+from panel.layout import Column, Row, Tabs, Spacer
+from panel.pane import (HTML, Str, PNG, JPG, GIF, SVG, Markdown, LaTeX,
+                        Matplotlib, RGGPlot, YT, Plotly, Vega)
+
+from .test_widgets import all_widgets
+
+
+def check_layoutable_properties(layoutable, model):
+    layoutable.background = '#ffffff'
+    assert model.background == '#ffffff'
+
+    layoutable.css_classes = ['custom_class']
+    assert model.css_classes == ['custom_class']
+
+    layoutable.width = 500
+    assert model.width == 500
+
+    layoutable.height = 450
+    assert model.height == 450
+
+    layoutable.min_height = 300
+    assert model.min_height == 300
+
+    layoutable.min_width = 250
+    assert model.min_width == 250
+
+    layoutable.max_height = 600
+    assert model.max_height == 600
+
+    layoutable.max_width = 550
+    assert model.max_width == 550
+
+    layoutable.margin = 10
+    assert model.margin == (10, 10, 10, 10)
+
+    layoutable.sizing_mode = 'stretch_width'
+    assert model.sizing_mode == 'stretch_width'
+
+    layoutable.width_policy = 'max'
+    assert model.width_policy == 'max'
+
+    layoutable.height_policy = 'min'
+    assert model.height_policy == 'min'
+
+
+@pytest.mark.parametrize('pane', [Str, Markdown, HTML, PNG, JPG, SVG,
+                                  GIF, LaTeX, Matplotlib, RGGPlot, YT,
+                                  Plotly, Vega])
+def test_pane_layout_properties(pane, document, comm):
+    p = pane()
+    model = p._get_root(document, comm)
+    check_layoutable_properties(p, model)
+
+
+@pytest.mark.parametrize('widget', all_widgets)
+def test_widget_layout_properties(widget, document, comm):
+    w = widget()
+    model = w._get_root(document, comm)
+    check_layoutable_properties(w, model)
+
+
+@pytest.mark.parametrize('layout', [Column, Row, Tabs, Spacer])
+def test_layout_properties(layout, document, comm):
+    l = layout()
+    model = l._get_root(document, comm)
+    check_layoutable_properties(l, model)

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -28,13 +28,12 @@ def test_pnwidget_hvplot_links(document, comm):
 
     assert len(hv_views) == 1
     assert len(widg_views) == 1
-    slider = widg_views[0]._models[model.ref['id']]
-    scatter = hv_views[0]._plots[model.ref['id']].handles['glyph']
+    slider = widg_views[0]._models[model.ref['id']][0]
+    scatter = hv_views[0]._plots[model.ref['id']][0].handles['glyph']
 
     link_customjs = slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is slider
     assert link_customjs.args['target'] is scatter
-
     
     code = ("value = source['value'];"
             "try { property = target.properties['size'];"
@@ -58,7 +57,7 @@ def test_bkwidget_hvplot_links(document, comm):
 
     assert len(hv_views) == 1
     slider = bokeh_widget
-    scatter = hv_views[0]._plots[model.ref['id']].handles['glyph']
+    scatter = hv_views[0]._plots[model.ref['id']][0].handles['glyph']
 
     link_customjs = slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is slider
@@ -113,8 +112,8 @@ def test_link_with_customcode(document, comm):
 
     assert len(hv_views) == 1
     assert len(widg_views) == 1
-    range_slider = widg_views[0]._models[model.ref['id']]
-    x_range = hv_views[0]._plots[model.ref['id']].handles['x_range']
+    range_slider = widg_views[0]._models[model.ref['id']][0]
+    x_range = hv_views[0]._plots[model.ref['id']][0].handles['x_range']
 
     link_customjs = range_slider.js_property_callbacks['change:value'][-1]
     assert link_customjs.args['source'] is range_slider

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -35,6 +35,7 @@ markdown_available = pytest.mark.skipif(markdown is None, reason="requires markd
 from .fixtures import mpl_figure
 
 
+
 def test_get_bokeh_pane_type():
     div = Div()
     assert PaneBase.get_pane_type(div) is Bokeh

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -35,7 +35,6 @@ markdown_available = pytest.mark.skipif(markdown is None, reason="requires markd
 from .fixtures import mpl_figure
 
 
-
 def test_get_bokeh_pane_type():
     div = Div()
     assert PaneBase.get_pane_type(div) is Bokeh

--- a/panel/tests/test_panes.py
+++ b/panel/tests/test_panes.py
@@ -33,7 +33,6 @@ except:
 markdown_available = pytest.mark.skipif(markdown is None, reason="requires markdown")
 
 from .fixtures import mpl_figure
-from .test_layout import get_div
 
 
 def test_get_bokeh_pane_type():
@@ -50,21 +49,18 @@ def test_bokeh_pane(document, comm):
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
     model = row.children[0]
-    assert row.ref['id'] in pane._callbacks
-    assert get_div(model) is div
-    assert pane._models[row.ref['id']] is model
+    assert model is div
+    assert pane._models[row.ref['id']][0] is model
 
     # Replace Pane.object
     div2 = Div()
     pane.object = div2
     new_model = row.children[0]
-    assert get_div(new_model) is div2
-    assert row.ref['id'] in pane._callbacks
-    assert pane._models[row.ref['id']] is new_model
+    assert new_model is div2
+    assert pane._models[row.ref['id']][0] is new_model
 
     # Cleanup
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -84,20 +80,17 @@ def test_matplotlib_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
     assert '<img' in model.text
     text = model.text
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
 
     # Replace Pane.object
     pane.object = mpl_figure()
     assert model.text != text
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -112,19 +105,16 @@ def test_markdown_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<p><strong>Markdown</strong></p>"
 
     # Replace Pane.object
     pane.object = "*Markdown*"
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<p><em>Markdown</em></p>"
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -133,19 +123,16 @@ def test_html_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<h1>Test</h1>"
 
     # Replace Pane.object
     pane.object = "<h2>Test</h2>"
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<h2>Test</h2>"
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -156,15 +143,14 @@ def test_latex_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     # Just checks for a PNG, not a specific rendering, to avoid
     # false alarms when formatting of the PNG changes
     assert model.text[0:32] == "<img src='data:image/png;base64,"
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
+    assert pane._models == {}
 
 
 def test_string_pane(document, comm):
@@ -172,19 +158,16 @@ def test_string_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<pre>&lt;h1&gt;Test&lt;/h1&gt;</pre>"
 
     # Replace Pane.object
     pane.object = "<h2>Test</h2>"
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text == "<pre>&lt;h2&gt;Test&lt;/h2&gt;</pre>"
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 
@@ -198,8 +181,7 @@ def test_svg_pane(document, comm):
 
     # Create pane
     model = pane._get_root(document, comm=comm)
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text.startswith('<img')
     assert b64encode(rect.encode('utf-8')).decode('utf-8') in model.text
 
@@ -210,14 +192,12 @@ def test_svg_pane(document, comm):
     </svg>
     """
     pane.object = circle
-    assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert model.text.startswith('<img')
     assert b64encode(circle.encode('utf-8')).decode('utf-8') in model.text
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
     assert pane._models == {}
 
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -11,7 +11,6 @@ from panel.pane import Pane, PaneBase, Matplotlib, Bokeh
 from panel.layout import Tabs, Row
 from panel.param import Param, ParamMethod, JSONInit
 
-from .test_layout import get_div
 from .fixtures import mpl_figure
 
 try:
@@ -591,17 +590,15 @@ def test_param_method_pane(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    div = get_div(model)
     assert pane._models[row.ref['id']][0] is inner_row
-    assert isinstance(div, Div)
-    assert div.text == '0'
+    assert isinstance(model, Div)
+    assert model.text == '0'
 
     # Update pane
     test.a = 5
     new_model = inner_row.children[0]
-    div = get_div(new_model)
     assert inner_pane is pane._pane
-    assert div.text == '5'
+    assert new_model.text == '5'
     assert pane._models[row.ref['id']][0] is inner_row
 
     # Cleanup pane
@@ -623,14 +620,13 @@ def test_param_method_pane_subobject(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    div = get_div(model)
+    assert isinstance(model, Div)
+    assert model.text == '42'
 
     # Ensure that subobject is being watched
     watchers = pane._callbacks
     assert any(w.inst is subobject for w in watchers)
     assert pane._models[row.ref['id']][0] is inner_row
-    assert isinstance(div, Div)
-    assert div.text == '42'
 
     # Ensure that switching the subobject triggers update in watchers
     new_subobject = View(name='Nested', a=42)
@@ -660,15 +656,14 @@ def test_param_method_pane_mpl(document, comm):
     inner_row = row.children[0]
     model = inner_row.children[0]
     assert pane._models[row.ref['id']][0] is inner_row
-    div = get_div(model)
-    text = div.text
+    text = model.text
 
     # Update pane
     test.a = 5
-    model = inner_row.children[0]
+    new_model = inner_row.children[0]
     assert inner_pane is pane._pane
-    assert div is get_div(model)
-    assert div.text != text
+    assert new_model is model
+    assert new_model.text != text
     assert pane._models[row.ref['id']][0] is inner_row
 
     # Cleanup pane
@@ -690,18 +685,16 @@ def test_param_method_pane_changing_type(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    
-    div = get_div(model)
-    text = div.text
+    text = model.text
+    assert text.startswith('<img src')
 
     # Update pane
     test.a = 5
-    model = inner_row.children[0]
+    new_model = inner_row.children[0]
     new_pane = pane._pane
     assert isinstance(new_pane, Bokeh)
-    div = get_div(model)
-    assert isinstance(div, Div)
-    assert div.text != text
+    assert isinstance(new_model, Div)
+    assert new_model.text != text
 
     # Cleanup pane
     new_pane._cleanup(row)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -277,7 +277,7 @@ def test_object_selector_param(document, comm):
 
     # Check changing param attribute updates widget
     a_param = test.param['a']
-    a_param.objects = ['c', 'd', '1']
+    a_param.objects = ['c', 'd', 1]
     assert slider.options == ['c', 'd', '1']
 
     a_param.constant = True
@@ -313,7 +313,7 @@ def test_list_selector_param(document, comm):
 
     # Check changing param attribute updates widget
     a_param = test.param['a']
-    a_param.objects = ['c', 'd', '1']
+    a_param.objects = ['c', 'd', 1]
     assert slider.options == ['c', 'd', '1']
 
     a_param.constant = True
@@ -387,7 +387,6 @@ def test_expand_param_subobject(document, comm):
     assert len(model.children) == 4
     _, _, _, subpanel = test_pane.layout.objects
     col = model.children[3]
-    assert 'instance' in subpanel._callbacks
     assert isinstance(col, BkColumn)
     assert isinstance(col, BkColumn)
     assert len(col.children) == 2
@@ -419,7 +418,6 @@ def test_switch_param_subobject(document, comm):
     assert len(model.children) == 4
     _, _, _, subpanel = test_pane.layout.objects
     col = model.children[3]
-    assert 'instance' in subpanel._callbacks
     assert isinstance(col, BkColumn)
     assert len(col.children) == 3
     div, select, widget = col.children
@@ -430,7 +428,6 @@ def test_switch_param_subobject(document, comm):
     test_pane._widgets['a'][0].value = o2    
     _, _, _, subpanel = test_pane.layout.objects
     col = model.children[3]
-    assert 'instance' in subpanel._callbacks
     assert isinstance(col, BkColumn)
     assert len(col.children) == 3
     div, select, widget = col.children
@@ -440,7 +437,7 @@ def test_switch_param_subobject(document, comm):
     # Collapse subpanel
     test_pane._widgets['a'][1].value = False
     assert len(model.children) == 3
-    assert subpanel._callbacks == {}
+    assert subpanel._models == {}
 
     
 
@@ -462,7 +459,6 @@ def test_expand_param_subobject_into_row(document, comm):
     assert len(model.children) == 2
     subpanel = row.objects[0]
     row = model.children[1]
-    assert 'instance' in subpanel._callbacks
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
     box = row.children[0]
@@ -475,7 +471,7 @@ def test_expand_param_subobject_into_row(document, comm):
     # Collapse subpanel
     test_pane._widgets['a'][1].value = False
     assert len(row.children) == 0
-    assert subpanel._callbacks == {}
+    assert subpanel._models == {}
 
     
 def test_expand_param_subobject_expand(document, comm):
@@ -493,7 +489,6 @@ def test_expand_param_subobject_expand(document, comm):
     assert len(model.children) == 4
     _, _, _, subpanel = test_pane.layout.objects
     col = model.children[3]
-    assert 'instance' in subpanel._callbacks
     assert isinstance(col, BkColumn)
     assert len(col.children) == 2
     div, widget = col.children
@@ -503,7 +498,7 @@ def test_expand_param_subobject_expand(document, comm):
     # Collapse subpanel
     test_pane._widgets['a'][1].value = False
     assert len(model.children) == 3
-    assert subpanel._callbacks == {}
+    assert subpanel._models == {}
 
 
 def test_param_subobject_expand_no_toggle(document, comm):
@@ -600,8 +595,7 @@ def test_param_method_pane(document, comm):
     inner_row = row.children[0]
     model = inner_row.children[0]
     div = get_div(model)
-    assert row.ref['id'] in inner_pane._callbacks
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
     assert isinstance(div, Div)
     assert div.text == '0'
 
@@ -611,7 +605,7 @@ def test_param_method_pane(document, comm):
     div = get_div(new_model)
     assert inner_pane is pane._pane
     assert div.text == '5'
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
 
     # Cleanup pane
     pane._cleanup(row)
@@ -638,23 +632,21 @@ def test_param_method_pane_subobject(document, comm):
     assert row.ref['id'] in pane._callbacks
     watchers = pane._callbacks[row.ref['id']]
     assert any(w.inst is subobject for w in watchers)
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
     assert isinstance(div, Div)
     assert div.text == '42'
 
     # Ensure that switching the subobject triggers update in watchers
     new_subobject = View(name='Nested', a=42)
     test.b = new_subobject
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
     watchers = pane._callbacks[row.ref['id']]
     assert not any(w.inst is subobject for w in watchers)
     assert any(w.inst is new_subobject for w in watchers)
     
     # Cleanup pane
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
-    assert inner_pane._callbacks == {}
     assert inner_pane._models == {}
 
     
@@ -671,7 +663,7 @@ def test_param_method_pane_mpl(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
     div = get_div(model)
     text = div.text
 
@@ -681,9 +673,7 @@ def test_param_method_pane_mpl(document, comm):
     assert inner_pane is pane._pane
     assert div is get_div(model)
     assert div.text != text
-    assert len(inner_pane._callbacks) == 1
-    assert row.ref['id'] in inner_pane._callbacks
-    assert pane._models[row.ref['id']] is inner_row
+    assert pane._models[row.ref['id']][0] is inner_row
 
     # Cleanup pane
     pane._cleanup(row)
@@ -712,12 +702,10 @@ def test_param_method_pane_changing_type(document, comm):
     test.a = 5
     model = inner_row.children[0]
     new_pane = pane._pane
-    assert inner_pane._callbacks == {}
     assert isinstance(new_pane, Bokeh)
     div = get_div(model)
     assert isinstance(div, Div)
     assert div.text != text
-    assert len(new_pane._callbacks) == 1
 
     # Cleanup pane
     new_pane._cleanup(row)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -552,7 +552,6 @@ def test_expand_param_subobject_tabs(document, comm):
     # Collapse subpanel
     test_pane._widgets['abc'][1].value = False
     assert len(model.tabs) == 1
-    assert subpanel._callbacks == {}
 
 
 class View(param.Parameterized):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -81,7 +81,7 @@ def test_get_root(document, comm):
         pass
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     assert isinstance(model, BkColumn)
@@ -98,7 +98,7 @@ def test_get_root_tabs(document, comm):
         pass
 
     test = Test()
-    test_pane = Pane(test, expand_layout=Tabs, _temporary=True)
+    test_pane = Pane(test, expand_layout=Tabs)
     model = test_pane._get_root(document, comm=comm)
 
     assert isinstance(model, BkTabs)
@@ -114,7 +114,7 @@ def test_number_param(document, comm):
         a = param.Number(default=1.2, bounds=(0, 5))
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
@@ -154,7 +154,7 @@ def test_boolean_param(document, comm):
         a = param.Boolean(default=False)
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     checkbox = model.children[1]
@@ -185,7 +185,7 @@ def test_range_param(document, comm):
         a = param.Range(default=(0.1, 0.5), bounds=(0, 1.1))
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     widget = model.children[1]
@@ -222,7 +222,7 @@ def test_integer_param(document, comm):
         a = param.Integer(default=2, bounds=(0, 5))
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
@@ -262,7 +262,7 @@ def test_object_selector_param(document, comm):
         a = param.ObjectSelector(default='b', objects=[1, 'b', 'c'])
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
@@ -298,7 +298,7 @@ def test_list_selector_param(document, comm):
         a = param.ListSelector(default=['b', 1], objects=[1, 'b', 'c'])
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
@@ -335,7 +335,7 @@ def test_action_param(document, comm):
         b = param.List(default=[])
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     slider = model.children[1]
@@ -348,7 +348,7 @@ def test_explicit_params(document, comm):
         b = param.Integer(default=1)
 
     test = Test()
-    test_pane = Pane(test, parameters=['a'], _temporary=True)
+    test_pane = Pane(test, parameters=['a'])
     model = test_pane._get_root(document, comm=comm)
 
     assert len(model.children) == 2
@@ -360,7 +360,7 @@ def test_param_precedence(document, comm):
         a = param.Number(default=1.2, bounds=(0, 5))
 
     test = Test()
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
 
     # Check changing precedence attribute hides and shows widget
     a_param = test.param['a']
@@ -376,7 +376,7 @@ def test_expand_param_subobject(document, comm):
         a = param.Parameter()
 
     test = Test(a=Test(name='Nested'))
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
@@ -407,7 +407,7 @@ def test_switch_param_subobject(document, comm):
     o2 = Test(name='Subobject 2')
     Test.param['a'].objects = [o1, o2, 3]
     test = Test(a=o1, name='Nested')
-    test_pane = Pane(test, _temporary=True)
+    test_pane = Pane(test)
     model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
@@ -447,7 +447,7 @@ def test_expand_param_subobject_into_row(document, comm):
 
     test = Test(a=Test(name='Nested'))
     row = Row()
-    test_pane = Pane(test, expand_layout=row, _temporary=True)
+    test_pane = Pane(test, expand_layout=row)
     layout = Row(test_pane, row)
     model = layout._get_root(document, comm=comm)
 
@@ -479,7 +479,7 @@ def test_expand_param_subobject_expand(document, comm):
         a = param.Parameter()
 
     test = Test(a=Test(name='Nested'))
-    test_pane = Pane(test, _temporary=True, expand=True, expand_button=True)
+    test_pane = Pane(test, expand=True, expand_button=True)
     model = test_pane._get_root(document, comm=comm)
 
     toggle = model.children[2]
@@ -506,7 +506,7 @@ def test_param_subobject_expand_no_toggle(document, comm):
         a = param.Parameter()
 
     test = Test(a=Test(name='Nested'))
-    test_pane = Pane(test, _temporary=True, expand=True,
+    test_pane = Pane(test, expand=True,
                      expand_button=False)
     model = test_pane._get_root(document, comm=comm)
 
@@ -525,7 +525,7 @@ def test_expand_param_subobject_tabs(document, comm):
         abc = param.Parameter()
 
     test = Test(abc=Test(name='Nested'), name='A')
-    test_pane = Pane(test, expand_layout=Tabs, _temporary=True)
+    test_pane = Pane(test, expand_layout=Tabs)
     model = test_pane._get_root(document, comm=comm)
 
     toggle = model.tabs[0].child.children[1]

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -516,7 +516,6 @@ def test_param_subobject_expand_no_toggle(document, comm):
     # Expand subpane
     _, _, subpanel = test_pane.layout.objects
     div, widget = model.children[2].children
-    assert 'instance' in subpanel._callbacks
     assert div.text == '<b>Nested</b>'
     assert isinstance(widget, BkTextInput)
     
@@ -538,7 +537,6 @@ def test_expand_param_subobject_tabs(document, comm):
     _, subpanel = test_pane.layout.objects
     subtabs = model.tabs[1].child
     assert model.tabs[1].title == 'Abc'
-    assert 'instance' in subpanel._callbacks
     assert isinstance(subtabs, BkTabs)
     assert len(subtabs.tabs) == 1
     assert subtabs.tabs[0].title == 'Nested'
@@ -628,8 +626,7 @@ def test_param_method_pane_subobject(document, comm):
     div = get_div(model)
 
     # Ensure that subobject is being watched
-    assert row.ref['id'] in pane._callbacks
-    watchers = pane._callbacks[row.ref['id']]
+    watchers = pane._callbacks
     assert any(w.inst is subobject for w in watchers)
     assert pane._models[row.ref['id']][0] is inner_row
     assert isinstance(div, Div)
@@ -639,7 +636,7 @@ def test_param_method_pane_subobject(document, comm):
     new_subobject = View(name='Nested', a=42)
     test.b = new_subobject
     assert pane._models[row.ref['id']][0] is inner_row
-    watchers = pane._callbacks[row.ref['id']]
+    watchers = pane._callbacks
     assert not any(w.inst is subobject for w in watchers)
     assert any(w.inst is new_subobject for w in watchers)
     

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -398,8 +398,6 @@ def test_expand_param_subobject(document, comm):
     # Collapse subpanel
     test_pane._widgets['a'][1].value = False
     assert len(model.children) == 3
-    assert subpanel._callbacks == {}
-
 
 
 def test_switch_param_subobject(document, comm):
@@ -613,14 +611,11 @@ def test_param_method_pane(document, comm):
     div = get_div(new_model)
     assert inner_pane is pane._pane
     assert div.text == '5'
-    assert row.ref['id'] in inner_pane._callbacks
     assert pane._models[row.ref['id']] is inner_row
 
     # Cleanup pane
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
-    assert inner_pane._callbacks == {}
     assert inner_pane._models == {}
 
 
@@ -643,7 +638,6 @@ def test_param_method_pane_subobject(document, comm):
     assert row.ref['id'] in pane._callbacks
     watchers = pane._callbacks[row.ref['id']]
     assert any(w.inst is subobject for w in watchers)
-    assert row.ref['id'] in inner_pane._callbacks
     assert pane._models[row.ref['id']] is inner_row
     assert isinstance(div, Div)
     assert div.text == '42'
@@ -651,7 +645,6 @@ def test_param_method_pane_subobject(document, comm):
     # Ensure that switching the subobject triggers update in watchers
     new_subobject = View(name='Nested', a=42)
     test.b = new_subobject
-    assert row.ref['id'] in pane._callbacks
     assert pane._models[row.ref['id']] is inner_row
     watchers = pane._callbacks[row.ref['id']]
     assert not any(w.inst is subobject for w in watchers)
@@ -678,7 +671,6 @@ def test_param_method_pane_mpl(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    assert row.ref['id'] in inner_pane._callbacks
     assert pane._models[row.ref['id']] is inner_row
     div = get_div(model)
     text = div.text
@@ -695,9 +687,7 @@ def test_param_method_pane_mpl(document, comm):
 
     # Cleanup pane
     pane._cleanup(row)
-    assert pane._callbacks == {}
     assert pane._models == {}
-    assert inner_pane._callbacks == {}
     assert inner_pane._models == {}
 
 
@@ -714,7 +704,6 @@ def test_param_method_pane_changing_type(document, comm):
     assert len(row.children) == 1
     inner_row = row.children[0]
     model = inner_row.children[0]
-    assert row.ref['id'] in inner_pane._callbacks
     
     div = get_div(model)
     text = div.text
@@ -729,11 +718,9 @@ def test_param_method_pane_changing_type(document, comm):
     assert isinstance(div, Div)
     assert div.text != text
     assert len(new_pane._callbacks) == 1
-    assert row.ref['id'] in new_pane._callbacks
 
     # Cleanup pane
     new_pane._cleanup(row)
-    assert new_pane._callbacks == {}
     assert new_pane._models == {}
 
 

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -107,5 +107,5 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     assert np.array_equal(cds2.data['y'], np.array([4, 5]))
 
     # Cleanup
-    pane._cleanup(model, True)
+    pane._cleanup(model)
     assert pane._models == {}

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -43,7 +43,7 @@ def test_plotly_pane_single_trace(document, comm):
     model = pane._get_root(document, comm=comm)
     assert isinstance(model, PlotlyPlot)
     assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'scatter'
     assert model.data['data'][0]['x'] == [0, 1]
@@ -63,7 +63,7 @@ def test_plotly_pane_single_trace(document, comm):
     assert len(model.data_sources) == 1
     assert model.data_sources[0].data == {}
     assert model.ref['id'] in pane._callbacks
-    assert pane._models[model.ref['id']] is model
+    assert pane._models[model.ref['id']][0] is model
 
     # Cleanup
     pane._cleanup(model)

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -42,7 +42,6 @@ def test_plotly_pane_single_trace(document, comm):
     # Create pane
     model = pane._get_root(document, comm=comm)
     assert isinstance(model, PlotlyPlot)
-    assert model.ref['id'] in pane._callbacks
     assert pane._models[model.ref['id']][0] is model
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'scatter'
@@ -62,12 +61,11 @@ def test_plotly_pane_single_trace(document, comm):
     assert model.data['layout'] == {'width': 350}
     assert len(model.data_sources) == 1
     assert model.data_sources[0].data == {}
-    assert model.ref['id'] in pane._callbacks
     assert pane._models[model.ref['id']][0] is model
 
     # Cleanup
     pane._cleanup(model)
-    assert pane._callbacks == {}
+    assert pane._models == {}
 
 
 @plotly_available
@@ -78,7 +76,6 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     # Create pane
     model = pane._get_root(document, comm=comm)
     assert isinstance(model, PlotlyPlot)
-    assert model.ref['id'] in pane._callbacks
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'scatter'
     assert 'x' not in model.data['data'][0]
@@ -108,8 +105,7 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     cds2 = model.data_sources[1]
     assert np.array_equal(cds2.data['x'], np.array([2, 3]))
     assert np.array_equal(cds2.data['y'], np.array([4, 5]))
-    assert model.ref['id'] in pane._callbacks
 
     # Cleanup
     pane._cleanup(model, True)
-    assert pane._callbacks == {}
+    assert pane._models == {}

--- a/panel/tests/test_plotly.py
+++ b/panel/tests/test_plotly.py
@@ -37,7 +37,7 @@ def test_get_plotly_pane_type_from_trace():
 @plotly_available
 def test_plotly_pane_single_trace(document, comm):
     trace = go.Scatter(x=[0, 1], y=[2, 3], uid='Test')
-    pane = Pane(trace, layout={'width': 350})
+    pane = Pane({'data': [trace], 'layout': {'width': 350}})
 
     # Create pane
     model = pane._get_root(document, comm=comm)
@@ -53,7 +53,7 @@ def test_plotly_pane_single_trace(document, comm):
 
     # Replace Pane.object
     new_trace = go.Bar(x=[2, 3], y=[4, 5])
-    pane.object = new_trace
+    pane.object = {'data': new_trace, 'layout': {'width': 350}}
     assert len(model.data['data']) == 1
     assert model.data['data'][0]['type'] == 'bar'
     assert model.data['data'][0]['x'] == [2, 3]
@@ -71,7 +71,7 @@ def test_plotly_pane_single_trace(document, comm):
 @plotly_available
 def test_plotly_pane_numpy_to_cds_traces(document, comm):
     trace = go.Scatter(x=np.array([1, 2]), y=np.array([2, 3]))
-    pane = Pane(trace, layout={'width': 350})
+    pane = Pane({'data': [trace], 'layout': {'width': 350}})
 
     # Create pane
     model = pane._get_root(document, comm=comm)
@@ -89,7 +89,7 @@ def test_plotly_pane_numpy_to_cds_traces(document, comm):
     # Replace Pane.object
     new_trace = [go.Scatter(x=np.array([5, 6]), y=np.array([6, 7])),
                  go.Bar(x=np.array([2, 3]), y=np.array([4, 5]))]
-    pane.object = new_trace
+    pane.object = {'data': new_trace, 'layout': {'width': 350}}
     assert len(model.data['data']) == 2
     assert model.data['data'][0]['type'] == 'scatter'
     assert 'x' not in model.data['data'][0]

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import param
 
-from bokeh.models import Div, Row as BkRow
+from bokeh.models import Div
 from panel.viewable import Reactive
 
 
@@ -40,25 +40,7 @@ def test_param_rename():
     assert params == {'a': 1}
 
     properties = obj._process_param_change({'a': 1})
-    assert properties == {'b': 1, 'min_width': None, 'min_height': None}
-
-
-def test_link_params_nb(document, comm):
-
-    class ReactiveLink(Reactive):
-
-        text = param.String(default='A')
-
-    root = BkRow()
-    obj = ReactiveLink()
-    div = Div()
-
-    # Set object parameter and assert bokeh property updates
-    obj.text = 'B'
-    assert div.text == 'B'
-
-    # Assert cleanup deletes callback
-    obj._cleanup(root, True)
+    assert properties == {'b': 1}
 
 
 def test_link_properties_nb(document, comm):

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -53,17 +53,12 @@ def test_link_params_nb(document, comm):
     obj = ReactiveLink()
     div = Div()
 
-    # Link params and ensure callback is cached
-    obj._link_params(div, ['text'], document, root, comm)
-    assert root.ref['id'] in obj._callbacks
-
     # Set object parameter and assert bokeh property updates
     obj.text = 'B'
     assert div.text == 'B'
 
     # Assert cleanup deletes callback
     obj._cleanup(root, True)
-    assert obj._callbacks == {}
 
 
 def test_link_properties_nb(document, comm):

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -21,9 +21,6 @@ def test_link():
     assert obj.a == 1
     assert obj2.a == 1
 
-    obj._cleanup(None, final=True)
-    assert obj._callbacks == {}
-
 
 def test_param_rename():
     "Test that Reactive renames params and properties"

--- a/panel/tests/test_vega.py
+++ b/panel/tests/test_vega.py
@@ -54,7 +54,7 @@ def test_vega_pane(document, comm):
     assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
 
     pane._cleanup(model)
-    assert pane._callbacks == {}
+    assert pane._models == {}
 
 
 def altair_example():
@@ -103,4 +103,4 @@ def test_altair_pane(document, comm):
     assert np.array_equal(cds_data['y'], np.array([5, 3, 6, 7, 2]))
 
     pane._cleanup(model)
-    assert pane._callbacks == {}
+    assert pane._models == {}

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -67,7 +67,6 @@ def test_widget_layout_properties(widget, document, comm):
 
 @pytest.mark.parametrize('widget', all_widgets)
 def test_widget_disabled_properties(widget, document, comm):
-
     w = widget(disabled=True)
 
     model = w._get_root(document, comm)
@@ -79,7 +78,7 @@ def test_widget_disabled_properties(widget, document, comm):
 
 @pytest.mark.parametrize('widget', all_widgets)
 def test_widget_model_cache_cleanup(widget, document, comm):
-    w = widget(disabled=True)
+    w = widget()
 
     model = w._get_root(document, comm)
 

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -51,14 +51,11 @@ def test_widget_triggers_events(document, comm):
     with block_comm():
         text.value = '123'
 
-    assert len(document._held_events) == 3
-    event_found = False
-    for event in document._held_events:
-        if event.attr == 'value':
-            assert event.model is widget
-            assert event.new == '123'
-            event_found = True
-    assert event_found
+    assert len(document._held_events) == 1
+    event = document._held_events[0]
+    assert event.attr == 'value'
+    assert event.model is widget
+    assert event.new == '123'
 
 
 def test_static_text(document, comm):

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -22,50 +22,6 @@ all_widgets = [w for w in param.concrete_descendents(Widget).values()
 
 
 @pytest.mark.parametrize('widget', all_widgets)
-def test_widget_layout_properties(widget, document, comm):
-
-    w = widget()
-
-    model = w._get_root(document, comm)
-
-    w.background = '#ffffff'
-    assert model.background == '#ffffff'
-
-    w.css_classes = ['custom_class']
-    assert model.css_classes == ['custom_class']
-
-    w.width = 500
-    assert model.width == 500
-
-    w.height = 450
-    assert model.height == 450
-
-    w.min_height = 300
-    assert model.min_height == 300
-
-    w.min_width = 250
-    assert model.min_width == 250
-
-    w.max_height = 600
-    assert model.max_height == 600
-
-    w.max_width = 550
-    assert model.max_width == 550
-
-    w.margin = 10
-    assert model.margin == (10, 10, 10, 10)
-
-    w.sizing_mode = 'stretch_width'
-    assert model.sizing_mode == 'stretch_width'
-
-    w.width_policy = 'max'
-    assert model.width_policy == 'max'
-
-    w.height_policy = 'min'
-    assert model.height_policy == 'min'
-
-
-@pytest.mark.parametrize('widget', all_widgets)
 def test_widget_disabled_properties(widget, document, comm):
     w = widget(disabled=True)
 

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -554,20 +554,25 @@ def test_discrete_slider_options_dict(document, comm):
 
 
 def test_cross_select_constructor(document, comm):
-    cross_select = CrossSelector(options=['A', 'B', 'C', 1, 2, 3], value=['A', 1])
+    cross_select = CrossSelector(options=['A', 'B', 'C', 1, 2, 3], value=['A', 1], size=5)
 
-    assert cross_select._lists[True].options == ['A', 1]
-    assert cross_select._lists[False].options == ['B', 'C', 2, 3]
+    assert cross_select._lists[True].options == ['A', '1']
+    assert cross_select._lists[False].options == ['B', 'C', '2', '3']
 
     # Change selection
     cross_select.value = ['B', 2]
-    assert cross_select._lists[True].options == {'B': 'B', '2': '2'}
-    assert cross_select._lists[False].options == {'A': 'A', 'C': 'C', '1': '1', '3': '3'}
+    assert cross_select._lists[True].options == ['B', '2']
+    assert cross_select._lists[False].options == ['A', 'C', '1', '3']
 
     # Change options
     cross_select.options = {'D': 'D', '4': 4}
-    assert cross_select._lists[True].options == {}
-    assert cross_select._lists[False].options == {'D': 'D', '4': '4'}
+    assert cross_select._lists[True].options == []
+    assert cross_select._lists[False].options == ['D', '4']
+
+    # Change size
+    cross_select.size = 5 
+    assert cross_select._lists[True].size == 5
+    assert cross_select._lists[False].size == 5
 
     # Query unselected item
     cross_select._search[False].value = 'D'
@@ -575,17 +580,17 @@ def test_cross_select_constructor(document, comm):
 
     # Move queried item
     cross_select._buttons[True].param.trigger('clicks')
-    assert cross_select._lists[False].options == {'4': '4'}
+    assert cross_select._lists[False].options == ['4']
     assert cross_select._lists[False].value == []
-    assert cross_select._lists[True].options == {'D': 'D'}
+    assert cross_select._lists[True].options == ['D']
     assert cross_select._lists[False].value == []
 
     # Query selected item
     cross_select._search[True].value = 'D'
     cross_select._buttons[False].param.trigger('clicks')
-    assert cross_select._lists[False].options == {'D': 'D', '4': '4'}
+    assert cross_select._lists[False].options == ['D', '4']
     assert cross_select._lists[False].value == ['D']
-    assert cross_select._lists[True].options == {}
+    assert cross_select._lists[True].options == []
 
     # Clear query
     cross_select._search[False].value = ''

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -220,7 +220,7 @@ def test_checkbox(document, comm):
 
 def test_select_list_constructor():
     select = Select(options=['A', 1], value=1)
-    assert select.options == {'A': 'A', '1': 1}
+    assert select.options == ['A', 1]
 
 
 def test_select(document, comm):
@@ -488,14 +488,13 @@ def test_discrete_slider(document, comm):
     assert label.text == '<b>DiscreteSlider:</b> 1'
 
     widget.value = 2
-    discrete_slider._comm_change({'value': 2})
+    discrete_slider._slider._comm_change({'value': 2})
     assert discrete_slider.value == 10
     assert label.text == '<b>DiscreteSlider:</b> 10'
 
     discrete_slider.value = 100
     assert widget.value == 3
     assert label.text == '<b>DiscreteSlider:</b> 100'
-
 
 
 def test_discrete_date_slider(document, comm):
@@ -518,14 +517,13 @@ def test_discrete_date_slider(document, comm):
     assert label.text == '<b>DiscreteSlider:</b> 2016-01-02'
 
     widget.value = 2
-    discrete_slider._comm_change({'value': 2})
+    discrete_slider._slider._comm_change({'value': 2})
     assert discrete_slider.value == dates['2016-01-03']
     assert label.text == '<b>DiscreteSlider:</b> 2016-01-03'
 
     discrete_slider.value = dates['2016-01-01']
     assert widget.value == 0
     assert label.text == '<b>DiscreteSlider:</b> 2016-01-01'
-
 
 
 def test_discrete_slider_options_dict(document, comm):
@@ -546,7 +544,7 @@ def test_discrete_slider_options_dict(document, comm):
     assert label.text == '<b>DiscreteSlider:</b> 1'
 
     widget.value = 2
-    discrete_slider._comm_change({'value': 2})
+    discrete_slider._slider._comm_change({'value': 2})
     assert discrete_slider.value == 10
     assert label.text == '<b>DiscreteSlider:</b> 10'
 
@@ -555,12 +553,11 @@ def test_discrete_slider_options_dict(document, comm):
     assert label.text == '<b>DiscreteSlider:</b> 100'
 
 
-
 def test_cross_select_constructor(document, comm):
     cross_select = CrossSelector(options=['A', 'B', 'C', 1, 2, 3], value=['A', 1])
 
-    assert cross_select._lists[True].options == {'A': 'A', '1': '1'}
-    assert cross_select._lists[False].options == {'B': 'B', 'C': 'C', '2': '2', '3': '3'}
+    assert cross_select._lists[True].options == ['A', 1]
+    assert cross_select._lists[False].options == ['B', 'C', 2, 3]
 
     # Change selection
     cross_select.value = ['B', 2]

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -616,7 +616,7 @@ class Reactive(Viewable):
             properties['min_height'] = None
         return properties
 
-    def _update_model(self, events, msg, root, model, doc, comm):
+    def _update_model(self, events, msg, root, model, doc, comm=None):
         if comm:
             for attr, new in msg.items():
                 setattr(model, attr, new)
@@ -661,8 +661,10 @@ class Reactive(Viewable):
                     cb = partial(self._update_model, events, msg, root, model, doc, comm)
                     doc.add_next_tick_callback(cb)
 
-        watcher = self.param.watch(param_change, self._synced_params())
-        self._callbacks['instance'].append(watcher)
+        params = self._synced_params()
+        if params:
+            watcher = self.param.watch(param_change, params)
+            self._callbacks['instance'].append(watcher)
 
     def _link_props(self, model, properties, doc, root, comm=None):
         if comm is None:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -237,6 +237,8 @@ class Viewable(Layoutable):
         """
         root = self._get_model(doc, comm=comm)
         self._preprocess(root)
+        ref = root.ref['id']
+        state._views[ref] = (self, root, doc, comm)
         return root
 
     def _cleanup(self, model=None, final=False):
@@ -252,6 +254,9 @@ class Viewable(Layoutable):
         """
 
     def _preprocess(self, root):
+        """
+        Applies preprocessing hooks to the model.
+        """
         for hook in self._preprocessing_hooks:
             hook(self, root)
 
@@ -260,7 +265,6 @@ class Viewable(Layoutable):
         doc = _Document()
         comm = state._comm_manager.get_server_comm()
         model = self._get_root(doc, comm)
-        state._views[model.ref['id']] = (self, model)
         return render_mimebundle(model, doc, comm)
 
     def _server_destroy(self, session_context):
@@ -514,9 +518,10 @@ class Reactive(Viewable):
     the objects parameters and the underlying bokeh model either via
     the defined pyviz_comms.Comm type or when using bokeh server.
 
-    In order to link parameters with bokeh model instances the
-    _link_params and _link_props methods may be called in the
-    _get_model method. Since there may not be a 1-to-1 mapping between
+    In order to bi-directionally link parameters with bokeh model
+    instances the _link_params and _link_props methods define
+    callbacks triggered when either the parameter or bokeh property
+    values change. Since there may not be a 1-to-1 mapping between
     parameter and the model property the _process_property_change and
     _process_param_change may be overridden to apply any necessary
     transformations.
@@ -539,6 +544,184 @@ class Reactive(Viewable):
         self._processing = False
         self._events = {}
         self._callbacks = defaultdict(list)
+        self._link_params()
+
+    def _cleanup(self, root=None, final=False):
+        super(Reactive, self)._cleanup(root, final)
+        if final:
+            watchers = self._callbacks.pop('instance', [])
+            for watcher in watchers:
+                obj = watcher.cls if watcher.inst is None else watcher.inst
+                obj.param.unwatch(watcher)
+
+        if root is None:
+            return
+
+        callbacks = self._callbacks.pop(root.ref['id'], {})
+        for watcher in callbacks:
+            obj = watcher.cls if watcher.inst is None else watcher.inst
+            obj.param.unwatch(watcher)
+
+        # Clean up comms
+        model, _ = self._models.pop(root.ref['id'], (None, None))
+        if model is None:
+            return
+
+        customjs = model.select({'type': CustomJS})
+        pattern = "data\['comm_id'\] = \"(.*)\""
+        for js in customjs:
+            comm_ids = list(re.findall(pattern, js.code))
+            if not comm_ids:
+                continue
+            comm_id = comm_ids[0]
+            comm = state._comm_manager._comms.pop(comm_id, None)
+            if comm:
+                try:
+                    comm.close()
+                except:
+                    pass
+
+    def _init_properties(self):
+        return {k: v for k, v in self.param.get_param_values()
+                if v is not None}
+
+    def _process_property_change(self, msg):
+        """
+        Transform bokeh model property changes into parameter updates.
+        Should be overridden to provide appropriate mapping between
+        parameter value and bokeh model change. By default uses the
+        _rename class level attribute to map between parameter and
+        property names.
+        """
+        inverted = {v: k for k, v in self._rename.items()}
+        return {inverted.get(k, k): v for k, v in msg.items()}
+
+    def _process_param_change(self, msg):
+        """
+        Transform parameter changes into bokeh model property updates.
+        Should be overridden to provide appropriate mapping between
+        parameter value and bokeh model change. By default uses the
+        _rename class level attribute to map between parameter and
+        property names.
+        """
+        properties = {self._rename.get(k, k): v for k, v in msg.items()
+                      if self._rename.get(k, False) is not None}
+        if 'width' in properties and self.sizing_mode is None:
+            properties['min_width'] = properties['width']
+        elif self.min_width is None:
+            properties['min_width'] = None
+        if 'height' in properties and self.sizing_mode is None:
+            properties['min_height'] = properties['height']
+        elif self.min_height is None:
+            properties['min_height'] = None
+        return properties
+
+    def _update_model(self, events, msg, root, model, doc, comm):
+        if comm:
+            for attr, new in msg.items():
+                setattr(model, attr, new)
+                event = doc._held_events[-1] if doc._held_events else None
+                if (event and event.model is model and event.attr == attr and
+                    event.new is new):
+                    continue
+                # If change did not trigger event trigger it manually
+                old = getattr(model, attr)
+                serializable_new = model.lookup(attr).serializable_value(model)
+                event = ModelChangedEvent(doc, model, attr, old, new, serializable_new)
+                _combine_document_events(event, doc._held_events)
+        else:
+            model.update(**msg)
+
+    def _synced_params(self):
+        return list(self.param)
+
+    def _link_params(self):
+
+        def param_change(*events):
+            msgs = []
+            for event in events:
+                msg = self._process_param_change({event.name: event.new})
+                if msg:
+                    msgs.append(msg)
+
+            events = {event.name: event for event in events}
+            msg = {k: v for msg in msgs for k, v in msg.items()}
+            if not msg:
+                return
+
+            for ref, (model, parent) in self._models.items():
+                if ref not in state._views:
+                    continue
+                viewable, root, doc, comm = state._views[ref]
+                if comm or state.curdoc:
+                    self._update_model(events, msg, root, model, doc, comm)
+                    if comm:
+                        push(doc, comm)
+                else:
+                    cb = partial(self._update_model, events, msg, root, model, doc, comm)
+                    doc.add_next_tick_callback(cb)
+
+        watcher = self.param.watch(param_change, self._synced_params())
+        self._callbacks['instance'].append(watcher)
+
+    def _link_props(self, model, properties, doc, root, comm=None):
+        if comm is None:
+            for p in properties:
+                model.on_change(p, partial(self._server_change, doc))
+        else:
+            client_comm = state._comm_manager.get_client_comm(on_msg=self._comm_change)
+            for p in properties:
+                customjs = self._get_customjs(p, client_comm, root.ref['id'])
+                model.js_on_change(p, customjs)
+
+    def _comm_change(self, msg):
+        if not msg:
+            return
+        self._events.update(msg)
+        self._change_event()
+
+    def _server_change(self, doc, attr, old, new):
+        self._events.update({attr: new})
+        if not self._processing:
+            self._processing = True
+            doc.add_timeout_callback(partial(self._change_event, doc), self._debounce)
+
+    def _change_event(self, doc=None):
+        try:
+            state.curdoc = doc
+            events = self._events
+            self._events = {}
+            self.set_param(**self._process_property_change(events))
+        except:
+            raise
+        else:
+            if self._events:
+                if doc:
+                    doc.add_timeout_callback(partial(self._change_event, doc), self._debounce)
+                else:
+                    self._change_event()
+        finally:
+            self._processing = False
+            state.curdoc = None
+
+    def _get_customjs(self, change, client_comm, plot_id):
+        """
+        Returns a CustomJS callback that can be attached to send the
+        model state across the notebook comms.
+        """
+        data_template = "data = {{{change}: cb_obj['{change}']}};"
+        fetch_data = data_template.format(change=change)
+        self_callback = JS_CALLBACK.format(comm_id=client_comm.id,
+                                           timeout=self._timeout,
+                                           debounce=self._debounce,
+                                           plot_id=plot_id)
+        js_callback = CustomJS(code='\n'.join([fetch_data,
+                                               self_callback]))
+        return js_callback
+
+    #----------------------------------------------------------------
+    # Public API
+    #----------------------------------------------------------------
 
     def link(self, target, callbacks=None, **links):
         """
@@ -626,159 +809,3 @@ class Reactive(Viewable):
             for k, v in list(mapping.items()):
                 mapping[k] = target._rename.get(v, v)
         return GenericLink(self, target, properties=links, code=code)
-
-    def _cleanup(self, root=None, final=False):
-        super(Reactive, self)._cleanup(root, final)
-        if final:
-            watchers = self._callbacks.pop('instance', [])
-            for watcher in watchers:
-                obj = watcher.cls if watcher.inst is None else watcher.inst
-                obj.param.unwatch(watcher)
-
-        if root is None:
-            return
-
-        callbacks = self._callbacks.pop(root.ref['id'], {})
-        for watcher in callbacks:
-            obj = watcher.cls if watcher.inst is None else watcher.inst
-            obj.param.unwatch(watcher)
-
-        # Clean up comms
-        model = self._models.pop(root.ref['id'], None)
-        if model is None:
-            return
-
-        customjs = model.select({'type': CustomJS})
-        pattern = "data\['comm_id'\] = \"(.*)\""
-        for js in customjs:
-            comm_ids = list(re.findall(pattern, js.code))
-            if not comm_ids:
-                continue
-            comm_id = comm_ids[0]
-            comm = state._comm_manager._comms.pop(comm_id, None)
-            if comm:
-                try:
-                    comm.close()
-                except:
-                    pass
-
-    def _init_properties(self):
-        return {k: v for k, v in self.param.get_param_values()
-                if v is not None}
-
-    def _process_property_change(self, msg):
-        """
-        Transform bokeh model property changes into parameter updates.
-        Should be overridden to provide appropriate mapping between
-        parameter value and bokeh model change. By default uses the
-        _rename class level attribute to map between parameter and
-        property names.
-        """
-        inverted = {v: k for k, v in self._rename.items()}
-        return {inverted.get(k, k): v for k, v in msg.items()}
-
-    def _process_param_change(self, msg):
-        """
-        Transform parameter changes into bokeh model property updates.
-        Should be overridden to provide appropriate mapping between
-        parameter value and bokeh model change. By default uses the
-        _rename class level attribute to map between parameter and
-        property names.
-        """
-        properties = {self._rename.get(k, k): v for k, v in msg.items()
-                      if self._rename.get(k, False) is not None}
-        if 'width' in properties and self.sizing_mode is None:
-            properties['min_width'] = properties['width']
-        elif self.min_width is None:
-            properties['min_width'] = None
-        if 'height' in properties and self.sizing_mode is None:
-            properties['min_height'] = properties['height']
-        elif self.min_height is None:
-            properties['min_height'] = None
-        return properties
-
-    def _link_params(self, model, params, doc, root, comm=None):
-        def param_change(*events):
-            msgs = []
-            for event in events:
-                msg = self._process_param_change({event.name: event.new})
-                if msg:
-                    msgs.append(msg)
-
-            if not msgs: return
-
-            def update_model():
-                update = {k: v for msg in msgs for k, v in msg.items()}
-                if comm:
-                    for attr, new in update.items():
-                        setattr(model, attr, new)
-                        event = doc._held_events[-1] if doc._held_events else None
-                        if (event and event.model is model and event.attr == attr and
-                            event.new is new):
-                            continue
-                        # If change did not trigger event trigger it manually
-                        old = getattr(model, attr)
-                        serializable_new = model.lookup(attr).serializable_value(model)
-                        event = ModelChangedEvent(doc, model, attr, old, new, serializable_new)
-                        _combine_document_events(event, doc._held_events)
-                else:
-                    model.update(**update)
-
-            if comm:
-                update_model()
-                push(doc, comm)
-            elif state.curdoc:
-                update_model()
-            else:
-                doc.add_next_tick_callback(update_model)
-
-        ref = root.ref['id']
-        watcher = self.param.watch(param_change, params)
-        self._callbacks[ref].append(watcher)
-
-    def _link_props(self, model, properties, doc, root, comm=None):
-        if comm is None:
-            for p in properties:
-                model.on_change(p, partial(self._server_change, doc))
-        else:
-            client_comm = state._comm_manager.get_client_comm(on_msg=self._comm_change)
-            for p in properties:
-                customjs = self._get_customjs(p, client_comm, root.ref['id'])
-                model.js_on_change(p, customjs)
-
-    def _comm_change(self, msg):
-        if not msg:
-            return
-        self._events.update(msg)
-        self._change_event()
-
-    def _server_change(self, doc, attr, old, new):
-        self._events.update({attr: new})
-        if not self._processing:
-            self._processing = True
-            doc.add_timeout_callback(partial(self._change_event, doc), self._debounce)
-
-    def _change_event(self, doc=None):
-        try:
-            state.curdoc = doc
-            events = self._events
-            self._events = {}
-            self.set_param(**self._process_property_change(events))
-        finally:
-            self._processing = False
-            state.curdoc = None
-
-    def _get_customjs(self, change, client_comm, plot_id):
-        """
-        Returns a CustomJS callback that can be attached to send the
-        model state across the notebook comms.
-        """
-        data_template = "data = {{{change}: cb_obj['{change}']}};"
-        fetch_data = data_template.format(change=change)
-        self_callback = JS_CALLBACK.format(comm_id=client_comm.id,
-                                           timeout=self._timeout,
-                                           debounce=self._debounce,
-                                           plot_id=plot_id)
-        js_callback = CustomJS(code='\n'.join([fetch_data,
-                                               self_callback]))
-        return js_callback

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -581,41 +581,6 @@ class Reactive(Viewable):
                 except:
                     pass
 
-    def _init_properties(self):
-        return {k: v for k, v in self.param.get_param_values()
-                if v is not None}
-
-    def _process_property_change(self, msg):
-        """
-        Transform bokeh model property changes into parameter updates.
-        Should be overridden to provide appropriate mapping between
-        parameter value and bokeh model change. By default uses the
-        _rename class level attribute to map between parameter and
-        property names.
-        """
-        inverted = {v: k for k, v in self._rename.items()}
-        return {inverted.get(k, k): v for k, v in msg.items()}
-
-    def _process_param_change(self, msg):
-        """
-        Transform parameter changes into bokeh model property updates.
-        Should be overridden to provide appropriate mapping between
-        parameter value and bokeh model change. By default uses the
-        _rename class level attribute to map between parameter and
-        property names.
-        """
-        properties = {self._rename.get(k, k): v for k, v in msg.items()
-                      if self._rename.get(k, False) is not None}
-        if 'width' in properties and self.sizing_mode is None:
-            properties['min_width'] = properties['width']
-        elif self.min_width is None:
-            properties['min_width'] = None
-        if 'height' in properties and self.sizing_mode is None:
-            properties['min_height'] = properties['height']
-        elif self.min_height is None:
-            properties['min_height'] = None
-        return properties
-
     def _update_model(self, events, msg, root, model, doc, comm=None):
         if comm:
             for attr, new in msg.items():
@@ -636,7 +601,6 @@ class Reactive(Viewable):
         return list(self.param)
 
     def _link_params(self):
-
         def param_change(*events):
             msgs = []
             for event in events:
@@ -720,6 +684,41 @@ class Reactive(Viewable):
         js_callback = CustomJS(code='\n'.join([fetch_data,
                                                self_callback]))
         return js_callback
+
+    #----------------------------------------------------------------
+    # Developer API
+    #----------------------------------------------------------------
+
+    def _init_properties(self):
+        return {k: v for k, v in self.param.get_param_values()
+                if v is not None}
+
+    def _process_property_change(self, msg):
+        """
+        Transform bokeh model property changes into parameter updates.
+        Should be overridden to provide appropriate mapping between
+        parameter value and bokeh model change. By default uses the
+        _rename class level attribute to map between parameter and
+        property names.
+        """
+        inverted = {v: k for k, v in self._rename.items()}
+        return {inverted.get(k, k): v for k, v in msg.items()}
+
+    def _process_param_change(self, msg):
+        """
+        Transform parameter changes into bokeh model property updates.
+        Should be overridden to provide appropriate mapping between
+        parameter value and bokeh model change. By default uses the
+        _rename class level attribute to map between parameter and
+        property names.
+        """
+        properties = {self._rename.get(k, k): v for k, v in msg.items()
+                      if self._rename.get(k, False) is not None}
+        if 'width' in properties and self.sizing_mode is None:
+            properties['min_width'] = properties['width']
+        if 'height' in properties and self.sizing_mode is None:
+            properties['min_height'] = properties['height']
+        return properties
 
     #----------------------------------------------------------------
     # Public API

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -241,7 +241,7 @@ class Viewable(Layoutable):
         state._views[ref] = (self, root, doc, comm)
         return root
 
-    def _cleanup(self, model=None, final=False):
+    def _cleanup(self, model):
         """
         Clean up method which is called when a Viewable is destroyed.
 
@@ -249,8 +249,6 @@ class Viewable(Layoutable):
         ----------
         model: bokeh.model.Model
           Bokeh model for the view being cleaned up
-        final: boolean
-          Whether the Viewable should be destroyed entirely
         """
 
     def _preprocess(self, root):
@@ -272,7 +270,7 @@ class Viewable(Layoutable):
         Server lifecycle hook triggered when session is destroyed.
         """
         doc = session_context._document
-        self._cleanup(self._documents[doc], final=self._temporary)
+        self._cleanup(self._documents[doc])
         del self._documents[doc]
 
     def _modify_doc(self, server_id, doc):
@@ -546,16 +544,8 @@ class Reactive(Viewable):
         self._callbacks = defaultdict(list)
         self._link_params()
 
-    def _cleanup(self, root=None, final=False):
-        super(Reactive, self)._cleanup(root, final)
-        if final:
-            watchers = self._callbacks.pop('instance', [])
-            for watcher in watchers:
-                obj = watcher.cls if watcher.inst is None else watcher.inst
-                obj.param.unwatch(watcher)
-
-        if root is None:
-            return
+    def _cleanup(self, root):
+        super(Reactive, self)._cleanup(root)
 
         callbacks = self._callbacks.pop(root.ref['id'], {})
         for watcher in callbacks:

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -4,7 +4,7 @@ communication between a rendered panel and the Widget parameters.
 """
 from __future__ import absolute_import, division, unicode_literals
 
-from .base import Widget # noqa
+from .base import Widget, CompositeWidget # noqa
 from .button import Button, Toggle # noqa
 from .input import ( # noqa
     ColorPicker, Checkbox, DatetimeInput, DatePicker, FileInput,

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -41,10 +41,8 @@ class Widget(Reactive):
         if root is None:
             root = model
         # Link parameters and bokeh model
-        params = list(self.param)
         values = dict(self.get_param_values())
         properties = list(self._process_param_change(values))
-        self._models[root.ref['id']] = model
-        self._link_params(model, params, doc, root, comm)
+        self._models[root.ref['id']] = (model, parent)
         self._link_props(model, properties, doc, root, comm)
         return model

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -46,3 +46,12 @@ class Widget(Reactive):
         self._models[root.ref['id']] = (model, parent)
         self._link_props(model, properties, doc, root, comm)
         return model
+
+
+class CompositeWidget(Widget):
+    """
+    A baseclass for widgets which are made up of two or more other
+    widgets
+    """
+
+    __abstract = True

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -18,6 +18,8 @@ class _ButtonBase(Widget):
 
     _rename = {'name': 'label'}
 
+    __abstract = True
+
 
 class Button(_ButtonBase):
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -84,6 +84,8 @@ class StaticText(Widget):
 
     _format = '<b>{title}</b>: {value}'
 
+    _rename = {'name': 'title', 'value': 'text'}
+
     def _process_param_change(self, msg):
         msg = super(StaticText, self)._process_property_change(msg)
         msg.pop('title', None)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -97,7 +97,6 @@ class StaticText(Widget):
         return msg
 
 
-
 class DatePicker(Widget):
 
     value = param.Date(default=None)
@@ -127,14 +126,13 @@ class ColorPicker(Widget):
     _rename = {'value': 'color', 'name': 'title'}
 
 
-
 class LiteralInput(Widget):
     """
     LiteralInput allows declaring Python literals using a text
     input widget. Optionally a type may be declared.
     """
 
-    type = param.ClassSelector(default=None, class_=type,
+    type = param.ClassSelector(default=None, class_=(type, tuple),
                                is_instance=True)
 
     value = param.Parameter(default=None)
@@ -153,9 +151,10 @@ class LiteralInput(Widget):
         if not isinstance(new, self.type):
             if event:
                 self.value = event.old
+            types = repr(self.type) if isinstance(self.type, tuple) else self.type.__name__
             raise ValueError('LiteralInput expected %s type but value %s '
                              'is of type %s.' %
-                             (self.type.__name__, new, type(new).__name__))
+                             (types, new, type(new).__name__))
 
     def _process_property_change(self, msg):
         msg = super(LiteralInput, self)._process_property_change(msg)

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -22,7 +22,7 @@ class PlayerBase(Widget):
     step = param.Integer(default=1, doc="""
        Number of frames to step forward and back by on each event.""")
 
-    height = param.Integer(default=250)
+    height = param.Integer(default=80)
 
     _widget_type = _BkPlayer
 
@@ -56,7 +56,7 @@ class Player(PlayerBase):
         super(Player, self).__init__(**params)
 
 
-class DiscretePlayer(SelectBase, PlayerBase):
+class DiscretePlayer(PlayerBase, SelectBase):
     """
     The DiscretePlayer provides controls to iterate through a list of
     discrete options.  The speed at which the widget plays is defined

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -6,7 +6,9 @@ from __future__ import absolute_import, division, unicode_literals
 import param
 
 from ..models.widgets import Player as _BkPlayer
+from ..util import hashable
 from .base import Widget
+from .select import SelectBase
 
 
 class PlayerBase(Widget):
@@ -20,7 +22,7 @@ class PlayerBase(Widget):
     step = param.Integer(default=1, doc="""
        Number of frames to step forward and back by on each event.""")
 
-    height = param.Integer(default=250, readonly=True)
+    height = param.Integer(default=250)
 
     _widget_type = _BkPlayer
 
@@ -54,7 +56,7 @@ class Player(PlayerBase):
         super(Player, self).__init__(**params)
 
 
-class DiscretePlayer(PlayerBase):
+class DiscretePlayer(SelectBase, PlayerBase):
     """
     The DiscretePlayer provides controls to iterate through a list of
     discrete options.  The speed at which the widget plays is defined
@@ -63,34 +65,28 @@ class DiscretePlayer(PlayerBase):
 
     interval = param.Integer(default=500, doc="Interval between updates")
 
-    options = param.ClassSelector(default=[], class_=(dict, list))
-
     value = param.Parameter()
 
     _rename = {'name': None, 'options': None}
 
     def _process_param_change(self, msg):
-        options = msg.get('options', self.options)
-        if isinstance(options, list):
-            values = options
-        else:
-            values = list(options.values())
+        values = [hashable(v) for v in self.values]
         if 'options' in msg:
             msg['start'] = 0
-            msg['end'] = len(options) - 1
-            if self.value not in values:
+            msg['end'] = len(values) - 1
+            if values and self.value not in values:
                 self.value = values[0]
         if 'value' in msg:
-            value = msg['value']
-            msg['value'] = values.index(value)
+            value = hashable(msg['value'])
+            if hashable(value) in values:
+                msg['value'] = values.index(value)
+            elif values:
+                self.value = values[0]
         return super(DiscretePlayer, self)._process_param_change(msg)
 
     def _process_property_change(self, msg):
-        options = self.options
-        if isinstance(options, list):
-            values = options
-        else:
-            values = list(options.values())
         if 'value' in msg:
-            msg['value'] = values[msg['value']]
+            value = msg.pop('value')
+            if value < len(self.options):
+                msg['value'] = self.values[value]
         return msg

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -115,7 +115,8 @@ class MultiSelect(Select):
     def _process_property_change(self, msg):
         msg = super(Select, self)._process_property_change(msg)
         if 'value' in msg:
-            msg['value'] = [self.items[v] for v in msg['value']]
+            msg['value'] = [self.items[v] for v in msg['value']
+                            if v in self.labels]
         msg.pop('options', None)
         return msg
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -42,7 +42,7 @@ class SelectBase(Widget):
             return self.options
 
     @property
-    def items(self):
+    def _items(self):
         return dict(zip(self.labels, self.values))
 
 
@@ -60,7 +60,7 @@ class Select(SelectBase):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        mapping = {hashable(v): k for k, v in self.items.items()}
+        mapping = {hashable(v): k for k, v in self._items.items()}
         if 'value' in msg:
             hash_val = hashable(msg['value'])
             if hash_val in mapping:
@@ -84,7 +84,7 @@ class Select(SelectBase):
             elif msg['value'] is None:
                 msg['value'] = self.values[0]
             else:
-                msg['value'] = self.items[msg['value']]
+                msg['value'] = self._items[msg['value']]
         msg.pop('options', None)
         return msg
 
@@ -101,7 +101,7 @@ class MultiSelect(Select):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        mapping = {hashable(v): k for k, v in self.items.items()}
+        mapping = {hashable(v): k for k, v in self._items.items()}
         if 'value' in msg:
             msg['value'] = [mapping[hashable(v)] for v in msg['value']
                             if hashable(v) in mapping]
@@ -115,7 +115,7 @@ class MultiSelect(Select):
     def _process_property_change(self, msg):
         msg = super(Select, self)._process_property_change(msg)
         if 'value' in msg:
-            msg['value'] = [self.items[v] for v in msg['value']
+            msg['value'] = [self._items[v] for v in msg['value']
                             if v in self.labels]
         msg.pop('options', None)
         return msg
@@ -140,7 +140,7 @@ class _RadioGroupBase(Select):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        values = [hashable(v) for v in self.items.values()]
+        values = [hashable(v) for v in self._items.values()]
         if 'value' in msg:
             value = hashable(msg.pop('value'))
             if value in values:
@@ -191,7 +191,7 @@ class _CheckGroupBase(Select):
 
     def _process_param_change(self, msg):
         msg = super(Select, self)._process_param_change(msg)
-        values = [hashable(v) for v in self.items.values()]
+        values = [hashable(v) for v in self._items.values()]
         if 'value' in msg:
             msg['active'] = [values.index(hashable(v)) for v in msg.pop('value')
                              if hashable(v) in values]
@@ -291,7 +291,7 @@ class CrossSelector(CompositeWidget, MultiSelect):
         super(CrossSelector, self).__init__(**kwargs)
         # Compute selected and unselected values
 
-        mapping = {hashable(v): k for k, v in self.items.items()}
+        mapping = {hashable(v): k for k, v in self._items.items()}
         selected = [mapping[hashable(v)] for v in kwargs.get('value', [])]
         unselected = [k for k in self.labels if k not in selected]
 
@@ -366,7 +366,7 @@ class CrossSelector(CompositeWidget, MultiSelect):
 
     @param.depends('value', watch=True)
     def _update_value(self):
-        mapping = {hashable(v): k for k, v in self.items.items()}
+        mapping = {hashable(v): k for k, v in self._items.items()}
         selected = [mapping[hashable(v)] for v in self.value]
         unselected = [k for k in self.labels if k not in selected]
         self._lists[True].options = selected

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -105,7 +105,6 @@ class MultiSelect(Select):
 
         if 'options' in msg:
             msg['options'] = self.labels
-            hash_val = hashable(self.value)
             if any(hashable(v) not in mapping for v in self.value):
                 self.value = [v for v in self.value if hashable(v) in mapping]
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -93,6 +93,9 @@ class DiscreteSlider(_SliderBase):
     formatter = param.String(default='%.3g')
 
     def __init__(self, **params):
+        self._processing = False
+        self._text = StaticText()
+        self._slider = IntSlider()
         super(DiscreteSlider, self).__init__(**params)
         if 'formatter' not in params and all(isinstance(v, (int, np.int_)) for v in self.values):
             self.formatter = '%d'
@@ -104,9 +107,6 @@ class DiscreteSlider(_SliderBase):
                              'is one of the declared options.'
                              % self.value)
 
-        self._processing = False
-        self._text = StaticText()
-        self._slider = IntSlider()
         self._composite = Column(self._text, self._slider)
         self._update_value()
         self._update_options()


### PR DESCRIPTION
Instead of creating callbacks per bokeh model this PR creates single callbacks on instantiation which update all existing models.

Fixes #292 

- [x] Ensure all Select widgets allow both list and dict
- [x] Update ParamMethod pane
- [x] Update CrossSelector
- [x] Simplify _callbacks
- [x] Remove final flag on cleanup
- [x] Ensure correct parameters are watched
- [x] Write tests for HoloViews pane, updating of backend parameter, more tests
- [x] Add dedicated cleanup tests