### PR TITLE
Fix get scalar array bug for VTK pane

### DIFF
--- a/panel/pane/vtk.py
+++ b/panel/pane/vtk.py
@@ -466,7 +466,7 @@ class VTK(PaneBase):
                         if dsAttrs:
                             if colorArrayName >= 0:
                                 dataArray = dsAttrs.GetArray(colorArrayName)
-                            elif dsAttrs.GetNumberOfArrays() == 1:
+                            elif dsAttrs.GetNumberOfArrays() >= 1:
                                 dataArray = dsAttrs.GetArray(0)
 
                         if dataArray:


### PR DESCRIPTION
There was a bug that would prevent scalars from being shown sometimes. This fixes it.

Here's code to see the difference (running off of `vtki` `master` branch - note there are several examples [here](https://mybinder.org/v2/gh/vtkiorg/vtki-examples/master) that show this happening):

```py
import vtki
import numpy as np

vtki.set_plot_theme('doc')
sphere = vtki.Sphere(radius=3.14)

# make cool swirly pattern
vectors = np.vstack((np.sin(sphere.points[:, 0]),
np.cos(sphere.points[:, 1]),
np.cos(sphere.points[:, 2]))).T

# add and scale
sphere.vectors = vectors*0.3

# plot the arrows and the sphere
p = vtki.Plotter()
p.add_mesh(sphere.arrows, scalars='GlyphScale', color=None, lighting=False, stitle='Vector Magnitude')
p.add_mesh(sphere, color='grey', ambient=0.6, opacity=0.5, show_edges=False)
p.show()
```