### PR TITLE
Reverse map discrete options using identity

### DIFF
--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime
 
 import param
+import numpy as np
 
 from bokeh.layouts import Column
 from bokeh.models import Div as BkDiv, Slider as BkSlider
@@ -261,7 +262,6 @@ def test_select(document, comm):
     assert widget.value == '1'
     assert widget.options == ['A', '1']
 
-    widget.value = '1'
     select._comm_change({'value': 'A'})
     assert select.value == opts['A']
 
@@ -271,6 +271,37 @@ def test_select(document, comm):
 
     select.value = opts['A']
     assert widget.value == 'A'
+
+
+def test_select_change_options(document, comm):
+    opts = {'A': 'a', '1': 1}
+    select = Select(options=opts, value=opts['1'], name='Select')
+
+    widget = select._get_root(document, comm=comm)
+
+    select.options = {'A': 'a'}
+    assert select.value == opts['A']
+    assert widget.value == 'A'
+
+    select.options = {}
+    assert select.value == None
+    assert widget.value == None
+
+
+def test_select_non_hashable_options(document, comm):
+    opts = {'A': np.array([1, 2, 3]), '1': np.array([3, 4, 5])}
+    select = Select(options=opts, value=opts['1'], name='Select')
+
+    widget = select._get_root(document, comm=comm)
+
+    select.value = opts['A']
+    assert select.value is opts['A']
+    assert widget.value == 'A'
+
+    opts.pop('A')
+    select.options = opts
+    assert select.value is opts['1']
+    assert widget.value is '1'
 
 
 def test_select_mutables(document, comm):
@@ -296,7 +327,7 @@ def test_select_mutables(document, comm):
     assert widget.value == 'A'
 
 
-def test_select_change_options(document, comm):
+def test_select_change_options_on_watch(document, comm):
     select = Select(options=OrderedDict([('A', 'A'), ('1', 1), ('C', object)]),
                          value='A', name='Select')
 

--- a/panel/tests/test_widgets.py
+++ b/panel/tests/test_widgets.py
@@ -301,7 +301,7 @@ def test_select_non_hashable_options(document, comm):
     opts.pop('A')
     select.options = opts
     assert select.value is opts['1']
-    assert widget.value is '1'
+    assert widget.value == '1'
 
 
 def test_select_mutables(document, comm):

--- a/panel/util.py
+++ b/panel/util.py
@@ -69,6 +69,26 @@ def hashable(x):
         return x
 
 
+def is_in(obj, objs):
+    """
+    Checks if the object is in the list of objects, unlike the ``in``
+    Python operator this will check only for identity not equality.
+    """
+    return any(o is obj for o in objs)
+
+
+def indexOf(obj, objs):
+    """
+    Returns the index of an object in a list of objects. Unlike the
+    list.index method this function only checks for identity not
+    equality.
+    """
+    indexes = [i for i, o in enumerate(objs) if o is obj]
+    if indexes:
+        return indexes[0]
+    raise ValueError('%s not in list' % obj)
+
+
 def as_unicode(obj):
     """
     Safely casts any object to unicode including regular string

--- a/panel/util.py
+++ b/panel/util.py
@@ -69,7 +69,7 @@ def hashable(x):
         return x
 
 
-def is_in(obj, objs):
+def isIn(obj, objs):
     """
     Checks if the object is in the list of objects, unlike the ``in``
     Python operator this will check only for identity not equality.

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 import param
 
 from ..models.widgets import Player as _BkPlayer
+from ..util import isIn, indexOf
 from .base import Widget
 from .select import SelectBase
 
@@ -73,12 +74,12 @@ class DiscretePlayer(PlayerBase, SelectBase):
         if 'options' in msg:
             msg['start'] = 0
             msg['end'] = len(values) - 1
-            if values and self.value not in values:
+            if values and not isIn(self.value, values):
                 self.value = values[0]
         if 'value' in msg:
             value = msg['value']
-            if value in values:
-                msg['value'] = values.index(value)
+            if isIn(value, values):
+                msg['value'] = indexOf(value, values)
             elif values:
                 self.value = values[0]
         return super(DiscretePlayer, self)._process_param_change(msg)

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, unicode_literals
 import param
 
 from ..models.widgets import Player as _BkPlayer
-from ..util import hashable
 from .base import Widget
 from .select import SelectBase
 

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -70,15 +70,15 @@ class DiscretePlayer(PlayerBase, SelectBase):
     _rename = {'name': None, 'options': None}
 
     def _process_param_change(self, msg):
-        values = [hashable(v) for v in self.values]
+        values = [v for v in self.values]
         if 'options' in msg:
             msg['start'] = 0
             msg['end'] = len(values) - 1
             if values and self.value not in values:
                 self.value = values[0]
         if 'value' in msg:
-            value = hashable(msg['value'])
-            if hashable(value) in values:
+            value = msg['value']
+            if value in values:
                 msg['value'] = values.index(value)
             elif values:
                 self.value = values[0]

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -70,7 +70,7 @@ class DiscretePlayer(PlayerBase, SelectBase):
     _rename = {'name': None, 'options': None}
 
     def _process_param_change(self, msg):
-        values = [v for v in self.values]
+        values = self.values
         if 'options' in msg:
             msg['start'] = 0
             msg['end'] = len(values) - 1

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -73,12 +73,12 @@ class Select(SelectBase):
                 self.value = None
 
         if 'options' in msg:
-            msg['options'] = self.labels
+            msg['options'] = labels
             val = self.value
             if values:
                 if not isIn(val, values):
                     self.value = values[0]
-            elif self.value is not None:
+            elif val is not None:
                 self.value = None
         return msg
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -69,15 +69,17 @@ class Select(SelectBase):
                 msg['value'] = labels[values.index(val)]
             elif values:
                 self.value = self.values[0]
-            else:
+            elif self.value is not None:
                 self.value = None
 
         if 'options' in msg:
             msg['options'] = self.labels
             val = self.value
-            if values and val not in values:
-                self.value = values[0]
-
+            if values:
+                if val not in values:
+                    self.value = values[0]
+            elif self.value is not None:
+                self.value = None
         return msg
 
     def _process_property_change(self, msg):
@@ -155,6 +157,8 @@ class _RadioGroupBase(Select):
             if value in values:
                 msg['active'] = values.index(value)
             else:
+                if self.value is not None:
+                    self.value = None
                 msg['active'] = None
 
         if 'options' in msg:

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -11,13 +11,13 @@ from collections import OrderedDict
 import param
 
 from bokeh.models.widgets import (
-    AutocompleteInput as _BkAutocompleteInput, CheckboxGroup as _BkCheckboxGroup, 
+    AutocompleteInput as _BkAutocompleteInput, CheckboxGroup as _BkCheckboxGroup,
     CheckboxButtonGroup as _BkCheckboxButtonGroup, MultiSelect as _BkMultiSelect,
     RadioButtonGroup as _BkRadioButtonGroup, RadioGroup as _BkRadioBoxGroup,
     Select as _BkSelect)
 
 from ..layout import Column, Row, VSpacer
-from ..util import as_unicode, hashable
+from ..util import as_unicode
 from ..viewable import Layoutable
 from .base import Widget, CompositeWidget
 from .button import _ButtonBase, Button


### PR DESCRIPTION
Using a dictionary to map options from their value to their label did not work well because the values may be non-hashable or hash inconsistently. Instead this PR switches to using the value's identity to do the reverse mapping which should work reliably.