### PR TITLE
Ensure that events are held while hooks are applied

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -61,12 +61,19 @@ class Panel(Reactive):
         if self._rename['objects'] in msg:
             old = events['objects'].old
             msg[self._rename['objects']] = self._get_objects(model, old, doc, root, comm)
+
+        held = doc._hold
+        if comm is None and not held:
+            doc.hold()
         model.update(**msg)
 
         from .io import state
         ref = root.ref['id']
         if ref in state._views:
             state._views[ref][0]._preprocess(root)
+
+        if comm is None and not held:
+            doc.unhold()
 
     #----------------------------------------------------------------
     # Model API


### PR DESCRIPTION
In some vague circumstances I haven't been able to pin down changing a model after it has been dynamically added to a layout will not actually sync the model change client side. This PR ensures that events are held and combined while hooks are applied which allows changing models before they are synced with the frontend and ensures those changes actually occur.