### PR TITLE
Updating travis to python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 
 env:
   global:
-    - PYENV_VERSION=3.6
+    - PYENV_VERSION=3.7
     - CHANS_DEV="-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
     - CHANS_REL="-c pyviz -c conda-forge"
     - LABELS_DEV="--label dev"
@@ -26,7 +26,7 @@ stages:
   - name: conda_dev_package
     if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: conda_package
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ 
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: pip_dev_package
     if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: pip_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
 
     - &conda_default
       stage: test
-      env: DESC="dev test_all"
+      env: DESC="dev test_all" PYTHON_VERSION=3.6
       before_install:
         # install doit/pyctdev and use to install miniconda...
         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
@@ -54,7 +54,7 @@ jobs:
         # ...and now install doit/pyctdev into miniconda
         - conda install -c pyviz "pyctdev>=0.5" && doit ecosystem_setup
       install:
-        - doit env_create $CHANS_DEV --python=$PYENV_VERSION
+        - doit env_create $CHANS_DEV --python=$PYTHON_VERSION
         - source activate test-environment
         - conda install -c conda-forge mesalib
         - doit develop_install -o recommended -o tests -o build $CHANS_DEV
@@ -70,7 +70,7 @@ jobs:
       after_success: codecov
 
     - <<: *conda_default
-      env: DESC="py2 tests" PYENV_VERSION=2.7
+      env: DESC="py2 tests" PYTHON_VERSION=2.7
 
     ########## END-USER PACKAGES ##########
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py27,py36,py37}-{flakes,unit,unit_deploy,examples,all_recommended}-{default}-{dev,pkg}
+envlist = {py27,py36}-{flakes,unit,unit_deploy,examples,all_recommended}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 # tox config (works with tox alone).
 
 [tox]
-#          python version             test group                  extra envs  extra commands       
-envlist = {py27,py35,py36}-{flakes,unit,unit_deploy,examples,all_recommended}-{default}-{dev,pkg}
+#          python version             test group                  extra envs  extra commands
+envlist = {py27,py36,py37}-{flakes,unit,unit_deploy,examples,all_recommended}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]


### PR DESCRIPTION
Not sure if this will work, but attempting to fix errors that have been cropping up in travis builds:

For instance in https://travis-ci.org/pyviz/panel/jobs/550370461:
```
0.03s$ pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
pyenv: version `3.6' is not installed (set by PYENV_VERSION environment variable)
The command "pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev" failed and exited with 1 during .
Your build has been stopped.
```