### PR TITLE
Getting rid of duplicate `python setup.py develop`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ jobs:
         - source activate test-environment
         - conda install -c conda-forge mesalib
         - doit develop_install -o recommended -o tests -o build $CHANS_DEV
-        - python setup.py develop --no-deps
         - doit env_capture
       before_script:
         - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x24"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ _recommended = [
     'holoviews >=1.12.0',
     'matplotlib',
     'pillow',
-    'plotly'
+    'plotly <3.8.0'
 ]
 
 extras_require = {
@@ -85,7 +85,7 @@ extras_require = {
         'codecov',
         # For Panes.ipynb
         'hvplot',
-        'plotly',
+        'plotly <3.8.0',
         'altair',
         'vega_datasets',
         'vtk ==8.1.1'


### PR DESCRIPTION
Now that pyctdev uses `python setup.py develop --no-deps` in pyctdev, we no longer need to duplicate that line in the travis file. 