### PR TITLE
Add fancy_layout option to HoloViews pane

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -210,12 +210,15 @@ class HoloViews(PaneBase):
         for i, dim in enumerate(dims):
             widget_type, widget, widget_kwargs = None, None, {}
             if fancy:
-                if i == 0:
-                    kwargs = {'margin': (20, 20, 5, 20)}
+                if i == 0 and i == (len(dims)-1):
+                    margin = (20, 20, 20, 20)
+                elif i == 0:
+                    margin = (20, 20, 5, 20)
                 elif i == (len(dims)-1):
-                    kwargs = {'margin': (5, 20, 20, 20)}
+                    margin = (5, 20, 20, 20)
                 else:
-                    kwargs = {'margin': (0, 20, 5, 20)}
+                    margin = (0, 20, 5, 20)
+                kwargs = {'margin': margin, 'width': 250}
             else:
                 kwargs = {}
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -10,6 +10,7 @@ from collections import OrderedDict, defaultdict
 from functools import partial
 
 import param
+
 from bokeh.models import Spacer as _BkSpacer
 
 from ..io import state
@@ -189,9 +190,10 @@ class HoloViews(PaneBase):
         return isinstance(obj, Dimensioned)
 
     @classmethod
-    def widgets_from_dimensions(cls, object, widget_types={}, widgets_type='individual', fancy=False):
+    def widgets_from_dimensions(cls, object, widget_types={}, widgets_type='individual',
+                                fancy=False):
         from holoviews.core import Dimension
-        from holoviews.core.util import isnumeric, unicode, datetime_types
+        from holoviews.core.util import isnumeric, unicode, datetime_types, unique_iterator
         from holoviews.core.traversal import unique_dimkeys
         from holoviews.plotting.util import get_dynamic_mode
         from ..widgets import Widget, DiscreteSlider, Select, FloatSlider, DatetimeInput
@@ -217,7 +219,7 @@ class HoloViews(PaneBase):
             else:
                 kwargs = {}
 
-            vals = dim.values or values.get(dim, None)
+            vals = list(unique_iterator(dim.values or values.get(dim, None)))
             dim_values[dim.name] = vals
             if widgets_type == 'scrubber':
                 if not vals:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -61,7 +61,7 @@ class HoloViews(PaneBase):
             self.layout.insert(0, HSpacer())
         self._update_widgets()
         if self.fancy_layout:
-            self.layout.append(HSpacer())
+            self.layout.insert(2, HSpacer())
         self._plots = {}
         self.param.watch(self._update_widgets, self._rerender_params)
 
@@ -91,12 +91,12 @@ class HoloViews(PaneBase):
         self.widget_box.objects = widgets
         if widgets and not self.widget_box in self.layout.objects:
             if self.fancy_layout:
-                self.layout.insert(2, Column(VSpacer(), self.widget_box, VSpacer()))
+                self.layout.append(Column(VSpacer(), self.widget_box, VSpacer()))
             else:
                 self.layout.append(self.widget_box)
         elif not widgets:
-            if self.fancy_layout and self.widget_box in self.layout[2]:
-                self.layout[2].pop(self.widget_box)
+            if self.fancy_layout and self.widget_box in self.layout[-1]:
+                self.layout[-1].pop(self.widget_box)
             elif self.widget_box in self.layout.objects:
                 self.layout.pop(self.widget_box)
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -69,12 +69,11 @@ class HoloViews(PaneBase):
     #----------------------------------------------------------------
 
     def _update_widgets(self, *events):
-        kwargs = {'margin': 20} if self.fancy_layout else {}
         if self.object is None:
             widgets, values = [], []
         else:
-            widgets, values = self.widgets_from_dimensions(self.object, self.widgets,
-                                                           self.widget_type, **kwargs)
+            widgets, values = self.widgets_from_dimensions(
+                self.object, self.widgets, self.widget_type, fancy=self.fancy_layout)
         self._values = values
 
         # Clean up anything models listening to the previous widgets
@@ -190,7 +189,7 @@ class HoloViews(PaneBase):
         return isinstance(obj, Dimensioned)
 
     @classmethod
