### PR TITLE
VTK panel scalar array choice correction

### DIFF
--- a/panel/pane/vtk/enums.py
+++ b/panel/pane/vtk/enums.py
@@ -1,0 +1,21 @@
+
+from enum import Enum
+
+
+class SCALAR_MODE(Enum):
+    Default = 0
+    UsePointData = 1
+    UseCellData = 2
+    UsePointFieldData = 3
+    UseCellFieldData = 4
+    UseFieldData = 5
+
+
+class COLOR_MODE(Enum):
+    DirectScalars = 0
+    MapScalars = 1
+
+
+class ACCESS_MODE(Enum):
+    ById = 0
+    ByName = 1


### PR DESCRIPTION
Work in progress
Need to test if the correction handle correctly the colormap of the vtk mesh in all case and does not bring regression
Should correct in https://github.com/pyvista/pyvista/pull/268 : 
- https://github.com/pyvista/pyvista-support/issues/15
- Make sure scalar/color mapping is working - sometimes the mapping is totally wrong. Blood vessels example shows this
- custom colormaps (see #345) (except we must create a pyvista plotter since mesh.plot(use_panel=True) does not work anymore due to auto_close=True
![image](https://user-images.githubusercontent.com/18531147/63281232-8c913200-c2ac-11e9-9508-010d9b1e70bf.png)

Concerning :
- Send text/labels to VTKjs or at least don't throw an error (text added with add_point_labels and add_text)
For me it does not throw error but the text does not show

@banesullivan it will be great if you could test it