### PR TITLE
Improved fancy layout for scrubber

### DIFF
--- a/examples/reference/panes/HoloViews.ipynb
+++ b/examples/reference/panes/HoloViews.ipynb
@@ -21,7 +21,10 @@
     "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "\n",
     "* **``backend``** (str): Any of the supported HoloViews backends ('bokeh', 'matplotlib', or 'plotly')\n",
+    "* **``center``** (boolean): Whether to center the plot\n",
     "* **``object``** (object): The HoloViews object being displayed\n",
+    "* **``widget_location``** (str): Where to lay out the widget relative to the plot \n",
+    "* **``widget_layout``** (ListPanel type): The object to lay the widgets out in, one of ``Row``, ``Column`` or ``WidgetBox``\n",
     "* **``widget_type``** (str): Whether to generate individual widgets for each dimension, or to use a global linear scrubber with dimensions concatenated.\n",
     "* **``widgets``** (dict): A mapping from dimension name to a widget class, instance, or dictionary of overrides to modify the default widgets.\n",
     "\n",
@@ -120,6 +123,32 @@
     "pn.Column(\n",
     "    pn.Row(*widgets),\n",
     "    hv_panel[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, more conveniently the HoloViews pane offers options to lay out the plot and widgets in a number of preconfigured arrangements using the ``center`` and ``widget_location`` parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.panel(dmap, center=True, widget_location='right_bottom')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``widget_location`` parameter accepts all of the following options:\n",
+    "    \n",
+    "    ['left', 'bottom', 'right', 'top', 'top_left', 'top_right', 'bottom_left',\n",
+    "     'bottom_right', 'left_top', 'left_bottom', 'right_top', 'right_bottom']"
    ]
   },
   {

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -88,14 +88,17 @@ class Panel(Reactive):
         for i, pane in enumerate(self.objects):
             pane = panel(pane)
             self.objects[i] = pane
+
+        for obj in old_objects:
+            if obj not in self.objects:
+                obj._cleanup(root)
+
+        for i, pane in enumerate(self.objects):
             if pane in old_objects:
                 child, _ = pane._models[root.ref['id']]
             else:
                 child = pane._get_model(doc, root, model, comm)
             new_models.append(child)
-        for obj in old_objects:
-            if obj not in self.objects:
-                obj._cleanup(root)
         return new_models
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
@@ -216,6 +219,7 @@ class ListPanel(Panel):
                                  (expected, type(self).__name__))
         for i, pane in zip(range(start, end), panes):
             new_objects[i] = panel(pane)
+
         self.objects = new_objects
 
     def clone(self, *objects, **params):
@@ -472,6 +476,12 @@ class Tabs(ListPanel):
         for i, (name, pane) in enumerate(zip(self._names, self)):
             pane = panel(pane, name=name)
             self.objects[i] = pane
+
+        for obj in old_objects:
+            if obj not in self.objects:
+                obj._cleanup(root)
+
+        for i, (name, pane) in enumerate(zip(self._names, self)):
             if pane in old_objects:
                 child, _ = pane._models[root.ref['id']]
             else:
@@ -479,9 +489,6 @@ class Tabs(ListPanel):
             child = BkPanel(title=name, name=pane.name, child=child,
                             closable=self.closable)
             new_models.append(child)
-        for obj in old_objects:
-            if obj not in self.objects:
-                obj._cleanup(root)
         return new_models
 
     #----------------------------------------------------------------

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -36,7 +36,7 @@ class HoloViews(PaneBase):
     center = param.Boolean(default=False, doc="""
         Whether to center the plot.""")
 
