### PR TITLE
Add disabled widgetbox

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -355,6 +355,20 @@ class WidgetBox(Column):
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")
 
+    disabled = param.Boolean(default=False, doc="""
+       Whether the widget is disabled.""")
+
+    @param.depends('disabled', 'objects', watch=True)
+    def _disable_widgets(self):
+        for obj in self:
+            if hasattr(obj, 'disabled'):
+                obj.disabled = self.disabled
+
+    def __init__(self, *objects, **params):
+        super(WidgetBox, self).__init__(*objects, **params)
+        if self.disabled:
+            self._disable_widgets()
+
 
 class Tabs(ListPanel):
     """


### PR DESCRIPTION
https://github.com/pyviz/panel/issues/502
Seems to work for init, modifying state, adding new item, popping item, and working with non-widgets. 

```
import panel as pn
pn.extension()

wdgtbox = pn.WidgetBox(
    pn.widgets.Button(name='hi'),
    pn.widgets.Button(name='yo'),
    disabled=False
)
wdgtbox

# new cell

wdgtbox = pn.WidgetBox(
    pn.widgets.Button(name='Hi'),
    pn.widgets.Button(name='Yo'),
    disabled=True
)
wdgtbox

# new cell
wdgtbox.append('Irrelevant text')
wdgtbox.append(pn.widgets.Button(name='Hello'))

# new cell
wdgtbox.pop(-1)

# new cell

wdgtbox.disabled = False

```

I didn't use `isinstance(obj. Widget)` due to an import error (circular?)

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-32094dc94d29> in <module>()
----> 1 import panel as pn
      2 pn.extension()
      3 
      4 wdgtbox = pn.WidgetBox(
      5     pn.widgets.Button(name='hi'),

/mnt/c/Users/sephi/GOOGLE~1/Bash/panel (1)/panel/__init__.py in <module>()
      3 import param as _param
      4 
----> 5 from . import layout # noqa
      6 from . import links # noqa
      7 from . import pane # noqa

/mnt/c/Users/sephi/GOOGLE~1/Bash/panel (1)/panel/layout.py in <module>()
     17 from .util import param_name, param_reprs
     18 from .viewable import Reactive
---> 19 from .widgets import Widget
     20 
     21 

/mnt/c/Users/sephi/GOOGLE~1/Bash/panel (1)/panel/widgets/__init__.py in <module>()
     11     LiteralInput, StaticText, TextInput, Spinner)
     12 from .misc import Audio, VideoStream # noqa
---> 13 from .player import DiscretePlayer, Player # noqa
     14 from .slider import (# noqa
     15     DateSlider, DateRangeSlider, DiscreteSlider, FloatSlider,

/mnt/c/Users/sephi/GOOGLE~1/Bash/panel (1)/panel/widgets/player.py in <module>()
      9 from ..util import isIn, indexOf
     10 from .base import Widget
---> 11 from .select import SelectBase
     12 
     13 

/mnt/c/Users/sephi/GOOGLE~1/Bash/panel (1)/panel/widgets/select.py in <module>()
     17     Select as _BkSelect)
     18 
---> 19 from ..layout import Column, Row, VSpacer
     20 from ..util import as_unicode, isIn, indexOf
     21 from ..viewable import Layoutable

ImportError: cannot import name 'Column'
```
