### PR TITLE
Add support for saving and loading embedded data from JSON

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
-  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup && conda install %CHANS_DEV% param --yes"
+  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
   - "doit develop_install -o recommended -o tests %CHANS_DEV%"
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
-  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
+  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup && conda install %CHANS_DEV% param --yes"
   - "doit develop_install -o recommended -o tests %CHANS_DEV%"
 
 build: off

--- a/panel/io.py
+++ b/panel/io.py
@@ -134,9 +134,9 @@ class _config(param.Parameterized):
     def inline(self, value):
         self._inline = value
 
-
+_params = _config.param.objects() if hasattr(_config.param, 'objects') else _config.params()
 config = _config(**{k: None if p.allow_None else getattr(_config, k)
-                    for k, p in _config.param.objects().items() if k != 'name'})
+                    for k, p in _params.items() if k != 'name'})
 
 
 class state(param.Parameterized):

--- a/panel/io.py
+++ b/panel/io.py
@@ -302,7 +302,7 @@ def add_to_doc(obj, doc, hold=False):
 def record_events(doc):
     msg = diff(doc, False)
     if msg is None:
-        return {}
+        return {'header': '{}', 'metadata': '{}', 'content': '{}'}
     return {'header': msg.header_json, 'metadata': msg.metadata_json,
             'content': msg.content_json}
 

--- a/panel/io.py
+++ b/panel/io.py
@@ -16,7 +16,6 @@ from itertools import product
 import param
 import bokeh
 import bokeh.embed.notebook
-import numpy as np
 
 from bokeh.document import Document
 from bokeh.core.templates import DOC_NB_JS
@@ -98,7 +97,7 @@ class _config(param.Parameterized):
         else:
             return os.environ.get('PANEL_EMBED_JSON', _config._embed_json) in self._truthy
 
-    @embed.setter
+    @embed_json.setter
     def embed_json(self, value):
         self._embed_json = value
 
@@ -109,7 +108,7 @@ class _config(param.Parameterized):
         else:
             return os.environ.get('PANEL_EMBED_SAVE_PATH', _config._embed_save_path) in self._truthy
 
-    @embed.setter
+    @embed_save_path.setter
     def embed_save_path(self, value):
         self._embed_save_path = value
 
@@ -120,7 +119,7 @@ class _config(param.Parameterized):
         else:
             return os.environ.get('PANEL_EMBED_LOAD_PATH', _config._embed_load_path) in self._truthy
 
-    @embed.setter
+    @embed_load_path.setter
     def embed_load_path(self, value):
         self._embed_load_path = value
 
