### PR TITLE
[vtk] correction of the texture serialization

### DIFF
--- a/panel/models/vtk.ts
+++ b/panel/models/vtk.ts
@@ -89,10 +89,11 @@ export class VTKPlotView extends HTMLBoxView {
           renderer: this._rendererEl.getRenderer(),
           dataAccessHelper,
         })
-        sceneImporter.setUrl('index.json');
-        sceneImporter.onReady(() => {
-          setTimeout(() => this._rendererEl.getRenderWindow().render(),100)
-        })
+        const fn = this._vtk.macro.debounce(() => setTimeout(
+          this._rendererEl.getRenderWindow().render,
+           100), 100)
+        sceneImporter.setUrl('index.json')
+        sceneImporter.onReady(fn)
       }
     })
   }

--- a/panel/models/vtk.ts
+++ b/panel/models/vtk.ts
@@ -91,7 +91,7 @@ export class VTKPlotView extends HTMLBoxView {
         })
         sceneImporter.setUrl('index.json');
         sceneImporter.onReady(() => {
-          this._rendererEl.getRenderWindow().render()
+          setTimeout(() => this._rendererEl.getRenderWindow().render(),100)
         })
       }
     })

--- a/panel/pane/vtk.py
+++ b/panel/pane/vtk.py
@@ -541,7 +541,7 @@ class VTK(PaneBase):
 
         # Save texture data if any
         for key, val in textureToSave.items():
-            _write_data_set(val, None, newDSName=key, compress=doCompressArrays)
+            _write_data_set(scDirs, val, None, newDSName=key, compress=doCompressArrays)
 
         activeCamera = renderer.GetActiveCamera()
         background = renderer.GetBackground()


### PR DESCRIPTION
fixes :  https://github.com/pyviz/panel/issues/350

However when renderding the vtkjs panel the texture does not appear unless an interaction is done
I tried to export the vtkjs file into the official scene explorer (https://kitware.github.io/vtk-js/examples/SceneExplorer.html) and the same issue arise

![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/18531147/55338549-3c523880-54a1-11e9-979a-541b96008ea6.gif)


May be we need to open an issue on the main repo
