### PR TITLE
Plotly: change default viewport update policy to "mouseup"

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -102,6 +102,7 @@ export class PlotlyPlotView extends HTMLBoxView {
   _setViewport: Function
   _settingViewport: boolean = false
   _plotInitialized: boolean = false
+  _reacting: boolean = false
 
   connect_signals(): void {
     super.connect_signals();
@@ -123,6 +124,7 @@ export class PlotlyPlotView extends HTMLBoxView {
       data.push(this._get_trace(i, false));
     }
 
+    this._reacting = true;
     Plotly.react(this.el, data, _.cloneDeep(this.model.layout), this.model.config).then(() => {
         this._updateSetViewportFunction();
         this._updateViewportProperty();
@@ -191,6 +193,7 @@ export class PlotlyPlotView extends HTMLBoxView {
           });
         }
         this._plotInitialized = true;
+        this._reacting = false;
       }
     );
   }
@@ -225,7 +228,7 @@ export class PlotlyPlotView extends HTMLBoxView {
   }
 
   _updateViewportFromProperty(): void {
-    if (!Plotly || this._settingViewport || !this.model.viewport ) { return }
+    if (!Plotly || this._settingViewport || this._reacting || !this.model.viewport ) { return }
 
     const fullLayout = (this.el as any)._fullLayout;
 

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -332,7 +332,7 @@ export class PlotlyPlot extends HTMLBox {
       clickannotation_data: [ p.Any, {} ],
       selected_data: [ p.Any, {} ],
       viewport: [ p.Any, {} ],
-      viewport_update_policy: [ p.String, "continuous" ],
+      viewport_update_policy: [ p.String, "mouseup" ],
       viewport_update_throttle: [ p.Number, 200 ],
       _render_count: [ p.Number, 0 ],
     })

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -33,12 +33,12 @@ class Plotly(PaneBase):
     selected_data = param.Dict(doc="""selected callback data""")
     viewport = param.Dict(doc="""current viewport state""")
     viewport_update_policy = param.Selector(
-        objects=["continuous", "mouseup", "throttle"],
-        default="continuous",
+        objects=["mouseup", "continuous", "throttle"],
+        default="mouseup",
         doc="""\
 Policy by which the viewport parameter is updated during user interactions:
- - "continuous": updates are synchronized continually while panning
  - "mouseup": updates are synchronized when mouse button is released after panning
+ - "continuous": updates are synchronized continually while panning
  - "throttle": updates are synchronized while panning, at intervals determined by the
                viewport_update_throttle parameter"""
     )


### PR DESCRIPTION
This PR changes the default viewport update policy for the plotly pane from "continuous" to "mouseup".

I'm still seeing some quirks when updating the plot from a callback on viewport changes when in "continuous" mode, so I'm more comfortable having the default be the more conservative "mouseup" mode.

This PR also adds an extra guard to prevent calling `relayout` while in the middle of a `react` call.  This avoided some unstable behavior I saw while playing with the continuous updates.