### PR TITLE
custom serializer registration improvement

### DIFF
--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -102,11 +102,14 @@ class VTK(PaneBase):
         elif hasattr(self.object, 'read'):
             vtkjs = self.object.read()
         else:
-            if not VTK._serializers:
+            available_serializer = [v for k, v in VTK._serializers.items() if isinstance(self.object, k)]
+            if len(available_serializer) == 0:
                 import vtk
                 from .vtkjs_serializer import render_window_serializer
                 VTK.register_serializer(vtk.vtkRenderWindow, render_window_serializer)
-            serializer = [v for k, v in VTK._serializers.items() if isinstance(self.object, k)][0]
+                serializer = render_window_serializer
+            else:
+                serializer = available_serializer[0]
             vtkjs = serializer(self.object)
         return base64encode(vtkjs) if vtkjs is not None else vtkjs
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -42,11 +42,12 @@ class VTK(PaneBase):
     """)
 
     _updates = True
-    _serializer = None
+    _serializers = {}
 
     @classmethod
     def applies(cls, obj):
-        if isinstance(obj, string_types) and obj.endswith('.vtkjs'):
+        if (isinstance(obj, string_types) and obj.endswith('.vtkjs') or
+            any([isinstance(obj, k) for k in cls._serializers.keys()])):
             return True
         elif 'vtk' not in sys.modules:
             return False
@@ -79,12 +80,14 @@ class VTK(PaneBase):
         return model
 
     @classmethod
-    def set_serializer(cls, serializer):
+    def register_serializer(cls, class_type, serializer):
         """
-        A serializer is a function which take a `vtk` render window as input
-        and return the binary zip stream of the corresponding `vtkjs` file 
+        Register a seriliazer for a given type of class.
+        A serializer is a function which take an instance of `class_type` 
+        (like a vtk.vtkRenderWindow) as input and return the binary zip 
+        stream of the corresponding `vtkjs` file 
         """
-        cls._serializer = serializer
+        cls._serializers.update({class_type:serializer})
 
     def _get_vtkjs(self):
         if self.object is None:
@@ -99,10 +102,12 @@ class VTK(PaneBase):
         elif hasattr(self.object, 'read'):
             vtkjs = self.object.read()
         else:
-            if VTK._serializer is None:
+            if not VTK._serializers:
+                import vtk
                 from .vtkjs_serializer import render_window_serializer
-                VTK.set_serializer(render_window_serializer)
-            vtkjs = VTK._serializer(self.object).read()
+                VTK.register_serializer(vtk.vtkRenderWindow, render_window_serializer)
+            serializer = [v for k, v in VTK._serializers.items() if isinstance(self.object, k)][0]
+            vtkjs = serializer(self.object)
         return base64encode(vtkjs) if vtkjs is not None else vtkjs
 
     def _update(self, model):

--- a/panel/pane/vtk/vtkjs_serializer.py
+++ b/panel/pane/vtk/vtkjs_serializer.py
@@ -507,14 +507,14 @@ def render_window_serializer(render_window):
 
     # create binary stream of the vtkjs directory structure
     compression = zipfile.ZIP_DEFLATED
-    in_memory = BytesIO()
-    zf = zipfile.ZipFile(in_memory, mode="w")
-    try:
-        for dirPath, data in (scDirs):
-            zf.writestr(dirPath, data, compress_type=compression)
-    finally:
-            zf.close()
-
-    in_memory.seek(0)
-    return in_memory
+    with BytesIO() as in_memory:
+        zf = zipfile.ZipFile(in_memory, mode="w")
+        try:
+            for dirPath, data in (scDirs):
+                zf.writestr(dirPath, data, compress_type=compression)
+        finally:
+                zf.close()
+        in_memory.seek(0)
+        vtkjs = in_memory.read()
+    return vtkjs
 


### PR DESCRIPTION
This PR improve the one to set a custom serializer for vtk RenderWindow (#409)
Here we can register serializer for different class not just the vtk RenderWindow wich is limitatting if as input of the serializer we have a custom class.

With this PR for example we can use the pyvista (#408) export function without major change in code:
```python
import panel as pn
pn.extension('vtk')

import pyvista as pv
from pyvista import examples

mesh = examples.download_st_helens().warp_by_scalar()

# First a default plot with jet colormap
p = pv.Plotter()
# Add the data, use active scalar for coloring, and show the scalar bar
p.add_mesh(mesh)

def pyvista_serializer(plotter, delete_tmp_file=False):
    filename = 'pyvista_tmp'
    plotter.export_vtkjs(filename)
    with open(filename + '.vtkjs', 'rb') as f:
        vtkjs = f.read()
    if delete_tmp_file:
        import os
        os.remove(filename + '.vtkjs')
    return vtkjs
pn.pane.VTK.register_serializer(pv.plotting.Plotter, pyvista_serializer)

pn.panel(p)
```
![image](https://user-images.githubusercontent.com/18531147/59183903-45c8e280-8b6d-11e9-9dee-f32cf333a00a.png)
