### PR TITLE
Removed some unused imports and names from examples

### DIFF
--- a/examples/gallery/apis/stocks_mpl.ipynb
+++ b/examples/gallery/apis/stocks_mpl.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import panel as pn\n",
     "import pandas as pd\n",
-    "import matplotlib\n",
     "from matplotlib.figure import Figure\n",
     "# not needed for mpl >= 3.1\n",
     "from matplotlib.backends.backend_agg import FigureCanvas\n",
@@ -45,7 +44,7 @@
     "def get_plot(ticker, window_size):\n",
     "    fig = Figure(figsize=(10, 6))\n",
     "    ax = fig.subplots()\n",
-    "    cv = FigureCanvas(fig)  # not needed for mpl >= 3.1\n",
+    "    FigureCanvas(fig)  # not needed for mpl >= 3.1\n",
     "    df = get_df(ticker, window_size)\n",
     "    df.plot.line('date', 'close', ax=ax)\n",
     "    return fig"
@@ -96,7 +95,7 @@
     "def get_plot(ticker, window_size):\n",
     "    fig = Figure(figsize=(10, 6))\n",
     "    ax = fig.subplots()\n",
-    "    cv = FigureCanvas(fig)  # not needed for mpl >= 3.1\n",
+    "    FigureCanvas(fig)  # not needed for mpl >= 3.1\n",
     "    df = get_df(ticker, window_size)\n",
     "    df.plot.line('date', 'close', ax=ax)\n",
     "    return fig\n",

--- a/examples/gallery/layout/distribution_tabs.ipynb
+++ b/examples/gallery/layout/distribution_tabs.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import panel as pn\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import holoviews as hv\n",
     "\n",
     "pn.extension()"

--- a/examples/gallery/links/plotly_link.ipynb
+++ b/examples/gallery/links/plotly_link.ipynb
@@ -25,8 +25,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "\n",
     "xs, ys = np.mgrid[-3:3:0.2, -3:3:0.2]\n",
     "contour = dict(ncontours=4, type='contour', z=np.sin(xs**2*ys**2))\n",
     "layout = {'width': 600, 'height': 500, 'margin': {'l': 8, 'b': 8, 'r': 8, 't': 8}}\n",

--- a/examples/gallery/param/reactive_plots.ipynb
+++ b/examples/gallery/param/reactive_plots.ipynb
@@ -16,7 +16,6 @@
     "import hvplot.pandas\n",
     "import param\n",
     "import panel as pn\n",
-    "import pandas as pd\n",
     "\n",
     "from bokeh.sampledata.iris import flowers\n",
     "\n",

--- a/examples/gallery/param/reactive_tables.ipynb
+++ b/examples/gallery/param/reactive_tables.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import param\n",
     "import panel as pn\n",
-    "import pandas as pd\n",
     "\n",
     "from bokeh.sampledata.iris import flowers\n",
     "from bokeh.sampledata.autompg import autompg_clean\n",

--- a/examples/gallery/simple/iris_kmeans.ipynb
+++ b/examples/gallery/simple/iris_kmeans.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import panel as pn\n",
     "import hvplot.pandas\n",
     "\n",

--- a/examples/reference/layouts/GridSpec.ipynb
+++ b/examples/reference/layouts/GridSpec.ipynb
@@ -117,7 +117,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import holoviews as hv\n",
     "import holoviews.plotting.bokeh\n",
     "\n",

--- a/examples/user_guide/Components.ipynb
+++ b/examples/user_guide/Components.ipynb
@@ -318,7 +318,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import holoviews as hv\n",
     "import holoviews.plotting.bokeh\n",
     "\n",

--- a/examples/user_guide/Links.ipynb
+++ b/examples/user_guide/Links.ipynb
@@ -28,7 +28,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import param\n",
     "import numpy as np\n",
     "import panel as pn\n",
     "pn.extension()"

--- a/examples/user_guide/Pipelines.ipynb
+++ b/examples/user_guide/Pipelines.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import param\n",
     "import panel as pn\n",
-    "import holoviews as hv\n",
     "\n",
     "pn.extension('katex')"
    ]


### PR DESCRIPTION
I addressed what I think are the obvious/uncontroversial ones from the output below:

