### PR TITLE
Ensure events do not bounce between server and client

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -113,7 +113,7 @@ class PaneBase(Reactive):
     def _update_pane(self, event):
         for ref, (model, parent) in self._models.items():
             viewable, root, doc, comm = state._views[ref]
-            if comm or state.curdoc:
+            if comm or doc is state.curdoc:
                 self._update_object(model, doc, root, parent, comm)
                 if comm:
                     push(doc, comm)

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -92,7 +92,7 @@ class HoloViews(PaneBase):
             key = tuple(w.value for w in widgets)
 
         if isinstance(plot, BokehPlot):
-            if plot.comm or state.curdoc:
+            if plot.comm or plot.document is state.curdoc:
                 plot.update(key)
                 if plot.comm:
                     plot.push()

--- a/panel/util.py
+++ b/panel/util.py
@@ -289,6 +289,21 @@ LOAD_MIME = 'application/vnd.holoviews_load.v0+json'
 EXEC_MIME = 'application/vnd.holoviews_exec.v0+json'
 HTML_MIME = 'text/html'
 
+ABORT_JS = """
+if (!window.PyViz) {{
+  return;
+}}
+var receiver = window.PyViz.receivers['{plot_id}'];
+var events = receiver ? receiver._partial.content.events : [];
+for (var event of events) {{
+  if ((event.kind == 'ModelChanged') && (event.attr == '{change}') &&
+      (cb_obj.id == event.model.id) &&
+      (cb_obj['{change}'] == event.new)) {{
+    events.pop(events.indexOf(event))
+    return;
+  }}
+}}
+"""
 
 def load_notebook(inline=True):
     from IPython.display import publish_display_data

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -22,7 +22,7 @@ from pyviz_comms import JS_CALLBACK, JupyterCommManager
 
 from .io import state
 from .util import (render_mimebundle, add_to_doc, push, param_reprs,
-                   _origin_url, show_server)
+                   _origin_url, show_server, ABORT_JS)
 
 
 class Layoutable(param.Parameterized):
@@ -539,6 +539,7 @@ class Reactive(Viewable):
         super(Reactive, self).__init__(**params)
         self._processing = False
         self._events = {}
+        self._changing = {}
         self._callbacks = []
         self._link_params()
 
@@ -548,7 +549,17 @@ class Reactive(Viewable):
 
     def _update_model(self, events, msg, root, model, doc, comm=None):
         if comm:
-            for attr, new in msg.items():
+            filtered = {}
+            for k, v in msg.items():
+                try:
+                    change = (k not in self._changing or
+                              self._changing[k] != v or
+                              self._changing['id'] != model.ref['id'])
+                except:
+                    change = True
+                if change:
+                    filtered[k] = v
+            for attr, new in filtered.items():
                 setattr(model, attr, new)
                 event = doc._held_events[-1] if doc._held_events else None
                 if (event and event.model is model and event.attr == attr and
@@ -605,8 +616,13 @@ class Reactive(Viewable):
     def _comm_change(self, msg):
         if not msg:
             return
+        self._changing.update(msg)
+        msg.pop('id', None)
         self._events.update(msg)
-        self._change_event()
+        try:
+            self._change_event()
+        finally:
+            self._changing = {}
 
     def _server_change(self, doc, attr, old, new):
         self._events.update({attr: new})
@@ -638,18 +654,8 @@ class Reactive(Viewable):
         model state across the notebook comms.
         """
         # Abort callback if value matches last received event
-        abort = """
-        const receiver = window.PyViz.receivers['{plot_id}'];
-        const events = receiver ? receiver._partial.content.events : [];
-        for (let event of events) {{
-          if ((event.kind == 'ModelChanged') && (event.attr == '{change}') &&
-              (cb_obj.id == event.model.id) &&
-              (cb_obj['{change}'] == event.new)) {{
-            return;
-          }}
-        }}
-        """.format(plot_id=plot_id, change=change)
-        data_template = "data = {{{change}: cb_obj['{change}']}};"
+        abort = ABORT_JS.format(plot_id=plot_id, change=change)
+        data_template = "data = {{{change}: cb_obj['{change}'], 'id': cb_obj.id}};"
         fetch_data = data_template.format(change=change)
         self_callback = JS_CALLBACK.format(comm_id=client_comm.id,
                                            timeout=self._timeout,

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -537,7 +537,7 @@ class Reactive(Viewable):
         # temporary flag denotes panes created for temporary, internal
         # use which should be garbage collected once they have been used
         super(Reactive, self).__init__(**params)
-        self._processing = False
+        self._processing = True
         self._events = {}
         self._changing = {}
         self._callbacks = []
@@ -590,7 +590,7 @@ class Reactive(Viewable):
                 if ref not in state._views:
                     continue
                 viewable, root, doc, comm = state._views[ref]
-                if comm or state.curdoc:
+                if comm or doc is state.curdoc:
                     self._update_model(events, msg, root, model, doc, comm)
                     if comm:
                         push(doc, comm)
@@ -638,12 +638,6 @@ class Reactive(Viewable):
             self.set_param(**self._process_property_change(events))
         except:
             raise
-        else:
-            if self._events:
-                if doc:
-                    doc.add_timeout_callback(partial(self._change_event, doc), self._debounce)
-                else:
-                    self._change_event()
         finally:
             self._processing = False
             state.curdoc = None

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -97,7 +97,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
     _rename = {'formatter': None}
 
     def __init__(self, **params):
-        self._processing = False
+        self._syncing = False
         self._text = StaticText()
         self._slider = IntSlider()
         super(DiscreteSlider, self).__init__(**params)
@@ -124,13 +124,13 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
             return
         index = self.values.index(self.value)
         self._text.value = labels[index]
-        if self._processing:
+        if self._syncing:
             return
         try:
-            self._processing = True
+            self._syncing = True
             self._slider.value = index
         finally:
-            self._processing = False
+            self._syncing = False
 
     @param.depends('options', watch=True)
     def _update_options(self):
@@ -141,13 +141,13 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
             self.value = values[0]
 
     def _sync_value(self, event):
-        if self._processing:
+        if self._syncing:
             return
         try:
             self._processing = True
             self.value = self.values[event.new]
         finally:
-            self._processing = False
+            self._syncing = False
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         return self._composite._get_model(doc, root, parent, comm)


### PR DESCRIPTION
Ensures that only the models that need it are updated across servers and notebook views.

Here is a demo of a bunch of synced views all updating each other:

![multi_view_sync](https://user-images.githubusercontent.com/1550771/54166121-912f0000-445b-11e9-9512-1a218a5ce3bb.gif)