-    widget_location = param.ObjectSelector(default='right', objects=[
+    widget_location = param.ObjectSelector(default='right_top', objects=[
         'left', 'bottom', 'right', 'top', 'top_left', 'top_right',
         'bottom_left', 'bottom_right', 'left_top', 'left_bottom',
         'right_top', 'right_bottom'], doc="""

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -14,7 +14,7 @@ import param
 from bokeh.models import Spacer as _BkSpacer
 
 from ..io import state
-from ..layout import Panel, ListPanel, Column, WidgetBox, HSpacer, VSpacer, Row
+from ..layout import Panel, Column, WidgetBox, HSpacer, VSpacer, Row
 from ..viewable import Viewable
 from ..widgets import Player
 from .base import PaneBase, Pane

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -278,12 +278,11 @@ def test_holoviews_fancy_layout(document, comm):
 
 
 @hv_available
-def test_holoviews_fancy_layout_scrubber(document, comm):
+def test_holoviews_fancy_layout_scrubber():
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
     hv_pane = HoloViews(hmap, fancy_layout=True, widget_type='scrubber')
     layout_obj = hv_pane.layout
-    layout = layout_obj.get_root(document, comm)
     assert hv_pane is layout_obj[1][0]
     assert len(hv_pane.widget_box.objects) == 1
     assert hv_pane.widget_box is layout_obj[1][1][1]

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -268,11 +268,35 @@ def test_holoviews_fancy_layout(document, comm):
 
     hv_pane.object = hv.Curve([1, 2, 3])
     assert len(hv_pane.widget_box.objects) == 0
-    assert len(layout_obj) == 3
+    assert len(layout_obj) == 4
     assert hv_pane is layout_obj[1]
+    assert len(layout_obj[-1]) == 0
 
     hv_pane.object = hmap
     assert hv_pane.widget_box is layout_obj[-1][1]
+    assert len(layout_obj[-1]) == 3
+
+
+@hv_available
+def test_holoviews_fancy_layout_scrubber(document, comm):
+    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
+
+    hv_pane = HoloViews(hmap, fancy_layout=True, widget_type='scrubber')
+    layout_obj = hv_pane.layout
+    layout = layout_obj.get_root(document, comm)
+    assert hv_pane is layout_obj[1][0]
+    assert len(hv_pane.widget_box.objects) == 1
+    assert hv_pane.widget_box is layout_obj[1][1][1]
+
+    hv_pane.object = hv.Curve([1, 2, 3])
+    assert len(hv_pane.widget_box.objects) == 0
+    assert len(layout_obj) == 3
+    assert hv_pane is layout_obj[1][0]
+    assert len(layout_obj[1][-1]) == 0
+
+    hv_pane.object = hmap
+    assert hv_pane.widget_box is layout_obj[1][1][1]
+    assert len(layout_obj[1][1]) == 3
 
 
 @hv_available

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -254,7 +254,7 @@ def test_holoviews_with_widgets_not_shown(document, comm):
 def test_holoviews_layouts(document, comm):
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
-    hv_pane = HoloViews(hmap)
+    hv_pane = HoloViews(hmap, backend='bokeh')
     layout = hv_pane.layout
     model = layout.get_root(document, comm)
     

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -208,12 +208,12 @@ def test_holoviews_updates_widgets(document, comm):
 
     hv_pane.widgets = {'X': Select}
     assert isinstance(hv_pane.widget_box[0], Select)
-    assert isinstance(layout.children[1].children[0], BkSelect)
+    assert isinstance(layout.children[1].children[1].children[0], BkSelect)
 
     hv_pane.widgets = {'X': DiscreteSlider}
     assert isinstance(hv_pane.widget_box[0], DiscreteSlider)
-    assert isinstance(layout.children[1].children[0], BkColumn)
-    assert isinstance(layout.children[1].children[0].children[1], BkSlider)
+    assert isinstance(layout.children[1].children[1].children[0], BkColumn)
+    assert isinstance(layout.children[1].children[1].children[0].children[1], BkSlider)
 
 @hv_available
 def test_holoviews_widgets_update_plot(document, comm):
@@ -251,51 +251,77 @@ def test_holoviews_with_widgets_not_shown(document, comm):
 
 
 @hv_available
-def test_holoviews_fancy_layout(document, comm):
+def test_holoviews_layouts(document, comm):
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
-    hv_pane = HoloViews(hmap, fancy_layout=True)
-    layout_obj = hv_pane.layout
-    layout = layout_obj.get_root(document, comm)
-    model = layout.children[1]
-    assert hv_pane is layout_obj[1]
-    assert len(hv_pane.widget_box.objects) == 2
-    assert hv_pane.widget_box is layout_obj[-1][1]
-    assert hv_pane.widget_box.objects[0].name == 'X'
-    assert hv_pane.widget_box.objects[1].name == 'Y'
+    hv_pane = HoloViews(hmap)
+    layout = hv_pane.layout
+    model = layout.get_root(document, comm)
+    
+    for center in (True, False):
+        for loc in HoloViews.param.widget_location.objects:
+            hv_pane.set_param(center=center, widget_location=loc)
+            if center:
+                if loc.startswith('left'):
+                    assert len(layout) == 4
+                    widgets, hv_obj = layout[0], layout[2]
+                    wmodel, hv_model = model.children[0],  model.children[2]
+                elif loc.startswith('right'):
+                    assert len(layout) == 4
+                    hv_obj, widgets = layout[1], layout[3]
+                    wmodel, hv_model = model.children[3],  model.children[1]
+                elif loc.startswith('top'):
+                    assert len(layout) == 3
+                    col = layout[1]
+                    cmodel = model.children[1]
+                    assert isinstance(col, Column)
+                    widgets, hv_obj = col
+                    wmodel, hv_model = cmodel.children[0],  cmodel.children[1]
+                elif loc.startswith('bottom'):
+                    col = layout[1]
+                    cmodel = model.children[1]
+                    assert isinstance(col, Column)
+                    hv_obj, widgets = col
+                    wmodel, hv_model = cmodel.children[1],  cmodel.children[0]
+            else:
+                if loc.startswith('left'):
+                    assert len(layout) == 2
+                    widgets, hv_obj = layout
+                    wmodel, hv_model = model.children
+                elif loc.startswith('right'):
+                    assert len(layout) == 2
+                    hv_obj, widgets = layout
+                    hv_model, wmodel = model.children
+                elif loc.startswith('top'):
+                    assert len(layout) == 1
+                    col = layout[0]
+                    cmodel = model.children[0]
+                    assert isinstance(col, Column)
+                    widgets, hv_obj = col
+                    wmodel, hv_model = cmodel.children
+                elif loc.startswith('bottom'):
+                    assert len(layout) == 1
+                    col = layout[0]
+                    cmodel = model.children[0]
+                    assert isinstance(col, Column)
+                    hv_obj, widgets = col
+                    hv_model, wmodel = cmodel.children
+            assert hv_pane is hv_obj
+            assert isinstance(hv_model, Figure)
 
-    assert hv_pane._models[layout.ref['id']][1].children[1] is model
-
-    hv_pane.object = hv.Curve([1, 2, 3])
-    assert len(hv_pane.widget_box.objects) == 0
-    assert len(layout_obj) == 4
-    assert hv_pane is layout_obj[1]
-    assert len(layout_obj[-1]) == 0
-
-    hv_pane.object = hmap
-    assert hv_pane.widget_box is layout_obj[-1][1]
-    assert len(layout_obj[-1]) == 3
-
-
-@hv_available
-def test_holoviews_fancy_layout_scrubber():
-    hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
-
-    hv_pane = HoloViews(hmap, fancy_layout=True, widget_type='scrubber')
-    layout_obj = hv_pane.layout
-    assert hv_pane is layout_obj[1][0]
-    assert len(hv_pane.widget_box.objects) == 1
-    assert hv_pane.widget_box is layout_obj[1][1][1]
-
-    hv_pane.object = hv.Curve([1, 2, 3])
-    assert len(hv_pane.widget_box.objects) == 0
-    assert len(layout_obj) == 3
-    assert hv_pane is layout_obj[1][0]
-    assert len(layout_obj[1][-1]) == 0
-
-    hv_pane.object = hmap
-    assert hv_pane.widget_box is layout_obj[1][1][1]
-    assert len(layout_obj[1][1]) == 3
+            if loc in ('left', 'right', 'top', 'bottom',
+                       'top_right', 'right_bottom', 'bottom_right',
+                       'left_bottom'):
+                box = widgets[1]
+                boxmodel = wmodel.children[1]
+            else:
+                box = widgets[0]
+                boxmodel = wmodel.children[0]
+            assert hv_pane.widget_box is box
+            assert isinstance(boxmodel, BkColumn)
+            assert isinstance(boxmodel.children[0], BkColumn)
+            assert isinstance(boxmodel.children[0].children[1], BkSlider)
+            assert isinstance(boxmodel.children[1], BkSelect)
 
 
 @hv_available

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -208,12 +208,12 @@ def test_holoviews_updates_widgets(document, comm):
 
     hv_pane.widgets = {'X': Select}
     assert isinstance(hv_pane.widget_box[0], Select)
-    assert isinstance(layout.children[1].children[1].children[0], BkSelect)
+    assert isinstance(layout.children[1].children[0].children[0], BkSelect)
 
     hv_pane.widgets = {'X': DiscreteSlider}
     assert isinstance(hv_pane.widget_box[0], DiscreteSlider)
-    assert isinstance(layout.children[1].children[1].children[0], BkColumn)
-    assert isinstance(layout.children[1].children[1].children[0].children[1], BkSlider)
+    assert isinstance(layout.children[1].children[0].children[0], BkColumn)
+    assert isinstance(layout.children[1].children[0].children[0].children[1], BkSlider)
 
 @hv_available
 def test_holoviews_widgets_update_plot(document, comm):


### PR DESCRIPTION
HoloViews pane now offers a number of options for arranging the plot and widgets

## left

<img width="908" alt="Screen Shot 2019-08-06 at 10 46 10 AM" src="https://user-images.githubusercontent.com/1550771/62525505-d6533480-b837-11e9-99da-55f9283e2e0c.png">

## top

<img width="607" alt="Screen Shot 2019-08-06 at 10 46 19 AM" src="https://user-images.githubusercontent.com/1550771/62525520-dbb07f00-b837-11e9-9edf-e8911b76e203.png">

## right

<img width="902" alt="Screen Shot 2019-08-06 at 10 45 10 AM" src="https://user-images.githubusercontent.com/1550771/62525457-bde31a00-b837-11e9-89ff-f58c8050cba2.png">

## bottom

<img width="608" alt="Screen Shot 2019-08-06 at 10 46 02 AM" src="https://user-images.githubusercontent.com/1550771/62525482-ccc9cc80-b837-11e9-8fc9-2f49da6a3042.png">

## center_left

<img width="1246" alt="Screen Shot 2019-08-06 at 10 46 37 AM" src="https://user-images.githubusercontent.com/1550771/62525540-e10dc980-b837-11e9-8753-c608e139d7a9.png">

## center_top

<img width="1262" alt="Screen Shot 2019-08-06 at 10 46 52 AM" src="https://user-images.githubusercontent.com/1550771/62525548-e66b1400-b837-11e9-8959-83491c2548b1.png">

## center_right

<img width="1271" alt="Screen Shot 2019-08-06 at 10 47 09 AM" src="https://user-images.githubusercontent.com/1550771/62525557-eb2fc800-b837-11e9-9cc2-72cc80cc8c4c.png">

## center_bottom

<img width="1336" alt="Screen Shot 2019-08-06 at 10 47 25 AM" src="https://user-images.githubusercontent.com/1550771/62525564-eec34f00-b837-11e9-8adf-34b153c37027.png">