```
(nbsdev) D:\code\pyviz\panel>pytest -v --nbsmoke-lint --nbsmoke-lint-debug examples
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- d:\venvs\nbsdev\scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\code\pyviz\panel, inifile: tox.ini
plugins: cov-2.7.1, nbsmoke-0.2.8.post44+gbdfd485
collected 92 items / 190 skipped

examples/gallery/apis/stocks_altair.ipynb::D:\code\pyviz\panel\examples\gallery\apis\stocks_altair.ipynb PASSED                               [  1%]
examples/gallery/apis/stocks_hvplot.ipynb::D:\code\pyviz\panel\examples\gallery\apis\stocks_hvplot.ipynb PASSED                               [  2%]
examples/gallery/apis/stocks_mpl.ipynb::D:\code\pyviz\panel\examples\gallery\apis\stocks_mpl.ipynb FAILED                                     [  3%]
examples/gallery/apis/stocks_plotly.ipynb::D:\code\pyviz\panel\examples\gallery\apis\stocks_plotly.ipynb PASSED                               [  4%]
examples/gallery/demos/clifford.ipynb::D:\code\pyviz\panel\examples\gallery\demos\clifford.ipynb PASSED                                       [  5%]
examples/gallery/demos/gapminder.ipynb::D:\code\pyviz\panel\examples\gallery\demos\gapminder.ipynb PASSED                                     [  6%]
examples/gallery/demos/glaciers.ipynb::D:\code\pyviz\panel\examples\gallery\demos\glaciers.ipynb PASSED                                       [  7%]
examples/gallery/demos/nyc_taxi.ipynb::D:\code\pyviz\panel\examples\gallery\demos\nyc_taxi.ipynb PASSED                                       [  8%]
examples/gallery/dynamic/dynamic_plot_layout.ipynb::D:\code\pyviz\panel\examples\gallery\dynamic\dynamic_plot_layout.ipynb PASSED             [  9%]
examples/gallery/dynamic/dynamic_ui.ipynb::D:\code\pyviz\panel\examples\gallery\dynamic\dynamic_ui.ipynb PASSED                               [ 10%]
examples/gallery/dynamic/dynamic_widget_values.ipynb::D:\code\pyviz\panel\examples\gallery\dynamic\dynamic_widget_values.ipynb PASSED         [ 11%]
examples/gallery/external/DataTable.ipynb::D:\code\pyviz\panel\examples\gallery\external\DataTable.ipynb PASSED                               [ 13%]
examples/gallery/external/deck.gl.ipynb::D:\code\pyviz\panel\examples\gallery\external\deck.gl.ipynb PASSED                                   [ 14%]
examples/gallery/layout/distribution_tabs.ipynb::D:\code\pyviz\panel\examples\gallery\layout\distribution_tabs.ipynb FAILED                   [ 15%]
examples/gallery/layout/plot_with_columns.ipynb::D:\code\pyviz\panel\examples\gallery\layout\plot_with_columns.ipynb PASSED                   [ 16%]
examples/gallery/links/bokeh_property_editor.ipynb::D:\code\pyviz\panel\examples\gallery\links\bokeh_property_editor.ipynb PASSED             [ 17%]
examples/gallery/links/holoviews_glyph_link.ipynb::D:\code\pyviz\panel\examples\gallery\links\holoviews_glyph_link.ipynb PASSED               [ 18%]
examples/gallery/links/plotly_link.ipynb::D:\code\pyviz\panel\examples\gallery\links\plotly_link.ipynb FAILED                                 [ 19%]
examples/gallery/links/vega_heatmap_link.ipynb::D:\code\pyviz\panel\examples\gallery\links\vega_heatmap_link.ipynb PASSED                     [ 20%]
examples/gallery/param/action_button.ipynb::D:\code\pyviz\panel\examples\gallery\param\action_button.ipynb PASSED                             [ 21%]
examples/gallery/param/param_subobjects.ipynb::D:\code\pyviz\panel\examples\gallery\param\param_subobjects.ipynb PASSED                       [ 22%]
examples/gallery/param/reactive_plots.ipynb::D:\code\pyviz\panel\examples\gallery\param\reactive_plots.ipynb FAILED                           [ 23%]
examples/gallery/param/reactive_tables.ipynb::D:\code\pyviz\panel\examples\gallery\param\reactive_tables.ipynb FAILED                         [ 25%]
examples/gallery/simple/altair_choropleth.ipynb::D:\code\pyviz\panel\examples\gallery\simple\altair_choropleth.ipynb PASSED                   [ 26%]
examples/gallery/simple/clifford_interact.ipynb::D:\code\pyviz\panel\examples\gallery\simple\clifford_interact.ipynb PASSED                   [ 27%]
examples/gallery/simple/iris_kmeans.ipynb::D:\code\pyviz\panel\examples\gallery\simple\iris_kmeans.ipynb FAILED                               [ 28%]
examples/gallery/simple/random_number_generator.ipynb::D:\code\pyviz\panel\examples\gallery\simple\random_number_generator.ipynb PASSED       [ 29%]
examples/gallery/simple/temperature_distribution.ipynb::D:\code\pyviz\panel\examples\gallery\simple\temperature_distribution.ipynb PASSED     [ 30%]
examples/getting_started/Introduction.ipynb::D:\code\pyviz\panel\examples\getting_started\Introduction.ipynb FAILED                           [ 31%]
examples/reference/layouts/Column.ipynb::D:\code\pyviz\panel\examples\reference\layouts\Column.ipynb PASSED                                   [ 32%]
examples/reference/layouts/GridBox.ipynb::D:\code\pyviz\panel\examples\reference\layouts\GridBox.ipynb PASSED                                 [ 33%]
examples/reference/layouts/GridSpec.ipynb::D:\code\pyviz\panel\examples\reference\layouts\GridSpec.ipynb FAILED                               [ 34%]
examples/reference/layouts/Row.ipynb::D:\code\pyviz\panel\examples\reference\layouts\Row.ipynb PASSED                                         [ 35%]
examples/reference/layouts/Tabs.ipynb::D:\code\pyviz\panel\examples\reference\layouts\Tabs.ipynb PASSED                                       [ 36%]
examples/reference/layouts/WidgetBox.ipynb::D:\code\pyviz\panel\examples\reference\layouts\WidgetBox.ipynb PASSED                             [ 38%]
examples/reference/panes/Ace.ipynb::D:\code\pyviz\panel\examples\reference\panes\Ace.ipynb PASSED                                             [ 39%]
examples/reference/panes/Bokeh.ipynb::D:\code\pyviz\panel\examples\reference\panes\Bokeh.ipynb PASSED                                         [ 40%]
examples/reference/panes/GIF.ipynb::D:\code\pyviz\panel\examples\reference\panes\GIF.ipynb PASSED                                             [ 41%]
examples/reference/panes/HTML.ipynb::D:\code\pyviz\panel\examples\reference\panes\HTML.ipynb PASSED                                           [ 42%]
examples/reference/panes/HoloViews.ipynb::D:\code\pyviz\panel\examples\reference\panes\HoloViews.ipynb PASSED                                 [ 43%]
examples/reference/panes/JPG.ipynb::D:\code\pyviz\panel\examples\reference\panes\JPG.ipynb PASSED                                             [ 44%]
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb PASSED                                         [ 45%]
examples/reference/panes/Markdown.ipynb::D:\code\pyviz\panel\examples\reference\panes\Markdown.ipynb PASSED                                   [ 46%]
examples/reference/panes/Matplotlib.ipynb::D:\code\pyviz\panel\examples\reference\panes\Matplotlib.ipynb PASSED                               [ 47%]
examples/reference/panes/PNG.ipynb::D:\code\pyviz\panel\examples\reference\panes\PNG.ipynb PASSED                                             [ 48%]
examples/reference/panes/Plotly.ipynb::D:\code\pyviz\panel\examples\reference\panes\Plotly.ipynb PASSED                                       [ 50%]
examples/reference/panes/SVG.ipynb::D:\code\pyviz\panel\examples\reference\panes\SVG.ipynb PASSED                                             [ 51%]
examples/reference/panes/Str.ipynb::D:\code\pyviz\panel\examples\reference\panes\Str.ipynb PASSED                                             [ 52%]
examples/reference/panes/VTK.ipynb::D:\code\pyviz\panel\examples\reference\panes\VTK.ipynb PASSED                                             [ 53%]
examples/reference/panes/Vega.ipynb::D:\code\pyviz\panel\examples\reference\panes\Vega.ipynb PASSED                                           [ 54%]
examples/reference/widgets/Audio.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Audio.ipynb PASSED                                     [ 55%]
examples/reference/widgets/AutocompleteInput.ipynb::D:\code\pyviz\panel\examples\reference\widgets\AutocompleteInput.ipynb PASSED             [ 56%]
examples/reference/widgets/Button.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Button.ipynb PASSED                                   [ 57%]
examples/reference/widgets/CheckBoxGroup.ipynb::D:\code\pyviz\panel\examples\reference\widgets\CheckBoxGroup.ipynb PASSED                     [ 58%]
examples/reference/widgets/CheckButtonGroup.ipynb::D:\code\pyviz\panel\examples\reference\widgets\CheckButtonGroup.ipynb PASSED               [ 59%]
examples/reference/widgets/Checkbox.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Checkbox.ipynb PASSED                               [ 60%]
examples/reference/widgets/ColorPicker.ipynb::D:\code\pyviz\panel\examples\reference\widgets\ColorPicker.ipynb PASSED                         [ 61%]
examples/reference/widgets/CrossSelector.ipynb::D:\code\pyviz\panel\examples\reference\widgets\CrossSelector.ipynb PASSED                     [ 63%]
examples/reference/widgets/DatePicker.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DatePicker.ipynb PASSED                           [ 64%]
examples/reference/widgets/DateRangeSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DateRangeSlider.ipynb PASSED                 [ 65%]
examples/reference/widgets/DateSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DateSlider.ipynb PASSED                           [ 66%]
examples/reference/widgets/DatetimeInput.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DatetimeInput.ipynb PASSED                     [ 67%]
examples/reference/widgets/DiscretePlayer.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DiscretePlayer.ipynb PASSED                   [ 68%]
examples/reference/widgets/DiscreteSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\DiscreteSlider.ipynb PASSED                   [ 69%]
examples/reference/widgets/FileInput.ipynb::D:\code\pyviz\panel\examples\reference\widgets\FileInput.ipynb PASSED                             [ 70%]
examples/reference/widgets/FloatSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\FloatSlider.ipynb PASSED                         [ 71%]
examples/reference/widgets/IntRangeSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\IntRangeSlider.ipynb PASSED                   [ 72%]
examples/reference/widgets/IntSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\IntSlider.ipynb PASSED                             [ 73%]
examples/reference/widgets/LiteralInput.ipynb::D:\code\pyviz\panel\examples\reference\widgets\LiteralInput.ipynb PASSED                       [ 75%]
examples/reference/widgets/MultiSelect.ipynb::D:\code\pyviz\panel\examples\reference\widgets\MultiSelect.ipynb PASSED                         [ 76%]
examples/reference/widgets/Player.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Player.ipynb PASSED                                   [ 77%]
examples/reference/widgets/RadioBoxGroup.ipynb::D:\code\pyviz\panel\examples\reference\widgets\RadioBoxGroup.ipynb PASSED                     [ 78%]
examples/reference/widgets/RadioButtonGroup.ipynb::D:\code\pyviz\panel\examples\reference\widgets\RadioButtonGroup.ipynb PASSED               [ 79%]
examples/reference/widgets/RangeSlider.ipynb::D:\code\pyviz\panel\examples\reference\widgets\RangeSlider.ipynb PASSED                         [ 80%]
examples/reference/widgets/Select.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Select.ipynb PASSED                                   [ 81%]
examples/reference/widgets/Spinner.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Spinner.ipynb PASSED                                 [ 82%]
examples/reference/widgets/StaticText.ipynb::D:\code\pyviz\panel\examples\reference\widgets\StaticText.ipynb PASSED                           [ 83%]
examples/reference/widgets/TextInput.ipynb::D:\code\pyviz\panel\examples\reference\widgets\TextInput.ipynb PASSED                             [ 84%]
examples/reference/widgets/Toggle.ipynb::D:\code\pyviz\panel\examples\reference\widgets\Toggle.ipynb PASSED                                   [ 85%]
examples/reference/widgets/VideoStream.ipynb::D:\code\pyviz\panel\examples\reference\widgets\VideoStream.ipynb PASSED                         [ 86%]
examples/user_guide/APIs.ipynb::D:\code\pyviz\panel\examples\user_guide\APIs.ipynb PASSED                                                     [ 88%]
examples/user_guide/Components.ipynb::D:\code\pyviz\panel\examples\user_guide\Components.ipynb FAILED                                         [ 89%]
examples/user_guide/Customization.ipynb::D:\code\pyviz\panel\examples\user_guide\Customization.ipynb PASSED                                   [ 90%]
examples/user_guide/Deploy_and_Export.ipynb::D:\code\pyviz\panel\examples\user_guide\Deploy_and_Export.ipynb FAILED                           [ 91%]
examples/user_guide/Django_Apps.ipynb::D:\code\pyviz\panel\examples\user_guide\Django_Apps.ipynb PASSED                                       [ 92%]
examples/user_guide/Interact.ipynb::D:\code\pyviz\panel\examples\user_guide\Interact.ipynb FAILED                                             [ 93%]
examples/user_guide/Links.ipynb::D:\code\pyviz\panel\examples\user_guide\Links.ipynb FAILED                                                   [ 94%]
examples/user_guide/Overview.ipynb::D:\code\pyviz\panel\examples\user_guide\Overview.ipynb PASSED                                             [ 95%]
examples/user_guide/Param.ipynb::D:\code\pyviz\panel\examples\user_guide\Param.ipynb PASSED                                                   [ 96%]
examples/user_guide/Pipelines.ipynb::D:\code\pyviz\panel\examples\user_guide\Pipelines.ipynb FAILED                                           [ 97%]
examples/user_guide/Templates.ipynb::D:\code\pyviz\panel\examples\user_guide\Templates.ipynb PASSED                                           [ 98%]
examples/user_guide/Widgets.ipynb::D:\code\pyviz\panel\examples\user_guide\Widgets.ipynb FAILED                                               [100%]

===================================================================== FAILURES =====================================================================
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\apis\stocks_mpl.ipynb
** line 16 col 0: 'matplotlib' imported but unused
** line 45 col 4: local variable 'cv' is assigned to but never used
** line 80 col 4: local variable 'cv' is assigned to but never used
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\apis\stocks_mpl.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\apis\stocks_mpl.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\layout\distribution_tabs.ipynb
** line 16 col 0: 'pandas as pd' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\layout\distribution_tabs.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\layout\distribution_tabs.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\links\plotly_link.ipynb
** line 25 col 0: redefinition of unused 'np' from line 14
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\links\plotly_link.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\links\plotly_link.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\param\reactive_plots.ipynb
** line 19 col 0: 'pandas as pd' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\param\reactive_plots.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\param\reactive_plots.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\param\reactive_tables.ipynb
** line 16 col 0: 'pandas as pd' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\param\reactive_tables.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\param\reactive_tables.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\gallery\simple\iris_kmeans.ipynb
** line 14 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\gallery\simple\iris_kmeans.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\gallery\simple\iris_kmeans.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\getting_started\Introduction.ipynb
** line 170 col 0: redefinition of unused 'hvplot' from line 168
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\getting_started\Introduction.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\getting_started\Introduction.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\reference\layouts\GridSpec.ipynb
** line 80 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\reference\layouts\GridSpec.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\reference\layouts\GridSpec.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Components.ipynb
** line 202 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Components.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Components.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Deploy_and_Export.ipynb
** line 78 col 4: undefined name 'display'
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Deploy_and_Export.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Deploy_and_Export.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Interact.ipynb
** line 20 col 0: 'panel.interact.interactive' imported but unused
** line 20 col 0: 'panel.interact.interact_manual' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Interact.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Interact.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Links.ipynb
** line 26 col 0: 'param' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Links.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Links.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Pipelines.ipynb
** line 16 col 0: 'holoviews as hv' imported but unused
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Pipelines.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Pipelines.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\pyviz\panel\examples\user_guide\Widgets.ipynb
** line 52 col 0: from __future__ imports must occur at the beginning of the file
To see python source that was checked by pyflakes: D:\code\pyviz\panel\examples\user_guide\Widgets.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\pyviz\panel\examples\user_guide\Widgets.nbsmoke-debug-premagicprocess.py
================================================================= warnings summary =================================================================
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
  <input>:1: DeprecationWarning: invalid escape sequence \(

examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
  <input>:1: DeprecationWarning: invalid escape sequence \s

examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
  D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb:36: DeprecationWarning: invalid escape sequence \(
    ]

examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
  D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb:46: DeprecationWarning: invalid escape sequence \s
    "latex"

examples/reference/panes/LaTeX.ipynb::D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb
  D:\code\pyviz\panel\examples\reference\panes\LaTeX.ipynb:54: DeprecationWarning: invalid escape sequence \s
    ]

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================= 14 failed, 78 passed, 190 skipped, 12 warnings in 125.78 seconds =========================================
```