@@ -337,10 +336,8 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
     load_path: str (default=None)
       The path or URL the json files will be loaded from.
     """
-    from .layout import Panel
     from .models.state import State
     from .widgets import Widget, DiscreteSlider
-    from .widgets.slider import _SliderBase
 
     target = model.ref['id']
     _, _, _, comm = state._views[target]

--- a/panel/models/state.py
+++ b/panel/models/state.py
@@ -1,13 +1,15 @@
 import os
 
 from bokeh.models import Model
-from bokeh.core.properties import Dict, Any, List
+from bokeh.core.properties import Bool, Dict, Any, List
 
 from ..util import CUSTOM_MODELS
 
 class State(Model):
 
     __implementation__ = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'state.ts')
+
+    json = Bool(False, help="Whether the values point to json files")
 
     state = Dict(Any, Any, help="Contains the recorded state")
 

--- a/panel/models/state.ts
+++ b/panel/models/state.ts
@@ -2,6 +2,19 @@ import * as p from "core/properties"
 import {View} from "core/view"
 import {copy} from "core/util/array"
 import {Model} from "model"
+import {Receiver} from "protocol/receiver"
+
+function get_json(file: string, callback: any): void {
+  var xobj = new XMLHttpRequest();
+  xobj.overrideMimeType("application/json");
+  xobj.open('GET', file, true);
+  xobj.onreadystatechange = function () {
+    if (xobj.readyState == 4 && xobj.status == 200) {
+      callback(xobj.responseText);
+    }
+  };
+  xobj.send(null);
+}
 
 export class StateView extends View {
   model: State
@@ -14,6 +27,7 @@ export namespace State {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = Model.Props & {
+    json: p.Property<boolean>
     state: p.Property<object>
     values: p.Property<any[]>
     widgets: p.Property<{[key: string]: number}>
@@ -24,12 +38,31 @@ export interface State extends State.Attrs {}
 
 export class State extends Model {
   properties: State.Props
+  _receiver: Receiver
+  _cache: {[key: string]: string}
 
   constructor(attrs?: Partial<State.Attrs>) {
     super(attrs)
+    this._receiver = new Receiver()
+    this._cache = {}
   }
 
-  get_state(widget: any): void {
+  apply_state(state: any): void {
+    this._receiver.consume(state.header)
+    this._receiver.consume(state.metadata)
+    this._receiver.consume(state.content)
+    if (this._receiver.message && this.document) {
+      this.document.apply_json_patch(this._receiver.message.content)
+    }
+  }
+
+  _receive_json(result: string, path: string): void {
+    const state = JSON.parse(result)
+    this._cache[path] = state
+    this.apply_state(state)
+  }
+
+  set_state(widget: any): void {
     let values: any[] = copy(this.values)
     const index: any = this.widgets[widget.id]
     values[index] = widget.value
@@ -38,14 +71,23 @@ export class State extends Model {
       state = state[i]
     }
     this.values = values
-    return state
+    if (this.json) {
+      if (this._cache[state]) {
+        this.apply_state(this._cache[state])
+      } else {
+        get_json(state, (result: string) => this._receive_json(result, state))
+      }
+    } else {
+      this.apply_state(state)
+    }
   }
-  
+
   static initClass(): void {
     this.prototype.type = "State"
     this.prototype.default_view = StateView
 
     this.define<State.Props>({
+      json:    [ p.Boolean, false ],
       state:   [ p.Any, {}        ],
       widgets: [ p.Any, {}        ],
       values:  [ p.Any, []        ],

--- a/panel/models/state.ts
+++ b/panel/models/state.ts
@@ -62,10 +62,10 @@ export class State extends Model {
     this.apply_state(state)
   }
 
-  set_state(widget: any): void {
+  set_state(widget: any, value: any): void {
     let values: any[] = copy(this.values)
     const index: any = this.widgets[widget.id]
-    values[index] = widget.value
+    values[index] = value
     let state: any = this.state
     for (const i of values) {
       state = state[i]

--- a/panel/tests/fixtures.py
+++ b/panel/tests/fixtures.py
@@ -1,3 +1,6 @@
+import re
+import shutil
+    
 import pytest
 
 import numpy as np
@@ -42,3 +45,16 @@ def mpl_figure():
     ax.plot(np.random.rand(10, 2))
     plt.close(fig)
     return fig
+
+
+@pytest.yield_fixture
+def tmpdir(request, tmpdir_factory):
+    name = request.node.name
+    name = re.sub("[\W]", "_", name)
+    MAXVAL = 30
+    if len(name) > MAXVAL:
+        name = name[:MAXVAL]
+    tmp_dir = tmpdir_factory.mktemp(name, numbered=True)
+    yield tmp_dir
+    shutil.rmtree(tmp_dir)
+

--- a/panel/tests/fixtures.py
+++ b/panel/tests/fixtures.py
@@ -56,5 +56,5 @@ def tmpdir(request, tmpdir_factory):
         name = name[:MAXVAL]
     tmp_dir = tmpdir_factory.mktemp(name, numbered=True)
     yield tmp_dir
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(str(tmp_dir))
 

--- a/panel/tests/test_io.py
+++ b/panel/tests/test_io.py
@@ -2,6 +2,8 @@ import os
 import json
 import glob
 
+from io import StringIO
+
 from panel import Row
 from panel.io import config, embed_state
 from panel.pane import Str
@@ -73,6 +75,19 @@ def test_embed_checkbox(document, comm):
         assert event['attr'] == 'text'
         assert event['model'] == model.children[1].ref
         assert event['new'] == '<pre>%s</pre>' % k
+
+
+def test_save_embed_bytesio(tmpdir):
+    checkbox = Checkbox()
+    string = Str()
+    checkbox.link(string, value='object')
+    panel = Row(checkbox, string)
+    stringio = StringIO()
+    panel.save(stringio, embed=True)
+    stringio.seek(0)
+    utf = stringio.read()
+    assert "&lt;pre&gt;False&lt;" in utf
+    assert "&lt;pre&gt;True&lt;" in utf
 
 
 def test_save_embed(tmpdir):

--- a/panel/tests/test_io.py
+++ b/panel/tests/test_io.py
@@ -3,13 +3,13 @@ import json
 from panel import Row
 from panel.io import config, embed_state
 from panel.pane import Str
-from panel.widgets import Select, FloatSlider
+from panel.widgets import Select, FloatSlider, Checkbox
 
 
 def test_embed_discrete(document, comm):
     select = Select(options=['A', 'B', 'C'])
     string = Str()
-    select.link(string, value='text')
+    select.link(string, value='object')
     panel = Row(select, string)
     with config.set(embed=True):
         model = panel._get_root(document, comm)
@@ -17,30 +17,57 @@ def test_embed_discrete(document, comm):
     _, state = document.roots
     assert set(state.state) == {'A', 'B', 'C'}
     for k, v in state.state.items():
-        events = json.loads(v['content'])['events']
+        content = json.loads(v['content'])
+        assert 'events' in content
+        events = content['events']
         assert len(events) == 1
         event = events[0]
         assert event['kind'] == 'ModelChanged'
-        assert event['attr'] == 'value'
-        assert event['model'] == model.children[0].ref
-        assert event['new'] == k
+        assert event['attr'] == 'text'
+        assert event['model'] == model.children[1].ref
+        assert event['new'] == '<pre>%s</pre>' % k
 
 
 def test_embed_continuous(document, comm):
     select = FloatSlider(start=0, end=10)
     string = Str()
-    select.link(string, value='text')
+    select.link(string, value='object')
     panel = Row(select, string)
     with config.set(embed=True):
         model = panel._get_root(document, comm)
     embed_state(panel, model, document)
     _, state = document.roots
     assert set(state.state) == {0, 1, 2}
+    values = [0, 5, 10]
     for k, v in state.state.items():
-        events = json.loads(v['content'])['events']
+        content = json.loads(v['content'])
+        assert 'events' in content
+        events = content['events']
         assert len(events) == 1
         event = events[0]
         assert event['kind'] == 'ModelChanged'
-        assert event['attr'] == 'value'
-        assert event['model'] == model.children[0].children[1].ref
-        assert event['new'] == k
+        assert event['attr'] == 'text'
+        assert event['model'] == model.children[1].ref
+        assert event['new'] == '<pre>%.1f</pre>' % values[k]
+
+
+def test_embed_checkbox(document, comm):
+    checkbox = Checkbox(start=0, end=10)
+    string = Str()
+    checkbox.link(string, value='object')
+    panel = Row(checkbox, string)
+    with config.set(embed=True):
+        model = panel._get_root(document, comm)
+    embed_state(panel, model, document)
+    _, state = document.roots
+    assert set(state.state) == {True, False}
+    for k, v in state.state.items():
+        content = json.loads(v['content'])
+        assert 'events' in content
+        events = content['events']
+        assert len(events) == 1
+        event = events[0]
+        assert event['kind'] == 'ModelChanged'
+        assert event['attr'] == 'text'
+        assert event['model'] == model.children[1].ref
+        assert event['new'] == '<pre>%s</pre>' % k

--- a/panel/tests/test_io.py
+++ b/panel/tests/test_io.py
@@ -77,7 +77,7 @@ def test_embed_checkbox(document, comm):
         assert event['new'] == '<pre>%s</pre>' % k
 
 
-def test_save_embed_bytesio(tmpdir):
+def test_save_embed_bytesio():
     checkbox = Checkbox()
     string = Str()
     checkbox.link(string, value='object')
@@ -95,7 +95,7 @@ def test_save_embed(tmpdir):
     string = Str()
     checkbox.link(string, value='object')
     panel = Row(checkbox, string)
-    filename = os.path.join(tmpdir, 'test.html')
+    filename = os.path.join(str(tmpdir), 'test.html')
     panel.save(filename, embed=True)
     assert os.path.isfile(filename)
 
@@ -105,11 +105,11 @@ def test_save_embed_json(tmpdir):
     string = Str()
     checkbox.link(string, value='object')
     panel = Row(checkbox, string)
-    filename = os.path.join(tmpdir, 'test.html')
+    filename = os.path.join(str(tmpdir), 'test.html')
     panel.save(filename, embed=True, embed_json=True,
-               save_path=tmpdir)
+               save_path=str(tmpdir))
     assert os.path.isfile(filename)
-    paths = glob.glob(os.path.join(tmpdir, '*'))
+    paths = glob.glob(os.path.join(str(tmpdir), '*'))
     paths.remove(filename)
     assert len(paths) == 1
     json_files = sorted(glob.glob(os.path.join(paths[0], '*.json')))

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -10,6 +10,7 @@ import signal
 import uuid
 
 from functools import partial
+from six import string_types
 
 import param
 
@@ -449,7 +450,7 @@ class Viewable(Layoutable):
 
         Arguments
         ---------
-        filename: string
+        filename: string or file-like object
            Filename to save the plot to
         title: string
            Optional title for the plot
@@ -478,12 +479,12 @@ class Viewable(Layoutable):
             else:
                 add_to_doc(model, doc, True)
 
-        if filename.endswith('png'):
-            _export_png(model, filename=filename)
-            return
-
-        if not filename.endswith('.html'):
-            filename = filename + '.html'
+        if isinstance(filename, string_types):
+            if filename.endswith('png'):
+                _export_png(model, filename=filename)
+                return
+            if not filename.endswith('.html'):
+                filename = filename + '.html'
 
         kwargs = {}
         if title is None:
@@ -494,6 +495,9 @@ class Viewable(Layoutable):
             kwargs['template'] = template
 
         html = _file_html(doc, resources, title, **kwargs)
+        if hasattr(filename, 'write'):
+            filename.write(decode_utf8(html))
+            return
         with open(filename, mode="w", encoding="utf-8") as f:
             f.write(decode_utf8(html))
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -264,7 +264,10 @@ class Viewable(Layoutable):
         comm = state._comm_manager.get_server_comm()
         model = self._get_root(doc, comm)
         if config.embed:
-            embed_state(self, model, doc)
+            embed_state(self, model, doc,
+                        json=config.json,
+                        save_path=config.embed_save_path,
+                        load_path=config.embed_load_path)
             return render_model(model)
         return render_mimebundle(model, doc, comm)
 
@@ -337,7 +340,8 @@ class Viewable(Layoutable):
         show_server(server, notebook_url, server_id)
         return server
 
-    def embed(self, max_states=1000, max_opts=3):
+    def embed(self, max_states=1000, max_opts=3, json=False,
+              save_path='./', load_path=None):
         """
         Renders a static version of a panel in a notebook by evaluating
         the set of states defined by the widgets in the model. Note
