### PR TITLE
Fix nested object equality check in notebook comm logic

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -50,9 +50,9 @@ if (!window.PyViz) {{
 var receiver = window.PyViz.receivers['{plot_id}'];
 var events = receiver ? receiver._partial.content.events : [];
 for (var event of events) {{
-  if ((event.kind == 'ModelChanged') && (event.attr == '{change}') &&
-      (cb_obj.id == event.model.id) &&
-      (cb_obj['{change}'] == event.new)) {{
+  if ((event.kind === 'ModelChanged') && (event.attr === '{change}') &&
+      (cb_obj.id === event.model.id) &&
+      (JSON.stringify(cb_obj['{change}']) === JSON.stringify(event.new))) {{
     events.pop(events.indexOf(event))
     return;
   }}


### PR DESCRIPTION
Closes https://github.com/pyviz/panel/issues/552.

The equality check in the `ABORT_JS` JavaScript snippet in `panel/io/notebook.py` used `==` to check whether two objects are equal and therefore do not need to be synchronized.  With simple properties (numbers, strings, etc) this works fine, but for object properties (e.g. the `camera` state in the VTK pane) this check always returns `false`.

This could lead to infinite feedback loops in the property synchronization logic.  An example of this is shown in https://github.com/pyviz/panel/issues/552#issue-473735398.

This PR update the equality check to use `JSON.stringify` on the objects before comparison, which does s decent job handling nested objects of simple types. We could look into optimizing this if performance here is a concern, but there are lots of subtleties to writing a deep object equality function by hand, so it would take some care.

Here's an updated clip of the VTK pane rotation with the this fix:

![fixed_dragon](https://user-images.githubusercontent.com/15064365/62010925-534b2380-b13f-11e9-8737-6da99a3c4a4a.gif)
