### PR TITLE
Added jscallback method to Viewable objects

### DIFF
--- a/examples/user_guide/Links.ipynb
+++ b/examples/user_guide/Links.ipynb
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.Row(pn.Column(toggle, width=200, height=50), selections, pn.Spacer(width=50), selected)"
+    "pn.Row(pn.Column(toggle, width=200, height=50), selections, pn.Spacer(width=50, height=50), selected)"
    ]
   },
   {
@@ -273,6 +273,36 @@
    "outputs": [],
    "source": [
     "#toggle.param.unwatch(watcher)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining Javascript callbacks\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "value1 =   pn.widgets.Spinner(value=0, width=75)\n",
+    "operator = pn.widgets.Select(value='*', options=['*', '+'], width=50, align='center')\n",
+    "value2 =   pn.widgets.Spinner(value=0, width=75)\n",
+    "button =   pn.widgets.Button(name='=', width=50)\n",
+    "result =   pn.widgets.StaticText(value='0', width=50, align='center')\n",
+    "\n",
+    "button.jscallback(clicks=\"\"\"\n",
+    "if (op.value == '*') \n",
+    "  result.text = (v1.value * v2.value).toString()\n",
+    "else\n",
+    "  result.text = (v1.value + v2.value).toString()\n",
+    "\"\"\", args={'op': operator, 'result': result, 'v1': value1, 'v2': value2})\n",
+    "\n",
+    "pn.Row(value1, operator, value2, button, result)"
    ]
   },
   {
@@ -377,6 +407,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Defining Javascript callbacks\n",
+    "\n",
+    "Sometimes defining a simple link between to objects is not sufficient, e.g. when there are a number of objects involved. In these cases it is helpful to be able to define arbitrary Javascript callbacks. A very simple example is a very basic calculator which allows multiplying or adding two values, in this case we have two widgets to input numbers, a selector to pick the operation, a display for the result and a button.\n",
+    "\n",
+    "To implement this we define a `jscallback`, which is triggered when the `Button.clicks` property changes and provide a number of `args` allowing us to access the values of the various widgets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "value1 =   pn.widgets.Spinner(value=0, width=75)\n",
+    "operator = pn.widgets.Select(value='*', options=['*', '+'], width=50, align='center')\n",
+    "value2 =   pn.widgets.Spinner(value=0, width=75)\n",
+    "button =   pn.widgets.Button(name='=', width=50)\n",
+    "result =   pn.widgets.StaticText(value='0', width=50, align='center')\n",
+    "\n",
+    "button.jscallback(clicks=\"\"\"\n",
+    "if (op.value == '*') \n",
+    "  result.text = (v1.value * v2.value).toString()\n",
+    "else\n",
+    "  result.text = (v1.value + v2.value).toString()\n",
+    "\"\"\", args={'op': operator, 'result': result, 'v1': value1, 'v2': value2})\n",
+    "\n",
+    "pn.Row(value1, operator, value2, button, result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Linking Plots\n",
     "\n",
     "The above examples link widgets to simple static panes, but links are probably most useful when combined with dynamic objects like plots.\n",
@@ -453,11 +516,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/panel/links.py
+++ b/panel/links.py
@@ -246,7 +246,7 @@ class CallbackGenerator(object):
         if any(link_id in cb.tags for cbs in src_model.js_property_callbacks.values() for cb in cbs):
             # Skip registering callback if already registered
             return
-        references['source'] = src_model
+        references['source'] = references['cb_obj'] = src_model
 
         tgt_model = None
         if link._requires_target:
@@ -270,8 +270,9 @@ class CallbackGenerator(object):
             prefix = 'source_' if hasattr(link, 'target') else ''
             if is_bokeh_element_plot(src):
                 for k, v in src.handles.items():
-                    if isinstance(v, BkModel):
-                        references[prefix + k] = v
+                    k = prefix + k
+                    if isinstance(v, BkModel) and k not in references:
+                        references[k] = v
 
             if isinstance(target, HoloViews):
                 tgt = target._plots[ref][0]
@@ -280,8 +281,9 @@ class CallbackGenerator(object):
 
             if is_bokeh_element_plot(tgt):
                 for k, v in tgt.handles.items():
-                    if isinstance(v, BkModel):
-                        references['target_' + k] = v
+                    k = 'target_' + k
+                    if isinstance(v, BkModel) and k not in references:
+                        references[k] = v
 
         self._initialize_models(link, source, src_model, src_spec[1], target, tgt_model, tgt_spec[1])
         self._process_references(references)

--- a/panel/links.py
+++ b/panel/links.py
@@ -16,25 +16,18 @@ from .widgets import CompositeWidget
 from bokeh.models import (CustomJS, Model as BkModel)
 
 
-class Link(param.Parameterized):
-    """
-    A Link defines some connection between a source and target model.
-    It allows defining callbacks in response to some change or event
-    on the source object. Instead a Link directly causes some action
-    to occur on the target, for JS based backends this usually means
-    that a corresponding JS callback will effect some change on the
-    target in response to a change on the source.
+class Callback(param.Parameterized):
 
-    A Link must define a source object which is what triggers events,
-    but must not define a target. It is also possible to define bi-
-    directional links between the source and target object.
-    """
+    args = param.Dict(default={}, allow_None=True, doc="""
+        A mapping of names to Python objects. These objects are made
+        available to the callback's code snippet as the values of
+        named parameters to the callback.""")
 
     # Mapping from a source id to a Link instance
     registry = weakref.WeakKeyDictionary()
 
     # Mapping to define callbacks by backend and Link type.
-    # e.g. Link._callbacks[Link] = Callback
+    # e.g. Callback._callbacks[Link] = Callback
     _callbacks = {}
 
     # Whether the link requires a target
@@ -43,13 +36,28 @@ class Link(param.Parameterized):
     def __init__(self, source, target=None, **params):
         if source is None:
             raise ValueError('%s must define a source' % type(self).__name__)
-        if self._requires_target and target is None:
-            raise ValueError('%s must define a target.' % type(self).__name__)
         # Source is stored as a weakref to allow it to be garbage collected
         self._source = None if source is None else weakref.ref(source)
-        self._target = None if target is None else weakref.ref(target)
-        super(Link, self).__init__(**params)
-        self.link()
+        super(Callback, self).__init__(**params)
+        self.init()
+
+    def init(self):
+        """
+        Registers the Callback
+        """
+        if self.source in self.registry:
+            links = self.registry[self.source]
+            params = {
+                k: v for k, v in self.get_param_values() if k != 'name'}
+            for link in links:
+                link_params = {
+                    k: v for k, v in link.get_param_values() if k != 'name'}
+                if (type(link) is type(self) and link.source is self.source
+                    and link.target is self.target and params == link_params):
+                    return
+            self.registry[self.source].append(self)
+        else:
+            self.registry[self.source] = [self]
 
     @classmethod
     def register_callback(cls, callback):
@@ -63,6 +71,68 @@ class Link(param.Parameterized):
     def source(self):
         return self._source() if self._source else None
 
+    @classmethod
+    def _process_callbacks(cls, root_view, root_model):
+        if not root_model:
+            return
+
+        linkable = root_view.select(Viewable)
+        linkable += root_model.select({'type' : BkModel})
+
+        if not linkable:
+            return
+
+        found = [(link, src, getattr(link, 'target', None)) for src in linkable
+                 for link in cls.registry.get(src, [])
+                 if not link._requires_target or link.target in linkable]
+
+        arg_overrides = {}
+        if 'holoviews' in sys.modules:
+            hv_views = root_view.select(HoloViews)
+            map_hve_bk = generate_panel_bokeh_map(root_model, hv_views)
+            for src in linkable:
+                for link in cls.registry.get(src, []):
+                    if hasattr(link, 'target'):
+                        for tgt in map_hve_bk.get(link.target, []):
+                            found.append((link, src, tgt))
+                    arg_overrides[id(link)] = {}
+                    for k, v in link.args.items():
+                        for tgt in map_hve_bk.get(v, []):
+                            arg_overrides[id(link)][k] = tgt
+
+        callbacks = []
+        for link, src, tgt in found:
+            cb = cls._callbacks[type(link)]
+            if src is None or (getattr(link, '_requires_target', False)
+                               and tgt is None):
+                continue
+            overrides = arg_overrides[id(link)]
+            callbacks.append(cb(root_model, link, src, tgt,
+                                arg_overrides=overrides))
+        return callbacks
+
+        
+class Link(Callback):
+    """
+    A Link defines some connection between a source and target model.
+    It allows defining callbacks in response to some change or event
+    on the source object. Instead a Link directly causes some action
+    to occur on the target, for JS based backends this usually means
+    that a corresponding JS callback will effect some change on the
+    target in response to a change on the source.
+
+    A Link must define a source object which is what triggers events,
+    but must not define a target. It is also possible to define bi-
+    directional links between the source and target object.
+    """
+
+    def __init__(self, source, target=None, **params):
+        if self._requires_target and target is None:
+            raise ValueError('%s must define a target.' % type(self).__name__)
+        # Source is stored as a weakref to allow it to be garbage collected
+        self._target = None if target is None else weakref.ref(target)
+        super(Link, self).__init__(**params)
+
     @property
     def target(self):
         return self._target() if self._target else None
@@ -71,6 +141,7 @@ class Link(param.Parameterized):
         """
         Registers the Link
         """
+        self.init()
         if self.source in self.registry:
             links = self.registry[self.source]
             params = {
@@ -93,37 +164,6 @@ class Link(param.Parameterized):
         if self in links:
             links.pop(links.index(self))
 
-    @classmethod
-    def _process_links(cls, root_view, root_model):
-        if not isinstance(root_view, (Panel, CompositeWidget)) or not root_model:
-            return
-
-        linkable = root_view.select(Viewable)
-        linkable += root_model.select({'type' : BkModel})
-
-        if not linkable:
-            return
-
-        found = [(link, src, link.target) for src in linkable
-                 for link in cls.registry.get(src, [])
-                 if link.target in linkable or not link._requires_target]
-
-        if 'holoviews' in sys.modules:
-            hv_views = root_view.select(HoloViews)
-            map_hve_bk = generate_panel_bokeh_map(root_model, hv_views)
-            found += [(link, src, tgt) for src in linkable if src in cls.registry
-                      for link in cls.registry[src]
-                      for tgt in map_hve_bk[link.target]]
-
-        callbacks = []
-        for link, src, tgt in found:
-            cb = cls._callbacks[type(link)]
-            if src is None or (getattr(link, '_requires_target', False)
-                               and tgt is None):
-                continue
-            callbacks.append(cb(root_model, link, src, tgt))
-        return callbacks
-
 
 class GenericLink(Link):
     """
@@ -144,6 +184,20 @@ class GenericLink(Link):
     # Whether the link requires a target
     _requires_target = True
 
+
+class GenericCallback(Callback):
+    """
+    A Callback which executes the provided code when the associated
+    properties change.
+    """
+
+    code = param.Dict(default=None, doc="""
+        A dictionary mapping from a source specication to a JS code
+        snippet to be executed if the source property changes.""")
+
+    # Whether the link requires a target
+    _requires_target = False
+    
 
 class LinkCallback(param.Parameterized):
 
@@ -189,11 +243,12 @@ class LinkCallback(param.Parameterized):
                 model = getattr(model, spec)
         return model
 
-    def __init__(self, root_model, link, source, target=None):
+    def __init__(self, root_model, link, source, target=None, arg_overrides={}):
         self.root_model = root_model
         self.link = link
         self.source = source
         self.target = target
+        self.arg_overrides = arg_overrides
         self.validate()
         specs = self._get_specs(link, source, target)
         for src_spec, tgt_spec, code in specs:
@@ -201,7 +256,7 @@ class LinkCallback(param.Parameterized):
 
     def _init_callback(self, root_model, link, source, src_spec, target, tgt_spec, code):
         references = {k: v for k, v in link.get_param_values()
-                      if k not in ('source', 'target', 'name', 'code')}
+                      if k not in ('source', 'target', 'name', 'code', 'args')}
 
         src_model = self._resolve_model(root_model, source, src_spec[0])
         link_id = id(link)
@@ -210,9 +265,18 @@ class LinkCallback(param.Parameterized):
             return
         references['source'] = src_model
 
-        tgt_model = self._resolve_model(root_model, target, tgt_spec[0])
-        if tgt_model is not None:
-            references['target'] = tgt_model
+        tgt_mode = None
+        if link._requires_target:
+            tgt_model = self._resolve_model(root_model, target, tgt_spec[0])
+            if tgt_model is not None:
+                references['target'] = tgt_model
+        else:
+            tgt_model = None
+
+        for k, v in dict(link.args, **self.arg_overrides).items():
+            arg_model = self._resolve_model(root_model, v, None)
+            if arg_model is not None:
+                references[k] = arg_model
 
         if 'holoviews' in sys.modules:
             if is_bokeh_element_plot(source):
@@ -334,5 +398,7 @@ class GenericLinkCallback(LinkCallback):
 
 
 GenericLink.register_callback(callback=GenericLinkCallback)
+GenericCallback.register_callback(callback=GenericLinkCallback)
 
-Viewable._preprocessing_hooks.append(Link._process_links)
+
+Viewable._preprocessing_hooks.append(Callback._process_callbacks)

--- a/panel/links.py
+++ b/panel/links.py
@@ -8,10 +8,8 @@ import weakref
 import sys
 
 from .viewable import Viewable, Reactive
-from .layout import Panel
 from .pane.holoviews import HoloViews, generate_panel_bokeh_map, is_bokeh_element_plot
 from .util import unicode_repr
-from .widgets import CompositeWidget
 
 from bokeh.models import (CustomJS, Model as BkModel)
 
@@ -250,13 +248,11 @@ class CallbackGenerator(object):
             return
         references['source'] = src_model
 
-        tgt_mode = None
+        tgt_model = None
         if link._requires_target:
             tgt_model = self._resolve_model(root_model, target, tgt_spec[0])
             if tgt_model is not None:
                 references['target'] = tgt_model
-        else:
-            tgt_model = None
 
         for k, v in dict(link.args, **self.arg_overrides).items():
             arg_model = self._resolve_model(root_model, v, None)

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -128,7 +128,7 @@ def test_widget_jscallback(document, comm):
     assert customjs.code == "some_code"
 
 
-def test_widget_jscallback(document, comm):
+def test_widget_jscallback_args_scalar(document, comm):
     widget = ColorPicker(value='#ff00ff')
 
     widget.jscallback(value='some_code', args={'scalar': 1})

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -845,6 +845,28 @@ class Reactive(Viewable):
             cb.start()
         return cb
 
+    def jscallback(self, args={}, **callbacks):
+        """
+        
+        Arguments
+        ----------
+        target: HoloViews object or bokeh Model or panel Viewable
+          The target to link the value to.
+        **callbacks: dict
+          A mapping between properties on the source model and the code
+          to execute when that property changes
+
+        Returns
+        -------
+        link: GenericCallback
+          The GenericCallback which can be used to disable the callback.
+        """
+
+        from .links import GenericCallback
+        for k, v in list(callbacks.items()):
+            callbacks[k] = self._rename.get(v, v)
+        return GenericCallback(self, code=callbacks, args=args)
+
     def jslink(self, target, code=None, **links):
         """
         Links properties on the source object to those on the target

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -847,27 +847,30 @@ class Reactive(Viewable):
 
     def jscallback(self, args={}, **callbacks):
         """
-        
+        Allows defining a JS callback to be triggered when a property
+        changes on the source object. The keyword arguments define the
+        properties that trigger a callback and the JS code that gets
+        executed.
+
         Arguments
         ----------
-        target: HoloViews object or bokeh Model or panel Viewable
-          The target to link the value to.
+        args: A mapping of objects to make available to the JS callback
         **callbacks: dict
           A mapping between properties on the source model and the code
           to execute when that property changes
 
         Returns
         -------
-        link: GenericCallback
-          The GenericCallback which can be used to disable the callback.
+        callback: Callback
+          The Callback which can be used to disable the callback.
         """
 
-        from .links import GenericCallback
+        from .links import Callback
         for k, v in list(callbacks.items()):
             callbacks[k] = self._rename.get(v, v)
-        return GenericCallback(self, code=callbacks, args=args)
+        return Callback(self, code=callbacks, args=args)
 
-    def jslink(self, target, code=None, **links):
+    def jslink(self, target, code=None, args=None, **links):
         """
         Links properties on the source object to those on the target
         object in JS code. Supports two modes, either specify a
@@ -900,10 +903,12 @@ class Reactive(Viewable):
         elif not links and not code:
             raise ValueError('Declare parameters to link or a set of '
                              'callbacks, neither was defined.')
+        if args is None:
+            args = {}
 
-        from .links import GenericLink
+        from .links import Link
         if isinstance(target, Reactive):
             mapping = code or links
             for k, v in list(mapping.items()):
                 mapping[k] = target._rename.get(v, v)
-        return GenericLink(self, target, properties=links, code=code)
+        return Link(self, target, properties=links, code=code, args=args)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -854,7 +854,8 @@ class Reactive(Viewable):
 
         Arguments
         ----------
-        args: A mapping of objects to make available to the JS callback
+        args: dict
+          A mapping of objects to make available to the JS callback
         **callbacks: dict
           A mapping between properties on the source model and the code
           to execute when that property changes

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -30,6 +30,27 @@ class Button(_ButtonBase):
     def on_click(self, callback):
         self.param.watch(callback, 'clicks')
 
+    def js_on_click(self, args={}, code=""):
+        """
+        Allows defining a JS callback to be triggered when the button
+        is clicked.
+
+        Arguments
+        ----------
+        args: dict
+          A mapping of objects to make available to the JS callback
+        code: str
+          The Javascript code to execute when the button is clicked.
+
+        Returns
+        -------
+        callback: Callback
+          The Callback which can be used to disable the callback.
+        """
+        from .links import Callback
+        return Callback(self, code={'clicks': code}, args=args)
+
+
 
 class Toggle(_ButtonBase):
 


### PR DESCRIPTION
While jslink is very convenient for linking two objects it is also limited because it only exposes the source and target object, doesn't allow providing just a callback on the source and is not really designed around providing custom code.

This PR introduces a ``.jscallback`` method which can be used to add arbitrary JS callbacks, e.g. this example takes the values of the two slider and triggers an alert:

```python
a = pn.widgets.Button(name='Add')
slider1 = pn.widgets.IntSlider()
slider2 = pn.widgets.IntSlider()

a.jscallback(clicks='alert(slider1.value+slider2.value)', args={'slider1': slider1, 'slider2': slider2})

pn.Row(a, slider1, slider2)
```

Cc: @xavArtley I know you were playing around with adding `args` to links but I think this generalizes this more.

- [x] Clean up ``links.py``
- [x] Improve docstrings
- [x] Write tests
- [x] Write docs