### PR TITLE
fixed DateRangeSlider crash

### DIFF
--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -257,7 +257,7 @@ class IntRangeSlider(RangeSlider):
 
 class DateRangeSlider(_SliderBase):
 
-    value = param.Tuple(default=None, length=2)
+    value = param.Tuple(default=(None, None), length=2)
 
     start = param.Date(default=None)
 


### PR DESCRIPTION
Fixes https://github.com/pyviz/panel/issues/495
This small change gives the DateRangeSlider the same behavior as the DateSlider