-    def widgets_from_dimensions(cls, object, widget_types={}, widgets_type='individual', **kwargs):
+    def widgets_from_dimensions(cls, object, widget_types={}, widgets_type='individual', fancy=False):
         from holoviews.core import Dimension
         from holoviews.core.util import isnumeric, unicode, datetime_types
         from holoviews.core.traversal import unique_dimkeys
@@ -206,8 +205,18 @@ class HoloViews(PaneBase):
         values = dict() if dynamic else dict(zip(dims, zip(*keys)))
         dim_values = OrderedDict()
         widgets = []
-        for dim in dims:
+        for i, dim in enumerate(dims):
             widget_type, widget, widget_kwargs = None, None, {}
+            if fancy:
+                if i == 0:
+                    kwargs = {'margin': (20, 20, 5, 20)}
+                elif i == (len(dims)-1):
+                    kwargs = {'margin': (5, 20, 20, 20)}
+                else:
+                    kwargs = {'margin': (0, 20, 5, 20)}
+            else:
+                kwargs = {}
+
             vals = dim.values or values.get(dim, None)
             dim_values[dim.name] = vals
             if widgets_type == 'scrubber':

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -96,7 +96,7 @@ class HoloViews(PaneBase):
                 self.layout.append(self.widget_box)
         elif not widgets:
             if self.fancy_layout and self.widget_box in self.layout[-1]:
-                self.layout[-1].pop(self.widget_box)
+                self.layout.pop(-1)
             elif self.widget_box in self.layout.objects:
                 self.layout.pop(self.widget_box)
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -222,7 +222,9 @@ class HoloViews(PaneBase):
             else:
                 kwargs = {}
 
-            vals = list(unique_iterator(dim.values or values.get(dim, None)))
+            vals = dim.values or values.get(dim, None)
+            if vals is not None:
+                vals = list(unique_iterator(vals))
             dim_values[dim.name] = vals
             if widgets_type == 'scrubber':
                 if not vals:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -33,7 +33,7 @@ class HoloViews(PaneBase):
         The HoloViews backend used to render the plot (if None defaults
         to the currently selected renderer).""")
 
-    fancy_layout = param.Boolean(default=False, doc="""
+    fancy_layout = param.Boolean(default=False, constant=True, doc="""
         Whether the widgets should be laid out like the classic HoloViews
         widgets.""")
 

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -251,6 +251,31 @@ def test_holoviews_with_widgets_not_shown(document, comm):
 
 
 @hv_available
+def test_holoviews_fancy_layout(document, comm):
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
+
+    hv_pane = HoloViews(hmap, fancy_layout=True)
+    layout_obj = hv_pane.layout
+    layout = layout_obj.get_root(document, comm)
+    model = layout.children[1]
+    assert hv_pane is layout_obj[1]
+    assert len(hv_pane.widget_box.objects) == 2
+    assert hv_pane.widget_box is layout_obj[-1][1]
+    assert hv_pane.widget_box.objects[0].name == 'X'
+    assert hv_pane.widget_box.objects[1].name == 'Y'
+
+    assert hv_pane._models[layout.ref['id']][1].children[1] is model
+
+    hv_pane.object = hv.Curve([1, 2, 3])
+    assert len(hv_pane.widget_box.objects) == 0
+    assert len(layout_obj) == 3
+    assert hv_pane is layout_obj[1]
+
+    hv_pane.object = hmap
+    assert hv_pane.widget_box is layout_obj[-1][1]
+
+
+@hv_available
 def test_holoviews_widgets_from_holomap():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 


### PR DESCRIPTION
The current HoloViews pane generates a simple layout of the plot and the set of widgets generated from that plot. This makes it easy to compose these two components in different ways but it doesn't match the look that the old-style HoloViews widgets use. Since we want to swap out the widgets in HoloViews with as little disruption as possible this PR adds a ``fancy_layout`` option which tries to match the look and feel of the original widget implementation.

As a simple example here is the output of a HoloMap with this option enabled:

<img width="1122" alt="Screen Shot 2019-07-21 at 1 23 32 PM" src="https://user-images.githubusercontent.com/1550771/61590502-cd692e80-abba-11e9-9775-867e6977dc56.png">