@@ -350,13 +354,20 @@ class Viewable(Layoutable):
           The maximum number of states to embed
         max_opts: int
           The maximum number of states for a single widget
+        json: boolean (default=True)
+          Whether to export the data to json files
+        save_path: str (default='./')
+          The path to save json files to
+        load_path: str (default=None)
+          The path or URL the json files will be loaded from.
         """
         from IPython.display import publish_display_data
         doc = _Document()
         comm = _Comm()
         with config.set(embed=True):
             model = self._get_root(doc, comm)
-            embed_state(self, model, doc, max_states)
+            embed_state(self, model, doc, max_states, max_opts,
+                        json, save_path, load_path)
         publish_display_data(*render_model(model))
 
     def get_server(self, port=0, websocket_origin=None, loop=None,

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -25,7 +25,7 @@ from pyviz_comms import JS_CALLBACK, JupyterCommManager, Comm as _Comm
 
 from .io import (
     ABORT_JS, add_to_doc, push, render_mimebundle, state, embed_state,
-    render_model, _origin_url, show_server, config, add_to_doc)
+    render_model, _origin_url, show_server, config)
 from .util import param_reprs
 
 
@@ -468,10 +468,6 @@ class Viewable(Layoutable):
         load_path: str (default=None)
            The path or URL the json files will be loaded from.
         """
