### PR TITLE
quick fix to issue #421

### DIFF
--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -115,7 +115,10 @@ class DatePicker(Widget):
     def _process_property_change(self, msg):
         msg = super(DatePicker, self)._process_property_change(msg)
         if 'value' in msg:
-            msg['value'] = datetime.strptime(msg['value'][4:], '%b %d %Y')
+            if not isiterable(msg['value']):
+                msg['value'] = datetime.strptime(str(msg['value']), '%Y-%m-%d')
+            else:
+                msg['value'] = datetime.strptime(msg['value'][4:], '%b %d %Y')
         return msg
 
 


### PR DESCRIPTION
Simply handling the `datetime.date` object solved the issue
``` bash
File "/home/noam/anaconda3/lib/python3.6/site-packages/panel/widgets/input.py", line 118, in _process_property_change
    msg['value'] = datetime.strptime(msg['value'][4:], '%b %d %Y')
TypeError: 'datetime.date' object is not subscriptable
```
Issue #421