### PR TITLE
Fix for Issue #661: IntSlider value should start at the `start` keyword value not 0 

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -47,6 +47,11 @@ def test_int_slider(document, comm):
     slider.value = 0
     assert widget.value == 0
 
+    # Testing that value matches start value if value not set.
+    slider_2 = IntSlider(start=1, end=3, name='Slider_2')
+    widget_2 = slider_2.get_root(document, comm=comm)
+    assert widget_2.value == widget_2.start
+
 
 def test_range_slider(document, comm):
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -110,6 +110,11 @@ class FloatSlider(ContinuousSlider):
 
 class IntSlider(ContinuousSlider):
 
+    def __init__(self, **params):
+        if 'value' not in params:
+            params['value'] = params.get('start', self.param.start.default)
+        super(ContinuousSlider, self).__init__(**params)
+
     value = param.Integer(default=0)
 
     start = param.Integer(default=0)


### PR DESCRIPTION
Fixing #661