### PR TITLE
Use extract geometry filter to enforce PolyData

### DIFF
--- a/panel/pane/vtk.py
+++ b/panel/pane/vtk.py
@@ -422,6 +422,13 @@ class VTK(PaneBase):
                         dataset = gf.GetOutput()
                     else:
                         dataset = mapper.GetInput()
+                        
+                    if dataset and not isinstance(dataset, (vtk.vtkPolyData)):
+                        # All data must be PolyData surfaces!
+                        gf = vtk.vtkGeometryFilter()
+                        gf.SetInputData(dataset)
+                        gf.Update()
+                        dataset = gf.GetOutputDataObject(0)
 
                     if dataset and dataset.GetPoints():
                         componentName = str(id(renProp))


### PR DESCRIPTION
VTKjs currently only supports `vtkPolyData`. These changes use an extract geometry filter to get a useable representation of any VTK data object.

Note that these changes make creating compelling scenes with `vtki` a breeze!!

# Examples

```py
import vtki
vtki.set_plot_theme('document')
from vtki import examples
import panel
panel.extension('vtk')
from panel.pane import VTK as panel_display

def display(p):
    return panel_display(p.ren_win)
```

```py
data = examples.load_uniform()

p = vtki.Plotter(notebook=False, off_screen=True)

p.add_mesh(data.threshold_percent([0.25, 0.75]))
p.add_mesh(data.wireframe())
p.add_mesh(data.slice_orthogonal())

p.show(auto_close=False)
display(p)
```
<img width="336" alt="Screen Shot 2019-03-31 at 7 23 57 PM" src="https://user-images.githubusercontent.com/22067021/55298384-904e1600-53ea-11e9-9e56-05b8c4563aee.png">


```py
data = examples.download_st_helens().warp_by_scalar()

p = vtki.Plotter(notebook=False, off_screen=True)
p.add_mesh(data, opacity='linear')
p.show(auto_close=False)
display(p)
```

<img width="358" alt="Screen Shot 2019-03-31 at 7 23 48 PM" src="https://user-images.githubusercontent.com/22067021/55298387-95ab6080-53ea-11e9-93b5-179beb4dcc70.png">


```py
data = examples.download_lidar()

p = vtki.Plotter(notebook=False, off_screen=True)
p.add_mesh(data)
p.show(auto_close=False)
display(p)
```
<img width="334" alt="Screen Shot 2019-03-31 at 7 24 03 PM" src="https://user-images.githubusercontent.com/22067021/55298390-9e9c3200-53ea-11e9-9d59-77b3ed231d12.png">