### PR TITLE
Plotly: Support preserving user-interaction states across updates with `uirevision` property

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -43,6 +43,7 @@ class PlotlyPlot(LayoutDOM):
     viewport = Dict(String, Any)
     viewport_update_policy = Enum("continuous", "mouseup", "throttle")
     viewport_update_throttle = Int()
+    _render_count = Int()
 
 
 CUSTOM_MODELS['panel.models.plotly.PlotlyPlot'] = PlotlyPlot

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -99,7 +99,6 @@ const filterEventData = (gd: any, eventData: any, event: string) => {
 
 export class PlotlyPlotView extends HTMLBoxView {
   model: PlotlyPlot
-  _connected: string[]
   _setViewport: Function
   _settingViewport: boolean = false
 
@@ -111,40 +110,19 @@ export class PlotlyPlotView extends HTMLBoxView {
     this.connect(this.model.properties.viewport_update_throttle.change,
         this._updateSetViewportFunction);
 
-    this.connect(this.model.properties.data.change, this.render);
-    this.connect(this.model.properties.layout.change, this._relayout);
-    this.connect(this.model.properties.config.change, this.render);
-    this.connect(this.model.properties.data_sources.change, () => this._connect_sources());
+    this.connect(this.model.properties._render_count.change, this.render);
     this.connect(this.model.properties.viewport.change, this._updateViewportFromProperty);
-
-
-    this._connected = [];
-    this._connect_sources();
-  }
-
-  _connect_sources(): void {
-    for (let i = 0; i < this.model.data.length; i++) {
-      const cds = this.model.data_sources[i]
-      if (this._connected.indexOf(cds.id) < 0) {
-        this.connect(cds.properties.data.change, () => this._restyle(i))
-        this._connected.push(cds.id)
-      }
-    }
   }
 
   render(): void {
-    super.render()
-    if (!Plotly) { return }
-    if (!this.model.data.length && !Object.keys(this.model.layout).length) {
-      Plotly.purge(this.el);
-    }
+    if (!(window as any).Plotly) { return }
+
     const data = [];
     for (let i = 0; i < this.model.data.length; i++) {
       data.push(this._get_trace(i, false));
     }
 
-    Plotly.react(this.el, _.cloneDeep(data), _.cloneDeep(this.model.layout), this.model.config).then(() => {
-        this._updateViewportFromProperty();
+    Plotly.react(this.el, data, _.cloneDeep(this.model.layout), this.model.config).then(() => {
         this._updateSetViewportFunction();
         this._updateViewportProperty();
       }
@@ -241,19 +219,6 @@ export class PlotlyPlotView extends HTMLBoxView {
     return trace;
   }
 
-  _restyle(index: number): void {
-    if (!Plotly) { return }
-    const trace = this._get_trace(index, true);
-
-    Plotly.restyle(this.el, _.cloneDeep(trace), index)
-  }
-
-  _relayout(): void {
-    if (!Plotly) { return }
-
-    Plotly.relayout(this.el, _.cloneDeep(this.model.layout))
-  }
-
   _updateViewportFromProperty(): void {
     if (!Plotly || this._settingViewport || !this.model.viewport ) { return }
 
@@ -330,6 +295,7 @@ export namespace PlotlyPlot {
     viewport: p.Property<any>
     viewport_update_policy: p.Property<string>
     viewport_update_throttle: p.Property<number>
+    _render_count: p.Property<number>
   }
 }
 
@@ -359,7 +325,8 @@ export class PlotlyPlot extends HTMLBox {
       selected_data: [ p.Any, {} ],
       viewport: [ p.Any, {} ],
       viewport_update_policy: [ p.String, "continuous" ],
-      viewport_update_throttle: [ p.Number, 200 ]
+      viewport_update_throttle: [ p.Number, 200 ],
+      _render_count: [ p.Number, 0 ],
     })
   }
 }

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -221,7 +221,7 @@ viewport_update_policy is "throttle"'''
                 cds = ColumnDataSource()
                 new_sources.append(cds)
 
-            update_sources = update_sources or self._update_data_sources(cds, trace)
+            update_sources = self._update_data_sources(cds, trace) or update_sources
         try:
             update_layout = model.layout != json.get('layout')
         except:


### PR DESCRIPTION
The goal of this PR is to make it possible to preserve user interaction states across updates to the plotly pane.  Examples of user interaction states include the current zoom level, the active modebar buttons, and the traces that were hidden by clicking on the legend.

By default, these user interaction states are reset during calls to `Plotly.react`, but Plotly.js provides `uirevision` properties for controlling which properties should persist across calls to `react`. See https://community.plot.ly/t/preserving-ui-state-like-zoom-in-dcc-graph-with-uirevision for more details.

Prior to this PR, there were a few issues that prevented `uirevision` from working properly.

 1. First, the `render` function in `panel/models/plotly.ts` sometimes called `Plotly.purge` prior to `Plotly.react`.  This deletes the prior plot state before `Plotly.react` has access to it, so it's not possible to preserve user interaction states.  This also takes away the efficiency of using `Plotly.react`.  The `Plotly.react` function is responsible for transforming whatever the prior figure state was into the new figure state, so the `purge` call shouldn't be needed.
 2. The `super.render()` call in the render function also has the effect of deleting the prior plot state.
 3. When an existing figure was updated, the traces, layout, and data sources were all updated independently.  This is advantageous in terms of synchronizing as little data as possible from Python  to JavaScript, but updating the figure using a combination of `relayout`, `restyle`, and `react` API calls made it hard to reason about when the `uirevision` property would be passed to the `react` function.

This PR addresses (1) and (2) by removing the calls to `purge` and `super.render()`.  Everything seems to work alright without the call to `super.render()`, is there anything to be concerned about with bypassing this logic?

To address (3), a new private `_render_count` param was added to store the number of times the figure has been rendered. The Python logic for updating the `layout`, `data`, and `data_sources` params has remained unchanged, but now the `_render_count` param is incremented if there is any change anywhere in the figure.  On the JavaScript side, `layout`, `data`, and `data_sources` properties are no longer watched for changes. Instead, the `_render_count` param is watched and when this changes, the figure is updated using `Plotly.react`.

Here's an example of responding to selection events to overlay a second trace with the selected points.  Without these changes, and without the `layout.uirevision=True` property on the figure, the modebar tool would reset to zoom after each selection.

```python
import panel as pn
import plotly.graph_objects as go
import plotly.express as px
import numpy as np
import pandas as pd
import plotly.io as pio
pn.extension("plotly")

df = px.data.iris()

scatter_opts = dict(mode='markers', unselected_marker_opacity=1.0, selected_marker_opacity=1.0)
fig = (go.Figure(layout_showlegend=False)
      .add_scatter(x=df.sepal_width, y=df.petal_length, marker_size=10, **scatter_opts)
      .add_scatter(x=[None], y=[None], **scatter_opts)
      .update_layout(
          uirevision=True
      ))
fig_pane = pn.pane.Plotly(fig)

def update_selected(event):
    selected_data = fig_pane.selected_data
    if not selected_data:
        point_inds = []
    else:
        point_inds = [point['pointNumber']
                      for point in selected_data['points']
                      if point['curveNumber'] == 0]
        
    selected_trace = fig.data[0]

    with fig.batch_update():
        fig.data[0].update(selectedpoints=[])
        fig.data[0].update(selectedpoints=None)
        fig.data[1].update(x=selected_trace.x[point_inds], y=selected_trace.y[point_inds])

fig_pane.param.watch(update_selected, 'selected_data')

fig_pane
```
![select_uirevision](https://user-images.githubusercontent.com/15064365/62056808-636d0c80-b1ec-11e9-8d8c-172923af4933.gif)


