### PR TITLE
Plotly: Fixes for continuous viewport updates

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -47,8 +47,15 @@ ABORT_JS = """
 if (!window.PyViz) {{
   return;
 }}
+var events = [];
 var receiver = window.PyViz.receivers['{plot_id}'];
-var events = receiver ? receiver._partial.content.events : [];
+if (receiver &&
+        receiver._partial &&
+        receiver._partial.content &&
+        receiver._partial.content.events) {{
+    events = receiver._partial.content.events;
+}}
+
 for (var event of events) {{
   if ((event.kind === 'ModelChanged') && (event.attr === '{change}') &&
       (cb_obj.id === event.model.id) &&

--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -41,7 +41,7 @@ class PlotlyPlot(LayoutDOM):
     clickannotation_data = Dict(String, Any)
     selected_data = Dict(String, Any)
     viewport = Dict(String, Any)
-    viewport_update_policy = Enum("continuous", "mouseup", "throttle")
+    viewport_update_policy = Enum( "mouseup", "continuous", "throttle")
     viewport_update_throttle = Int()
     _render_count = Int()
 


### PR DESCRIPTION
This PR contains a few more fixes for using the contunuous viewport update mode with the Plotly pane.

ccf45a8 Makes the Bokeh enum order consistent with the Param selector ordering.  Not quite sure why this was significant, but the mismatch caused the initial value of the `viewport_update_policy` param to not be synchronized from Python to JavaScript.

f8e5894 Adds a fix for calling `react` while panning.  Basically, while panning the axis `range` values should be set to the current `layout.range` values (the values from before the pan action began).  This avoids the unstable panning behavior that was happening when updating the figure while panning. 

327f5b5 is a fix for the "Cannot read property 'content' of null" error that I've been getting in Panel when property updates in both directions are happening very rapidly.  This error happened after a few seconds of dragging a plot with continuous update mode, if an update callback updated the same figure.

Basically, we were previously checking if `receiver` was `null`/`undefined`.  But in these high throughput situations, it sometimes happened that `receiver`  was not null, but `receiver._partial` was. With these extra guards, the error is fixed for me.

Here's an example of continuous update behavior with this PR.

![plotly_panel](https://user-images.githubusercontent.com/15064365/62538704-72be0c80-b821-11e9-9b96-746a67b58153.gif)

If you watch closely in the middle of the clip, there is still an occasion blip/jump while panning that I haven't tracked down. But overall the experience is greatly improved.


