### PR TITLE
Avoid dropping events across properties

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -66,7 +66,10 @@ def get_comm_customjs(change, client_comm, plot_id, timeout=5000, debounce=50):
     """
     # Abort callback if value matches last received event
     abort = ABORT_JS.format(plot_id=plot_id, change=change)
-    data_template = "data = {{{change}: cb_obj['{change}'], 'id': cb_obj.id}};"
+    data_template = """\
+data = {{{change}: cb_obj['{change}'], 'id': cb_obj.id}};
+cb_obj.event_name = '{change}';"""
+
     fetch_data = data_template.format(change=change)
     self_callback = JS_CALLBACK.format(
         comm_id=client_comm.id, timeout=timeout, debounce=debounce,


### PR DESCRIPTION
This PR is one approach to addressing the issue mentioned in https://github.com/pyviz/panel/pull/529#issuecomment-514299433.  The symptom in that case was that occasionally a selection event would be dropped, and not synchronized from JavaScript to Python.  And this problem only happened when hover data events were being synchronized around the same time.

Here's an overview of my understanding of what's currently happening between Panel and pyviz_comms.

When working in the notebook, Panel builds a JavaScript fragment for each synchronized property of a model.  This JavaScript fragment is used to create a Bokeh `CustomJS` object which is passed to Bokeh for execution whenever the given property changes.  This fragment is built in the `get_comm_customjs` function

https://github.com/pyviz/panel/blob/74efb05f8ef0178bff07f3af8d2cb4a5fe890a40/panel/io/notebook.py#L62

The bulk of the logic for this fragment is pulled from the `JS_CALLBACK` string from pyviz_comms.

https://github.com/pyviz/pyviz_comms/blob/master/pyviz_comms/__init__.py#L118

This `JS_CALLBACK` fragment has some [debouncing](https://codeburst.io/throttling-and-debouncing-in-javascript-b01cad5c8edf) logic, where events that occur in rapid succession are batched up and processed together.  This "batch" of events is stored in an array as the `event_buffer` property of the `comm_status` object.

https://github.com/pyviz/pyviz_comms/blob/e9f50e031f993f732e9c89035cabca4740c65244/pyviz_comms/__init__.py#L177-L181

Note that there is one buffer per comm, which for Panel means one buffer per model (across all synchronized properties in the model).

Before the events in the `event_buffer` array are processed, the `unique_events` function is run on the buffer to "Processes the event queue ignoring duplicate events of the same type".

https://github.com/pyviz/pyviz_comms/blob/e9f50e031f993f732e9c89035cabca4740c65244/pyviz_comms/__init__.py#L119-L122

This "event type" is pulled from the `event_name` property of the callback object

https://github.com/pyviz/pyviz_comms/blob/e9f50e031f993f732e9c89035cabca4740c65244/pyviz_comms/__init__.py#L184

The issue is that this `event_name` property is not defined for Panel models (at least the ones I looked at).  So, whenever events occur rapidly enough to build up in the `event_buffer`, all of the events except for the last one are dropped.

If all of these events are updates to the same property, then this is probably fine. But when the event buffer contains events that update multiple properties, this is a problem.

This PR makes the simple update of setting the `event_name` property of the callback object to the property name before the pyviz_comms logic processes it.  With this change, the logic for "ignoring duplicate events" will occur for each property individually.

With this change, I no longer have the problem with the Plotly pane of `selected_data` events being dropped occasionally when they are accompanied by rapid `hover_data` updates. 

