### PR TITLE
Allow passing Parameter instances to Param pane

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -134,6 +134,11 @@ class Param(PaneBase):
     _rerender_params = []
 
     def __init__(self, object=None, **params):
+        if isinstance(object, param.Parameter):
+            if not 'show_name' in params:
+                params['show_name'] = False
+            params['parameters'] = [object.name]
+            object = object.owner
         if isinstance(object, param.parameterized.Parameters):
             object = object.cls if object.self is None else object.self
         if 'parameters' not in params and object is not None:
@@ -371,11 +376,11 @@ class Param(PaneBase):
             # Set up links to parameterized object
             watchers.append(self.object.param.watch(link, p_name, 'constant'))
             watchers.append(self.object.param.watch(link, p_name, 'precedence'))
-            watchers.append(self.object.param.watch(link, p_name))
             if hasattr(p_obj, 'get_range'):
                 watchers.append(self.object.param.watch(link, p_name, 'objects'))
             if hasattr(p_obj, 'get_soft_bounds'):
                 watchers.append(self.object.param.watch(link, p_name, 'bounds'))
+            watchers.append(self.object.param.watch(link, p_name))
 
         options = kwargs.get('options', [])
         if isinstance(options, dict):
@@ -441,7 +446,9 @@ class Param(PaneBase):
 
     @classmethod
     def applies(cls, obj):
-        return (is_parameterized(obj) or isinstance(obj, param.parameterized.Parameters))
+        return (is_parameterized(obj) or
+                isinstance(obj, param.parameterized.Parameters) or
+                (isinstance(obj, param.Parameter) and obj.owner is not None))
 
     @classmethod
     def widget_type(cls, pobj):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -31,6 +31,15 @@ def test_instantiate_from_class():
     assert isinstance(Pane(Test), Param)
 
 
+def test_instantiate_from_parameter():
+
+    class Test(param.Parameterized):
+
+        a = param.Number()
+
+    assert isinstance(Pane(Test.param.a), Param)
+
+
 def test_instantiate_from_parameters():
 
     class Test(param.Parameterized):
@@ -47,6 +56,15 @@ def test_instantiate_from_instance():
         a = param.Number()
 
     assert isinstance(Pane(Test()), Param)
+
+
+def test_instantiate_from_parameter_on_instance():
+
+    class Test(param.Parameterized):
+
+        a = param.Number()
+
+    assert isinstance(Pane(Test().param.a), Param)
 
 
 def test_instantiate_from_parameters_on_instance():
@@ -90,6 +108,23 @@ def test_get_root(document, comm):
     div = model.children[0]
     assert isinstance(div, Div)
     assert div.text == '<b>'+test.name[:-5]+'</b>'
+
+
+def test_single_param(document, comm):
+
+    class Test(param.Parameterized):
+        a = param.Parameter(default=0)
+
+    test = Test()
+    test_pane = Pane(test.param.a)
+    model = test_pane._get_root(document, comm=comm)
+
+    assert isinstance(model, BkColumn)
+    assert len(model.children) == 1
+
+    widget = model.children[0]
+    assert isinstance(widget, TextInput)
+    assert widget.value == '0'
 
 
 def test_get_root_tabs(document, comm):


### PR DESCRIPTION
This is a bit of convenience to easily add single parameter widgets, i.e. this code:

```python
 pn.pane.Param(parameterized, parameters=['parameter'], show_name=False)
```

 becomes:

```python
pn.pane.Param(parameterized.param.parameter)
```