### PR TITLE
Extending FileInput: Add accept param

### DIFF
--- a/examples/reference/widgets/FileInput.ipynb
+++ b/examples/reference/widgets/FileInput.ipynb
@@ -24,6 +24,7 @@
     "\n",
     "##### Core\n",
     "\n",
+    "* **``accept``** (str):  A list of file input filters that restrict what files the user can pick from.\n",
     "* **``filename``** (str): The filename of the uploaded file\n",
     "* **``mime_type``** (str): The mime type of the uploaded file\n",
     "* **``value``** (bytes): A bytes object containing the file data\n",
@@ -78,12 +79,50 @@
     "if file_input.value is not None:\n",
     "    file_input.save('test.png')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `accept` parameter restricts what files the user can pick from. This consists of comma-separated list of standard HTML\n",
+    "file input filters. Values can be:\n",
+    "\n",
+    "* `<file extension>` - Specific file extension(s) (e.g: .gif, .jpg, .png, .doc) are pickable\n",
+    "* `audio/*` - all sound files are pickable\n",
+    "* `video/*` - all video files are pickable\n",
+    "* `image/*` - all image files are pickable\n",
+    "* `<media type>` - A valid [IANA Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml), with no parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_input = pn.widgets.FileInput(accept='.csv,.json')\n",
+    "\n",
+    "file_input"
+   ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -53,7 +53,7 @@ def test_date_picker(document, comm):
 
 
 def test_file_input(document, comm):
-    file_input = FileInput()
+    file_input = FileInput(accept='.txt')
 
     widget = file_input.get_root(document, comm=comm)
 
@@ -62,6 +62,7 @@ def test_file_input(document, comm):
     file_input._comm_change({'mime_type': 'text/plain', 'value': 'U29tZSB0ZXh0Cg=='})
     assert file_input.value == b'Some text\n'
     assert file_input.mime_type == 'text/plain'
+    assert file_input.accept == '.txt'
 
 
 def test_literal_input(document, comm):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -32,6 +32,8 @@ class TextInput(Widget):
 
 class FileInput(Widget):
 
+    accept = param.String(default=None)
+
     filename = param.String(default=None)
 
     mime_type = param.String(default=None)


### PR DESCRIPTION
Bokeh's FileInput have an attribute `accept` which is not passed through
`panel` so this PR will allow `panel`'s FileInput to access `accept`
attribute. The `accept` attribute restrict FileInput to files with
specified extensions.

- [x]  Add accept param
- [x] Add tests
- [x]  Add docs