### PR TITLE
Add viewport property to plotly pane to hold the axis range for all axes

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -19,7 +19,7 @@ class PlotlyPlot(LayoutDOM):
                       'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js']
 
     __js_require__ = {'paths': {'plotly': 'https://cdn.plot.ly/plotly-latest.min',
-                                'lodash': 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js'},
+                                'lodash': 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min'},
                       'exports': {'plotly': 'Plotly',
                                   'lodash': '_'}}
 

--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -3,7 +3,7 @@ Defines a custom PlotlyPlot bokeh model to render Plotly plots.
 """
 import os
 
-from bokeh.core.properties import Dict, String, List, Any, Instance, Enum
+from bokeh.core.properties import Dict, String, List, Any, Instance, Enum, Int
 from bokeh.models import LayoutDOM, ColumnDataSource
 
 from ..compiler import CUSTOM_MODELS
@@ -17,8 +17,10 @@ class PlotlyPlot(LayoutDOM):
 
     __javascript__ = ['https://cdn.plot.ly/plotly-latest.min.js']
 
-    __js_require__ = {'paths': {'plotly': 'https://cdn.plot.ly/plotly-latest.min'},
-                      'exports': {'plotly': 'Plotly'}}
+    __js_require__ = {'paths': {'plotly': 'https://cdn.plot.ly/plotly-latest.min',
+                                'lodash': 'https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min'},
+                      'exports': {'plotly': 'Plotly',
+                                  'lodash': '_'}}
 
     __implementation__ = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'plotly.ts')
 
@@ -38,7 +40,8 @@ class PlotlyPlot(LayoutDOM):
     clickannotation_data = Dict(String, Any)
     selected_data = Dict(String, Any)
     viewport = Dict(String, Any)
-    viewport_update_policy = Enum("continuous", "mouseup")
+    viewport_update_policy = Enum("continuous", "mouseup", "throttle")
+    viewport_update_throttle = Int()
 
 
 CUSTOM_MODELS['panel.models.plotly.PlotlyPlot'] = PlotlyPlot

--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -15,10 +15,11 @@ class PlotlyPlot(LayoutDOM):
     a bokeh plot.
     """
 
-    __javascript__ = ['https://cdn.plot.ly/plotly-latest.min.js']
+    __javascript__ = ['https://cdn.plot.ly/plotly-latest.min.js',
+                      'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js']
 
     __js_require__ = {'paths': {'plotly': 'https://cdn.plot.ly/plotly-latest.min',
-                                'lodash': 'https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min'},
+                                'lodash': 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js'},
                       'exports': {'plotly': 'Plotly',
                                   'lodash': '_'}}
 

--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -3,7 +3,7 @@ Defines a custom PlotlyPlot bokeh model to render Plotly plots.
 """
 import os
 
-from bokeh.core.properties import Dict, String, List, Any, Instance
+from bokeh.core.properties import Dict, String, List, Any, Instance, Enum
 from bokeh.models import LayoutDOM, ColumnDataSource
 
 from ..compiler import CUSTOM_MODELS
@@ -37,6 +37,8 @@ class PlotlyPlot(LayoutDOM):
     hover_data = Dict(String, Any)
     clickannotation_data = Dict(String, Any)
     selected_data = Dict(String, Any)
+    viewport = Dict(String, Any)
+    viewport_update_policy = Enum("continuous", "mouseup")
 
 
 CUSTOM_MODELS['panel.models.plotly.PlotlyPlot'] = PlotlyPlot

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -258,7 +258,7 @@ export class PlotlyPlotView extends HTMLBoxView {
     // Call relayout if viewport differs from fullLayout
     _.forOwn(this.model.viewport, (value: any, key: string) => {
       if (!_.isEqual(_.get(fullLayout, key), value)) {
-        Plotly.relayout(this.el, this.model.viewport);
+        Plotly.relayout(this.el, _.cloneDeep(this.model.viewport));
         return false
       } else {
         return true
@@ -277,7 +277,7 @@ export class PlotlyPlotView extends HTMLBoxView {
       }
       let maybe_axis = prop.slice(0, 5);
       if (maybe_axis === 'xaxis' || maybe_axis === 'yaxis') {
-        viewport[prop + '.range'] = fullLayout[prop].range
+        viewport[prop + '.range'] = _.cloneDeep(fullLayout[prop].range)
       }
     }
 

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -105,7 +105,6 @@ export class PlotlyPlotView extends HTMLBoxView {
   connect_signals(): void {
     super.connect_signals();
 
-    this._updateSetViewportFunction();
     this.connect(this.model.properties.viewport_update_policy.change,
         this._updateSetViewportFunction);
     this.connect(this.model.properties.viewport_update_throttle.change,
@@ -144,6 +143,7 @@ export class PlotlyPlotView extends HTMLBoxView {
     }
 
     Plotly.react(this.el, data, this.model.layout, this.model.config).then(() => {
+        this._updateSetViewportFunction();
         this._updateViewportProperty();
       }
     );

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -101,6 +101,7 @@ export class PlotlyPlotView extends HTMLBoxView {
   model: PlotlyPlot
   _connected: string[]
   _setViewport: Function
+  _settingViewport: boolean = false
 
   connect_signals(): void {
     super.connect_signals();
@@ -251,7 +252,7 @@ export class PlotlyPlotView extends HTMLBoxView {
   }
 
   _updateViewportFromProperty(): void {
-    if (!Plotly) { return }
+    if (!Plotly || this._settingViewport) { return }
 
     const fullLayout = (this.el as any)._fullLayout;
 
@@ -290,11 +291,15 @@ export class PlotlyPlotView extends HTMLBoxView {
     if (this.model.viewport_update_policy === "continuous" ||
         this.model.viewport_update_policy === "mouseup") {
       this._setViewport = (viewport: any) => {
+        this._settingViewport = true;
         this.model.viewport = viewport
+        this._settingViewport = false;
       }
     } else {
       this._setViewport = _.throttle((viewport: any) => {
+        this._settingViewport = true;
         this.model.viewport = viewport;
+        this._settingViewport = false;
       }, this.model.viewport_update_throttle);
     }
   }

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -115,6 +115,8 @@ export class PlotlyPlotView extends HTMLBoxView {
     this.connect(this.model.properties.layout.change, this._relayout);
     this.connect(this.model.properties.config.change, this.render);
     this.connect(this.model.properties.data_sources.change, () => this._connect_sources());
+    this.connect(this.model.properties.viewport.change, this._updateViewportFromProperty);
+
 
     this._connected = [];
     this._connect_sources();
@@ -248,6 +250,22 @@ export class PlotlyPlotView extends HTMLBoxView {
     Plotly.relayout(this.el, this.model.layout)
   }
 
+  _updateViewportFromProperty(): void {
+    if (!Plotly) { return }
+
+    const fullLayout = (this.el as any)._fullLayout;
+
+    // Call relayout if viewport differs from fullLayout
+    _.forOwn(this.model.viewport, (value: any, key: string) => {
+      if (!_.isEqual(_.get(fullLayout, key), value)) {
+        Plotly.relayout(this.el, this.model.viewport);
+        return false
+      } else {
+        return true
+      }
+    });
+  }
+
   _updateViewportProperty(): void {
     const fullLayout = (this.el as any)._fullLayout;
     let viewport: any = {};
@@ -259,7 +277,7 @@ export class PlotlyPlotView extends HTMLBoxView {
       }
       let maybe_axis = prop.slice(0, 5);
       if (maybe_axis === 'xaxis' || maybe_axis === 'yaxis') {
-        viewport[prop] = fullLayout[prop].range
+        viewport[prop + '.range'] = fullLayout[prop].range
       }
     }
 

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -153,10 +153,10 @@ export class PlotlyPlotView extends HTMLBoxView {
     // Install callbacks
     //  - plotly_relayout
     (<PlotlyHTMLElement>(this.el)).on('plotly_relayout', (eventData: any) => {
-      this.model.relayout_data = filterEventData(
-          this.el, eventData, 'relayout');
-
       if (eventData['_update_from_property'] !== true) {
+        this.model.relayout_data = filterEventData(
+            this.el, eventData, 'relayout');
+
         this._updateViewportProperty();
       }
     });

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -157,6 +157,7 @@ class Plotly(PaneBase):
         model = PlotlyPlot(data=json.get('data', []),
                            layout=json.get('layout', {}),
                            config=self.config,
+                           viewport=self.viewport,
                            viewport_update_policy=self.viewport_update_policy,
                            viewport_update_throttle=self.viewport_update_throttle,
                            data_sources=sources)

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -33,8 +33,22 @@ class Plotly(PaneBase):
     selected_data = param.Dict(doc="""selected callback data""")
     viewport = param.Dict(doc="""current viewport state""")
     viewport_update_policy = param.Selector(
-        objects=["continuous", "mouseup", "throttle"])
-    viewport_update_throttle = param.Integer(bounds=(0, None), default=200)
+        objects=["continuous", "mouseup", "throttle"],
+        default="continuous",
+        doc="""\
+Policy by which the viewport parameter is updated during user interactions:
+ - "continuous": updates are synchronized continually while panning
+ - "mouseup": updates are synchronized when mouse button is released after panning
+ - "throttle": updates are synchronized while panning, at intervals determined by the
+               viewport_update_throttle parameter"""
+    )
+    viewport_update_throttle = param.Integer(
+        bounds=(0, None),
+        default=200,
+        doc='''\
+Time interval in milliseconds at which viewport updates are synchronized when
+viewport_update_policy is "throttle"'''
+    )
 
     _updates = True
 

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -31,6 +31,8 @@ class Plotly(PaneBase):
     hover_data = param.Dict(doc="""hover callback data""")
     clickannotation_data = param.Dict(doc="""clickannotation callback data""")
     selected_data = param.Dict(doc="""selected callback data""")
+    viewport = param.Dict(doc="""current viewport state""")
+    viewport_update_policy = param.Selector(objects=["continuous", "mouseup"])
 
     _updates = True
 
@@ -161,7 +163,8 @@ class Plotly(PaneBase):
         self._link_props(
             model, [
                 'config', 'relayout_data', 'restyle_data', 'click_data',  'hover_data',
-                'clickannotation_data', 'selected_data'
+                'clickannotation_data', 'selected_data', 'viewport',
+                'viewport_update_policy'
             ],
             doc,
             root,

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -32,7 +32,9 @@ class Plotly(PaneBase):
     clickannotation_data = param.Dict(doc="""clickannotation callback data""")
     selected_data = param.Dict(doc="""selected callback data""")
     viewport = param.Dict(doc="""current viewport state""")
-    viewport_update_policy = param.Selector(objects=["continuous", "mouseup"])
+    viewport_update_policy = param.Selector(
+        objects=["continuous", "mouseup", "throttle"])
+    viewport_update_throttle = param.Integer(bounds=(0, None), default=200)
 
     _updates = True
 
@@ -164,7 +166,7 @@ class Plotly(PaneBase):
             model, [
                 'config', 'relayout_data', 'restyle_data', 'click_data',  'hover_data',
                 'clickannotation_data', 'selected_data', 'viewport',
-                'viewport_update_policy'
+                'viewport_update_policy', 'viewport_update_throttle'
             ],
             doc,
             root,

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -157,6 +157,8 @@ class Plotly(PaneBase):
         model = PlotlyPlot(data=json.get('data', []),
                            layout=json.get('layout', {}),
                            config=self.config,
+                           viewport_update_policy=self.viewport_update_policy,
+                           viewport_update_throttle=self.viewport_update_throttle,
                            data_sources=sources)
 
         if root is None:


### PR DESCRIPTION
This PR is a follow on to the initial plotly callback support added in https://github.com/pyviz/panel/pull/529.

This adds a new `viewport` property to the plotly pane that holds the current axis ranges of all 2D cartesian axes in the figure.  This information isn't alway available through the `relayout_data` callback, for example when a figure is first displayed. This will be required to implement `Range*` streams in HoloViews, and by extension to support Datashader

Also added `viewport_update_policy` to control whether to update viewport
property with "continuous", "mouseup", or "throttle" policies.  When `viewport_update_policy='throttle'`, the throttle duration is controled by the new `viewport_update_throttle` property.  Here's an example of it in action.

```python
import panel as pn
import plotly.graph_objects as go
from plotly.subplots import make_subplots
pn.extension('plotly')

fig = make_subplots(rows=1, cols=2)
fig.add_scatter(y=[1, 3, 2], row=1, col=1);
fig.add_bar(y=[3, 2, 10], row=1, col=2);

fig_pane = pn.pane.Plotly(fig)
viewport_pane = pn.pane.Str()

pn.layout.Column(
    fig_pane,
    fig_pane.param.viewport,
    fig_pane.param.viewport_update_policy,
    fig_pane.param.viewport_update_throttle,
)
```
![viewport_plotly](https://user-images.githubusercontent.com/15064365/61961076-d0866500-af94-11e9-8972-a8a8892c2fba.gif)

The `viewport` property can also be set from Python to set the figure viewport.

![SetViewport](https://user-images.githubusercontent.com/15064365/61961318-3a067380-af95-11e9-86cd-0654bb3bf84b.gif)

With this, the viewports of multiple views of the same pane will stay in sync.

```python
pn.layout.Column(fig_pane, fig_pane)
```

![viewports_sync](https://user-images.githubusercontent.com/15064365/61961595-b1d49e00-af95-11e9-94d1-c2f31a3f0351.gif)

I added `lodash` as a dependecy of the Plotly pane so handle deep object equality and throttling.  Including lodash will also make it easier to port more of the `FigureWidget` logic to the panel pane in the future.