-        if filename.endswith('png'):
-            _export_png(plot, filename=filename)
-            return
-
         doc = _Document()
         comm = _Comm()
         with config.set(embed=embed):
@@ -481,6 +477,10 @@ class Viewable(Layoutable):
                             embed_json, save_path, load_path)
             else:
                 add_to_doc(model, doc, True)
+
+        if filename.endswith('png'):
+            _export_png(model, filename=filename)
+            return
 
         if not filename.endswith('.html'):
             filename = filename + '.html'

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -5,6 +5,7 @@ response to changes to parameters and the underlying bokeh models.
 """
 from __future__ import absolute_import, division, unicode_literals
 
+import io
 import re
 import signal
 import uuid
@@ -498,7 +499,7 @@ class Viewable(Layoutable):
         if hasattr(filename, 'write'):
             filename.write(decode_utf8(html))
             return
-        with open(filename, mode="w", encoding="utf-8") as f:
+        with io.open(filename, mode="w", encoding="utf-8") as f:
             f.write(decode_utf8(html))
 
     def server_doc(self, doc=None, title=None):
@@ -610,7 +611,7 @@ class Reactive(Viewable):
         # temporary flag denotes panes created for temporary, internal
         # use which should be garbage collected once they have been used
         super(Reactive, self).__init__(**params)
-        self._processing = True
+        self._processing = False
         self._events = {}
         self._changing = {}
         self._callbacks = []
@@ -711,8 +712,6 @@ class Reactive(Viewable):
             events = self._events
             self._events = {}
             self.set_param(**self._process_property_change(events))
-        except:
-            raise
         finally:
             self._processing = False
             state.curdoc = None

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -36,6 +36,8 @@ class Widget(Reactive):
     def __init__(self, **params):
         if 'name' not in params:
             params['name'] = ''
+        if '_supports_embed' in params:
+            self._supports_embed = params.pop('_supports_embed')
         super(Widget, self).__init__(**params)
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
@@ -49,7 +51,7 @@ class Widget(Reactive):
         self._link_props(model, properties, doc, root, comm)
         return model
 
-    def _get_embed_state(self, root, parent, max_opts=3):
+    def _get_embed_state(self, root, max_opts=3):
         """
         Returns the bokeh model and a discrete set of value states
         for the widget.
