### PR TITLE
Fixed broken links

### DIFF
--- a/examples/getting_started/Introduction.ipynb
+++ b/examples/getting_started/Introduction.ipynb
@@ -315,19 +315,19 @@
     "\n",
     "As you have seen above, Panel can be used in several different ways, each appropriate for different applications:\n",
     "\n",
-    "- [Interact](Interact.ipynb): Instant GUI, given a function with arguments\n",
-    "- [Widgets](Widgets.ipynb): Explicitly instantiating widgets and linking them to actions\n",
-    "- [Parameters](Parameters.ipynb): Capturing parameters and their links to actions declaratively\n",
+    "- [Interact](../user_guide/Interact.ipynb): Instant GUI, given a function with arguments\n",
+    "- [Widgets](../user_guide/Widgets.ipynb): Explicitly instantiating widgets and linking them to actions\n",
+    "- [Parameters](../user_guide/Parameters.ipynb): Capturing parameters and their links to actions declaratively\n",
     "\n",
     "Just pick the style that seems most appropriate for the task you want to do, then study that section of the user guide. Regardless of which approach you take, you'll want to learn more about Panel's panes and layouts:\n",
     "\n",
-    "- [Components](Components.ipynb): An overview of the core components of Panel including Panes, Widgets and Layouts\n",
-    "- [Customization](Customization.ipynb): How to set styles and sizes of Panel components\n",
-    "- [Deploy & Export](Deploy_and_Export.ipynb): An overview on how to display, export and deploy Panel apps and dashboards\n",
+    "- [Components](../user_guide/Components.ipynb): An overview of the core components of Panel including Panes, Widgets and Layouts\n",
+    "- [Customization](../user_guide/Customization.ipynb): How to set styles and sizes of Panel components\n",
+    "- [Deploy & Export](../user_guide/Deploy_and_Export.ipynb): An overview on how to display, export and deploy Panel apps and dashboards\n",
     "\n",
     "Finally, if you are building a complex multi-stage application, you can consider our preliminary support for organizing and navigating between pages (still a work in progress!):\n",
     "\n",
-    "- [Pipelines](Pipelines.ipynb): Making multi-stage processing pipelines in notebooks and as deployed apps"
+    "- [Pipelines](../user_guide/Pipelines.ipynb): Making multi-stage processing pipelines in notebooks and as deployed apps"
    ]
   }
  ],


### PR DESCRIPTION
Might also want to consider rewording this last section, which was written before there was good reactive support and doesn't anticipate it much.  Maybe replace the separate API links with one link to the API section of the user guide?