### PR TITLE
Select behavior

### DIFF
--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -291,32 +291,32 @@ def test_object_selector_param(document, comm):
     test_pane = Pane(test)
     model = test_pane.get_root(document, comm=comm)
 
-    slider = model.children[1]
-    assert isinstance(slider, Select)
-    assert slider.options == ['1', 'b', 'c']
-    assert slider.value == 'b'
-    assert slider.disabled == False
+    select = model.children[1]
+    assert isinstance(select, Select)
+    assert select.options == [('1','1'), ('b','b'), ('c','c')]
+    assert select.value == 'b'
+    assert select.disabled == False
 
     # Check changing param value updates widget
     test.a = 1
-    assert slider.value == '1'
+    assert select.value == '1'
 
     # Check changing param attribute updates widget
     a_param = test.param['a']
     a_param.objects = ['c', 'd', 1]
-    assert slider.options == ['c', 'd', '1']
+    assert select.options == [('c','c'), ('d','d'), ('1','1')]
 
     a_param.constant = True
-    assert slider.disabled == True
+    assert select.disabled == True
 
     # Ensure cleanup works
     test_pane._cleanup(model)
     a_param.constant = False
     a_param.objects = [1, 'c', 'd']
     test.a = 'd'
-    assert slider.value == '1'
-    assert slider.options == ['c', 'd', '1']
-    assert slider.disabled == True
+    assert select.value == '1'
+    assert select.options == [('c','c'), ('d','d'), ('1','1')]
+    assert select.disabled == True
 
 
 def test_list_selector_param(document, comm):

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from panel.widgets import Select, MultiSelect, CrossSelector, ToggleGroup
+from panel.util import as_unicode
 
 
 def test_select_list_constructor():
@@ -45,18 +46,18 @@ def test_select(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == '1'
-    assert widget.options == ['A', '1']
+    assert widget.value == as_unicode(opts['1'])
+    assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
 
-    select._comm_change({'value': 'A'})
+    select._comm_change({'value': as_unicode(opts['A'])})
     assert select.value == opts['A']
 
-    widget.value = '1'
-    select._comm_change({'value': '1'})
+    widget.value = as_unicode(opts['1'])
+    select.value = opts['1']
     assert select.value == opts['1']
 
     select.value = opts['A']
-    assert widget.value == 'A'
+    assert widget.value == as_unicode(opts['A'])
 
 
 def test_select_change_options(document, comm):
@@ -67,7 +68,7 @@ def test_select_change_options(document, comm):
 
     select.options = {'A': 'a'}
     assert select.value == opts['A']
-    assert widget.value == 'A'
+    assert widget.value == as_unicode(opts['A'])
 
     select.options = {}
     assert select.value == None
@@ -82,12 +83,12 @@ def test_select_non_hashable_options(document, comm):
 
     select.value = opts['A']
     assert select.value is opts['A']
-    assert widget.value == 'A'
+    assert widget.value == as_unicode(opts['A'])
 
     opts.pop('A')
     select.options = opts
     assert select.value is opts['1']
-    assert widget.value == '1'
+    assert widget.value == as_unicode(opts['1'])
 
 
 def test_select_mutables(document, comm):
@@ -98,19 +99,19 @@ def test_select_mutables(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == 'B'
-    assert widget.options == ['A', 'B', 'C']
+    assert widget.value == as_unicode(opts['B'])
+    assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
 
-    widget.value = 'B'
-    select._comm_change({'value': 'A'})
+    widget.value = as_unicode(opts['B'])
+    select._comm_change({'value': as_unicode(opts['A'])})
     assert select.value == opts['A']
 
-    widget.value = 'B'
-    select._comm_change({'value': 'B'})
+    widget.value = as_unicode(opts['B'])
+    select._comm_change({'value': as_unicode(opts['B'])})
     assert select.value == opts['B']
 
     select.value = opts['A']
-    assert widget.value == 'A'
+    assert widget.value == as_unicode(opts['A'])
 
 
 def test_select_change_options_on_watch(document, comm):
@@ -125,8 +126,8 @@ def test_select_change_options_on_watch(document, comm):
     model = select.get_root(document, comm=comm)
 
     select.value = 1
-    assert model.value == 'D'
-    assert model.options == ['D', 'E']
+    assert model.value == as_unicode(list(select.options.values())[0])
+    assert model.options == [(as_unicode(v),k) for k,v in select.options.items()]
 
 
 def test_multi_select(document, comm):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -66,14 +66,17 @@ class Select(SelectBase):
         if 'value' in msg:
             val = msg['value']
             if isIn(val, values):
-                msg['value'] = labels[indexOf(val, values)]
+                msg['value'] = self.unicode_values[indexOf(val, values)]
             elif values:
                 self.value = self.values[0]
             elif self.value is not None:
                 self.value = None
 
         if 'options' in msg:
-            msg['options'] = labels
+            if isinstance(self.options, dict):
+                msg['options'] = [(v,l) for l,v in zip(labels, self.unicode_values)]
+            else:
+                msg['options'] = self.unicode_values
             val = self.value
             if values:
                 if not isIn(val, values):
@@ -81,6 +84,10 @@ class Select(SelectBase):
             elif val is not None:
                 self.value = None
         return msg
+
+    @property
+    def unicode_values(self):
+        return [as_unicode(v) for v in self.values]
 
     def _process_property_change(self, msg):
         msg = super(Select, self)._process_property_change(msg)
@@ -90,7 +97,7 @@ class Select(SelectBase):
             elif msg['value'] is None:
                 msg['value'] = self.values[0]
             else:
-                msg['value'] = self._items[msg['value']]
+                msg['value'] = self._items[self.labels[indexOf(msg['value'],self.unicode_values)]]
         msg.pop('options', None)
         return msg
 


### PR DESCRIPTION
Related to https://github.com/pyviz/panel/issues/718

```python
import panel as pn
pn.extension()
sel = pn.widgets.Select(value='val1', options={'lab1': 'val1', 'lab2': 'val2'})
sel.jscallback(value="""console.log(source.value); console.log(...source.options)""")
sel
```
With this PR on js side the change of the select value gives
![image](https://user-images.githubusercontent.com/18531147/67746939-dd997100-fa27-11e9-8a2f-23c2c8b258c1.png)
