### PR TITLE
Add HTML model capable of executing JS code

### DIFF
--- a/examples/reference/panes/HTML.ipynb
+++ b/examples/reference/panes/HTML.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``HTML`` pane allows rendering arbitrary HTML (excluding script tags) in a panel. It renders strings containing valid HTML as well as objects with a ``_repr_html_`` method and may define custom CSS styles.\n",
+    "The ``HTML`` pane allows rendering arbitrary HTML in a panel. It renders strings containing valid HTML as well as objects with a ``_repr_html_`` method and may define custom CSS styles.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``HTML`` pane accepts the entire HTML5 spec but will not execute any embedded script tags. It also supports a ``style`` dictionary to apply styles to control the style of the ``<div>`` tag the HTML contents will be rendered in."
+    "The ``HTML`` pane accepts the entire HTML5 spec including any embedded script tags, which will be executed. It also supports a ``style`` dictionary to apply styles to control the style of the ``<div>`` tag the HTML contents will be rendered in."
    ]
   },
   {

--- a/panel/models/__init__.py
+++ b/panel/models/__init__.py
@@ -5,5 +5,6 @@ defined as pairs of Python classes and TypeScript models defined in .ts
 files.
 """
 
+from .markup import HTML # noqa
 from .state import State # noqa
 from .widgets import Audio, FileInput, Player # noqa

--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -1,0 +1,48 @@
+import * as p from "core/properties"
+import {Markup, MarkupView} from "models/widgets/markup"
+
+function htmlDecode(input: string): string | null {
+  var doc = new DOMParser().parseFromString(input, "text/html");
+  return doc.documentElement.textContent;
+}
+
+export class HTMLView extends MarkupView {
+  model: HTML
+
+  render(): void {
+    super.render()
+    const html = htmlDecode(this.model.text);
+    if (!html) { return }
+    this.markup_el.innerHTML = html
+    Array.from(this.markup_el.querySelectorAll("script")).forEach( oldScript => {
+      const newScript = document.createElement("script");
+      Array.from(oldScript.attributes)
+        .forEach( attr => newScript.setAttribute(attr.name, attr.value) );
+      newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+      if (oldScript.parentNode)
+        oldScript.parentNode.replaceChild(newScript, oldScript);
+    });
+  }
+}
+
+export namespace HTML {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Markup.Props
+}
+
+export interface HTML extends HTML.Attrs {}
+
+export class HTML extends Markup {
+  properties: HTML.Props
+
+  constructor(attrs?: Partial<HTML.Attrs>) {
+    super(attrs)
+  }
+
+  static initClass(): void {
+    this.prototype.type = "HTML"
+    this.prototype.default_view = HTMLView
+  }
+}
+HTML.initClass()

--- a/panel/models/markup.py
+++ b/panel/models/markup.py
@@ -17,3 +17,6 @@ class HTML(Markup):
     """
 
     __implementation__ = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'html.ts')
+
+
+CUSTOM_MODELS['panel.models.markup.HTML'] = HTML

--- a/panel/models/markup.py
+++ b/panel/models/markup.py
@@ -1,0 +1,19 @@
+"""
+Custom bokeh Markup models.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import os
+
+from bokeh.core.properties import Int, Float, Override, Enum, Any, Bool
+from bokeh.models.widgets import Markup
+
+from ..compiler import CUSTOM_MODELS
+
+
+class HTML(Markup):
+    """
+    A bokeh model to render HTML markup including embedded script tags.
+    """
+
+    __implementation__ = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'html.ts')

--- a/panel/models/markup.py
+++ b/panel/models/markup.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, unicode_literals
 
 import os
 
-from bokeh.core.properties import Int, Float, Override, Enum, Any, Bool
 from bokeh.models.widgets import Markup
 
 from ..compiler import CUSTOM_MODELS

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -1,3 +1,8 @@
+"""
+Custom bokeh Widget models.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
 import os
 
 from bokeh.core.properties import Int, Float, Override, Enum, Any, Bool

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -15,6 +15,7 @@ import param
 from bokeh.models import Div as _BkDiv
 
 from ..viewable import Layoutable
+from ..models import HTML as _BkHTML
 from .base import PaneBase
 
 
@@ -64,6 +65,8 @@ class HTML(DivPaneBase):
     # Priority is dependent on the data type
     priority = None
 
+    _bokeh_model = _BkHTML
+
     @classmethod
     def applies(cls, obj):
         if hasattr(obj, '_repr_html_'):
@@ -78,7 +81,7 @@ class HTML(DivPaneBase):
         text = '' if self.object is None else self.object
         if hasattr(text, '_repr_html_'):
             text = text._repr_html_()
-        return dict(properties, text=text)
+        return dict(properties, text=escape(text))
 
 
 class Str(DivPaneBase):

--- a/panel/pane/tests/test_markup.py
+++ b/panel/pane/tests/test_markup.py
@@ -31,12 +31,12 @@ def test_html_pane(document, comm):
     # Create pane
     model = pane._get_root(document, comm=comm)
     assert pane._models[model.ref['id']][0] is model
-    assert model.text == "<h1>Test</h1>"
+    assert model.text == "&lt;h1&gt;Test&lt;/h1&gt;"
 
     # Replace Pane.object
     pane.object = "<h2>Test</h2>"
     assert pane._models[model.ref['id']][0] is model
-    assert model.text == "<h2>Test</h2>"
+    assert model.text == "&lt;h2&gt;Test&lt;/h2&gt;"
 
     # Cleanup
     pane._cleanup(model)

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1,5 +1,5 @@
 from bokeh.client import pull_session
-from bokeh.models import Div
+from panel.models import HTML as BkHTML
 from panel.io import state
 from panel.pane import HTML
 
@@ -13,8 +13,8 @@ def test_get_server():
     url = "http://localhost:" + str(server.port) + "/"
     session = pull_session(session_id='Test', url=url, io_loop=server.io_loop)
     root = session.document.roots[0]
-    assert isinstance(root, Div)
-    assert root.text == '<h1>Title</h1>'
+    assert isinstance(root, BkHTML)
+    assert root.text == '&lt;h1&gt;Title&lt;/h1&gt;'
     server.stop()
 
 
@@ -29,8 +29,8 @@ def test_server_update():
 
     session.pull()
     root = session.document.roots[0]
-    assert isinstance(root, Div)
-    assert root.text == '<h1>New Title</h1>'
+    assert isinstance(root, BkHTML)
+    assert root.text == '&lt;h1&gt;New Title&lt;/h1&gt;'
     server.stop()
 
 


### PR DESCRIPTION
This adds an HTML model which executes any script tags found inside of it. This makes it possible to execute arbitrary Javascript inside an ``HTML`` pane, and even allows embedding a panel inside an HTML pane. So if you really need it you can embed other panels or even bokeh servers inside a panel.

![embedded](https://user-images.githubusercontent.com/1550771/54868087-868c3900-4d80-11e9-9eca-19eb176bbd29.gif)

Implements https://github.com/pyviz/panel/issues/325