@@ -58,8 +60,6 @@ class Widget(Reactive):
         ---------
         root: bokeh.model.Model
           The root model of the widget
-        parent: bokeh.model.Model
-          The parent model of the widget
         max_opts: int
           The maximum number of states the widget should return
 
@@ -71,6 +71,12 @@ class Widget(Reactive):
           The bokeh model to record the current value state on
         values: list
           A list of value states to explore.
+        getter: callable
+          A function that returns the state value given the model
+        on_change: string
+          The name of the widget property to attach a callback on
+        js_getter: string
+          JS snippet that returns the state value given the model
         """
 
 
@@ -101,3 +107,9 @@ class CompositeWidget(Widget):
         for obj in self._composite.objects:
             objects += obj.select(selector)
         return objects
+
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        return self._composite._get_model(doc, root, parent, comm)
+
+    def __contains__(self, object):
+        return object in self._composite.objects

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -29,6 +29,8 @@ class Widget(Reactive):
 
     _widget_type = None
 
+    _supports_embed = False
+
     _rename = {'name': 'title'}
 
     def __init__(self, **params):
@@ -46,6 +48,30 @@ class Widget(Reactive):
         self._models[root.ref['id']] = (model, parent)
         self._link_props(model, properties, doc, root, comm)
         return model
+
+    def _get_embed_state(self, root, parent, max_opts=3):
+        """
+        Returns the bokeh model and a discrete set of value states
+        for the widget.
+
+        Arguments
+        ---------
+        root: bokeh.model.Model
+          The root model of the widget
+        parent: bokeh.model.Model
+          The parent model of the widget
+        max_opts: int
+          The maximum number of states the widget should return
+
+        Returns
+        -------
+        widget: panel.widget.Widget
+          The Panel widget instance to modify to effect state changes
+        model: bokeh.model.Model
+          The bokeh model to record the current value state on
+        values: list
+          A list of value states to explore.
+        """
 
 
 class CompositeWidget(Widget):

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -42,5 +42,6 @@ class Toggle(_ButtonBase):
 
     _widget_type = _BkToggle
 
-    def _get_embed_state(self, root, parent, max_opts=3):
-        return self, self._models[root.ref['id']][0], [False, True]
+    def _get_embed_state(self, root, max_opts=3):
+        return (self, self._models[root.ref['id']][0], [False, True],
+                lambda x: x.active, 'active', 'cb_obj.active')

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -38,4 +38,9 @@ class Toggle(_ButtonBase):
 
     _rename = {'value': 'active'}
 
+    _supports_embed = True
+
     _widget_type = _BkToggle
+
+    def _get_embed_state(self, root, parent, max_opts=3):
+        return self, self._models[root.ref['id']][0], [False, True]

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -278,5 +278,6 @@ class Checkbox(Widget):
             msg['labels'] = [msg.pop('title')]
         return msg
 
-    def _get_embed_state(self, root, parent, max_opts=3):
-        return self, self._models[root.ref['id']][0], [False, True]
+    def _get_embed_state(self, root, max_opts=3):
+        return (self, self._models[root.ref['id']][0], [False, True],
+                lambda x: 0 in x.active, 'active', 'cb_obj.active.indexOf(0) >= 0')

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -260,6 +260,8 @@ class Checkbox(Widget):
 
     value = param.Boolean(default=False)
 
+    _supports_embed = True
+
     _widget_type = _BkCheckboxGroup
 
     def _process_property_change(self, msg):
@@ -275,3 +277,6 @@ class Checkbox(Widget):
         if 'title' in msg:
             msg['labels'] = [msg.pop('title')]
         return msg
+
+    def _get_embed_state(self, root, parent, max_opts=3):
+        return self, self._models[root.ref['id']][0], [False, True]

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -52,6 +52,8 @@ class Select(SelectBase):
 
     _widget_type = _BkSelect
 
+    _supports_embed = True
+
     def __init__(self, **params):
         super(Select, self).__init__(**params)
         values = self.values
@@ -87,6 +89,9 @@ class Select(SelectBase):
                 msg['value'] = self._items[msg['value']]
         msg.pop('options', None)
         return msg
+
+    def _get_embed_state(self, root, parent, max_opts=3):
+        return self, self._models[root.ref['id']][0], self.values
 
 
 class MultiSelect(Select):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -90,8 +90,9 @@ class Select(SelectBase):
         msg.pop('options', None)
         return msg
 
-    def _get_embed_state(self, root, parent, max_opts=3):
-        return self, self._models[root.ref['id']][0], self.values
+    def _get_embed_state(self, root, max_opts=3):
+        return (self, self._models[root.ref['id']][0], self.values,
+                lambda x: x.value, 'value', 'cb_obj.value')
 
 
 class MultiSelect(Select):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -64,9 +64,9 @@ class ContinuousSlider(_SliderBase):
 
     __abstract = True
 
-    def _get_embed_state(self, root, parent, max_opts=3):
+    def _get_embed_state(self, root, max_opts=3):
         ref = root.ref['id']
-        w_model = self._models[ref][0]
+        w_model, parent = self._models[ref]
         _, _, doc, comm = state._views[ref]
 
         # Compute sampling
@@ -90,7 +90,7 @@ class ContinuousSlider(_SliderBase):
         w_model = w_model.children[1]
         w_model.js_on_change('value', link)
 
-        return dw, w_model, vals
+        return (dw, w_model, vals, lambda x: x.value, 'value', 'cb_obj.value')
 
 
 class FloatSlider(ContinuousSlider):
@@ -171,7 +171,8 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         else:
             value = values.index(self.value)
         self._slider = IntSlider(start=0, end=len(self.options)-1, value=value,
-                                 show_value=False, margin=(0, 5, 5, 5))
+                                 tooltips=False, show_value=False, margin=(0, 5, 5, 5),
+                                 _supports_embed=False)
         js_code = self._text_link.format(labels=repr(self.labels))
         self._jslink = self._slider.jslink(self._text, code={'value': js_code})
         self._slider.param.watch(self._sync_value, 'value')
@@ -201,12 +202,9 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         finally:
             self._syncing = False
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
-        return self._composite._get_model(doc, root, parent, comm)
-
-    def _get_embed_state(self, root, parent, max_opts=3):
+    def _get_embed_state(self, root, max_opts=3):
         model = self._composite[1]._models[root.ref['id']][0]
-        return self, model, self.values
+        return self, model, self.values, lambda x: x.value, 'value', 'cb_obj.value'
 
     @property
     def labels(self):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -10,10 +10,12 @@ from six import string_types
 import param
 import numpy as np
 
+from bokeh.models import CustomJS
 from bokeh.models.widgets import (
     DateSlider as _BkDateSlider, DateRangeSlider as _BkDateRangeSlider,
     RangeSlider as _BkRangeSlider, Slider as _BkSlider)
 
+from ..io import config, state
 from ..util import value_as_datetime
 from .base import Widget, CompositeWidget
 from ..layout import Column
@@ -56,7 +58,42 @@ class _SliderBase(Widget):
     __abstract = True
 
 
-class FloatSlider(_SliderBase):
+class ContinuousSlider(_SliderBase):
+
+    _supports_embed = True
+
+    __abstract = True
+
+    def _get_embed_state(self, root, parent, max_opts=3):
+        ref = root.ref['id']
+        w_model = self._models[ref][0]
+        _, _, doc, comm = state._views[ref]
+
+        # Compute sampling
+        start, end, step = w_model.start, w_model.end, w_model.step
+        span = end-start
+        dtype = int if isinstance(step, int) else float
+        if (span/step) > (max_opts-1):
+            step = dtype(span/(max_opts-1))
+        vals = [dtype(v) for v in np.arange(start, end+step, step)]
+
+        # Replace model
+        dw = DiscreteSlider(options=vals, name=self.name)
+        dw.link(self, value='value')
+        self._models.pop(ref)
+        index = parent.children.index(w_model)
+        with config.set(embed=True):
+            w_model = dw._get_model(doc, root, parent, comm)
+        link = CustomJS(code=dw._jslink.code['value'], args={
+            'source': w_model.children[1], 'target': w_model.children[0]})
+        parent.children[index] = w_model
+        w_model = w_model.children[1]
+        w_model.js_on_change('value', link)
+
+        return dw, w_model, vals
+
+
+class FloatSlider(ContinuousSlider):
 
     start = param.Number(default=0.0)
 
@@ -67,7 +104,7 @@ class FloatSlider(_SliderBase):
     step = param.Number(default=0.1)
 
 
-class IntSlider(_SliderBase):
+class IntSlider(ContinuousSlider):
 
     value = param.Integer(default=0)
 
@@ -98,6 +135,8 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
     formatter = param.String(default='%.3g')
 
     _rename = {'formatter': None}
+
+    _supports_embed = True
 
     _text_link = """
     var labels = {labels}
