### PR TITLE
Added definition_order parameter to CrossSelector

### DIFF
--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -302,3 +302,13 @@ def test_cross_select_move_unselected_to_selected():
 
     assert cross_select.value == ['A', 1, 'B', 3]
     assert cross_select._lists[True].options == ['A', 'B', '1', '3']
+
+
+def test_cross_select_move_unselected_to_selected_not_definition_order():
+    cross_select = CrossSelector(options=['B', 'A', 'C', 1, 2, 3], value=['A', 1], size=5, definition_order=False)
+
+    cross_select._lists[False].value = ['B', '3']
+    cross_select._buttons[True].clicks = 1
+
+    assert cross_select.value == ['A', 1, 'B', 3]
+    assert cross_select._lists[True].options == ['A', '1', 'B', '3']

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -300,6 +300,10 @@ class CrossSelector(CompositeWidget, MultiSelect):
        The number of options shown at once (note this is the
        only way to control the height of this widget)""")
 
+    definition_order = param.Integer(default=True, doc=""" Whether to
+       preserve definition order after filtering. Disable to allow the
+       order of selection to define the order of the selected list.""")
+
     def __init__(self, *args, **kwargs):
         super(CrossSelector, self).__init__(**kwargs)
         # Compute selected and unselected values
@@ -418,7 +422,10 @@ class CrossSelector(CompositeWidget, MultiSelect):
         query = self._query[selected]
         other = self._lists[not selected].labels
         labels = self.labels
-        options = [k for k in labels if k not in other]
+        if self.definition_order:
+            options = [k for k in labels if k not in other]
+        else:
+            options = self._lists[selected].values
         if not query:
             self._lists[selected].options = options
             self._lists[selected].value = []


### PR DESCRIPTION
Right now you can't specify any chosen ordering in the selected list on the right side of a cross-selector as the filtering forces the items into the definition order for `options`. Note that when you set the order via `value`, the widget temporarily accepts the chosen ordering before reverting to definition order.

In some situations, you want to specify the ordering of the selected list based on the ordering you add/remove items to/from it. This PR adds a `definition_order` parameter that you can set to `False` to allow this use case.

I'm not entirely sure that `self._lists[selected].values` is the right set of values here but it does seem to work correctly in my (limited) testing. At the very least I no longer see the reordering back to definition order.

