### PR TITLE
Add tight option bbox

### DIFF
--- a/examples/reference/panes/Matplotlib.ipynb
+++ b/examples/reference/panes/Matplotlib.ipynb
@@ -15,11 +15,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Matplotlib`` pane allows displaying any displayable matplotlib figure inside a Panel app. It will render the plot to png at the declared DPI and then embed it.\n",
+    "The ``Matplotlib`` pane allows displaying any displayable matplotlib figure inside a Panel app. It will render the plot to png at the declared DPI and then embed it. If the figure happens to be clipped on the edges, setting `tight` to be `True` can automatically resize objects to fit within the pane.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "* **``dpi``** (int, default=144): The dots per inch of the exported png\n",
+    "* **``tight``** (bool, default=False): Automatically adjust the figure size to fit the subplots and other artist elements.\n",
     "* **``object``** (matplotlib.Figure): The matplotlib Figure object to display\n",
     "\n",
     "___"

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -59,6 +59,10 @@ class Matplotlib(PNG):
     dpi = param.Integer(default=144, bounds=(1, None), doc="""
         Scales the dpi of the matplotlib figure.""")
 
+    tight = param.Boolean(default=False, doc="""
+        Automatically adjust the figure size to fit the
+        subplots and other artist elements.""")
+
     _rerender_params = ['object', 'dpi']
 
     @classmethod
@@ -80,7 +84,13 @@ class Matplotlib(PNG):
     def _img(self):
         self.object.set_dpi(self.dpi)
         b = BytesIO()
-        self.object.canvas.print_figure(b)
+
+        if self.tight:
+            bbox_inches = 'tight'
+        else:
+            bbox_inches = None
+
+        self.object.canvas.print_figure(b, bbox_inches=bbox_inches)
         return b.getvalue()
 
 


### PR DESCRIPTION
https://github.com/pyviz/panel/issues/454

```
import panel as pn
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1 import make_axes_locatable
pn.extension()

fig = plt.figure(figsize=(8, 5))
ax = plt.axes()
im = ax.scatter([0, 1, 2], [3, 4, 5], c=[5, 6, 7])
ax.set_title('test')
ax.set_xlabel('someth', fontsize=40)
ax.set_ylabel('someth', fontsize=40)
divider = make_axes_locatable(ax)
cax = divider.append_axes("right", size="5%", pad=0.05)
cbar = plt.colorbar(im, label='colorbar', cax=ax)
plt.suptitle('somethingsomething loooong somethingsomething loooongsomethingsomething loooongsomethingsomething loooong')

pn.Pane(fig)

pn.Pane(fig, tight=True)
```

top is default render from Jupyter, second is wrapped fig with panel, and third is wrapped fig again but with tight
![image](https://user-images.githubusercontent.com/15331990/58605541-fc16f880-824c-11e9-8bd3-9e167abbf61f.png)
