### PR TITLE
Add run() to StoppableThread class

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -122,6 +122,15 @@ class StoppableThread(threading.Thread):
         if self.stopped:
             self._cb.stop()
             self.io_loop.stop()
+    
+    def run(self):
+        try:
+            if self._target:
+                bokeh_server = self._target(*self._args, **self._kwargs)
+        finally:
+            if isinstance(bokeh_server, Server):
+                bokeh_server.stop()
+            del self._target, self._args, self._kwargs
 
     def stop(self):
         self._stop_event.set()


### PR DESCRIPTION
## Overview

This PR adds a `run()` method to the `StoppableThread` class. The method overrides the default `run()` from [threading library](https://github.com/python/cpython/blob/master/Lib/threading.py#L871-L886). The result from `_target` is used stop the bokeh server completely, thereby releasing the port.

This should fix #634. 

@friedrichknuth has tested this with his work, and it seemed to solve the issue.