@@ -165,6 +204,10 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
     def _get_model(self, doc, root=None, parent=None, comm=None):
         return self._composite._get_model(doc, root, parent, comm)
 
+    def _get_embed_state(self, root, parent, max_opts=3):
+        model = self._composite[1]._models[root.ref['id']][0]
+        return self, model, self.values
+
     @property
     def labels(self):
         title = (self.name + ': ' if self.name else '')
@@ -176,7 +219,6 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
     @property
     def values(self):
         return list(self.options.values()) if isinstance(self.options, dict) else self.options
-
 
 
 class RangeSlider(_SliderBase):

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,8 @@ class CustomEggInfoCommand(egg_info):
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=1.1.0dev8',
-    'param >=1.9.0a3',
+    'bokeh >=1.1.0dev9',
+    'param >=1.9.0a4',
     'pyviz_comms >=0.7.0',
     'markdown',
     'pyct >=0.4.4',
@@ -131,7 +131,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 # until pyproject.toml/equivalent is widely supported (setup_requires
 # doesn't work well with pip)
 extras_require['build'] = [
-    'param >=1.7.0',
+    'param >=1.9.0a4',
     'pyct >=0.4.4',
     'setuptools >=30.3.0',
     'bokeh >=1.0.0',


### PR DESCRIPTION
Makes it possible to export the embedded state to JSON files which can be loaded independently. Unlike the equivalent functionality in HoloViews each state is stored as a separate file which means it can be loaded only when it is needed, allowing a huge state space to be exported with a minimal file size penalty.