### PR TITLE
Made Pipelines user guide consistent and clearer

### DIFF
--- a/examples/user_guide/Pipelines.ipynb
+++ b/examples/user_guide/Pipelines.ipynb
@@ -16,7 +16,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [Param user guide](Param.ipynb) described how to set up classes which declare parameters and link them to some computation or visualization. In this section we will discover how to connect multiple such panels into a ``Pipeline`` to express complex workflows where the output of one stage feeds into the next stage. To start using a ``Pipeline`` let us declare an empty one by instantiating the class:"
+    "The [Param user guide](Param.ipynb) described how to set up classes that declare parameters and link them to some computation or visualization. In this section we will discover how to connect multiple such panels into a ``Pipeline`` to express complex multi-page workflows where the output of one stage feeds into the next stage. \n",
+    "\n",
+    "To start using a ``Pipeline``, let us declare an empty one by instantiating the class:"
    ]
   },
   {
@@ -32,21 +34,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Having set up a Pipeline it is now possible to start populating it. While we have already seen how to declare a ``Parameterized`` class with parameters which are linked to some visualization or computation on a method using the ``param.depends`` decorator, ``Pipelines`` make use of another decorator and a convention for displaying the objects.\n",
+    "Having set up a Pipeline it is now possible to start populating it with one or more stages.  We have previously seen how a ``Parameterized`` class can have parameters controlling some visualization or computation on a method, with that linkage declared using the ``param.depends`` decorator. To use such classes as a pipeline stage, the `Parameterized` class will also need to designate at least one of the methods as an \"output\", and it should also provide a visual representation for that pipeline stage.\n",
     "\n",
-    "The ``param.output`` decorator provides a way to annotate the methods on a class by declaring its outputs. A ``Pipeline`` uses this information to determine what outputs are available to be fed into the next stage of the workflow. In the example below the ``Stage1`` class has two parameters of its own (``a`` and ``b``) and one output, which is named ``c``. The signature of the decorator allows a number of different ways of declaring the outputs:\n",
+    "To declare the output for a stage, decorate one of its methods with ``param.output``. A ``Pipeline`` will use this information to determine what outputs are available to be fed into the next stage of the workflow. In the example below, the ``Stage1`` class has two parameters (``a`` and ``b``) and one output (``c``). The signature of the decorator allows a number of different ways of declaring the outputs:\n",
     "\n",
-    "* ``param.output()``: Declaring an output without arguments will declare that the method returns an output which will inherit the name of the method and does not make any specific type declarations.\n",
+    "* ``param.output()``: Declaring an output without arguments will declare that the method returns an output that will inherit the name of the method and does not make any specific type declarations.\n",
     "* ``param.output(param.Number)``: Declaring an output with a specific ``Parameter`` or Python type also declares an output with the name of the method but declares that the output will be of a specific type.\n",
     "* ``param.output(c=param.Number)``: Declaring an output using a keyword argument allows overriding the method name as the name of the output and declares the type.\n",
     "\n",
-    "It is also possible to declare multiple parameters, either as keywords (Python >= 3.6 required) or tuples:\n",
+    "It is also possible to declare multiple outputs, either as keywords (Python >= 3.6 required) or tuples:\n",
     "\n",
-    "* ``param.output(c=param.Number, d=param.String)`` or ``param.output(('c', param.Number), ('d', param.String))``\n",
+    "* ``param.output(c=param.Number, d=param.String)`` or\n",
+    "* ``param.output(('c', param.Number), ('d', param.String))``\n",
     "\n",
-    "In the example below the output is simply the result of multiplying the two inputs (``a`` and ``b``) which will produce output ``c``. Additionally we declare a ``view`` method which returns a ``LaTeX`` pane which will render the equation to ``LaTeX``. Finally a ``panel`` method should be implemented to return a Panel object providing a visual representation of the stage; this is the second convention that a ``Pipeline`` expects.\n",
+    "The example below takes two inputs (``a`` and ``b``) and produces two outputs (``c``, computed by mutiplying the inputs, and ``d``, computed by raising ``a`` to the power ``b``). To use the class as a pipeline stage, we also have to implement a ``panel`` method, which returns a Panel object providing a visual representation of the stage.  Here we help implement the ``panel`` method using an additional ``view`` method that returns a ``LaTeX`` pane, which will render the equation to ``LaTeX``. \n",
     "\n",
-    "In addition to the output parameters, as long as ``inherit_params`` is set any parameters which exist between two different stages will also be passed along.\n",
+    "In addition to passing along the outputs, the Pipeline will also pass along the values of any input parameters whose names match input parameters on the next stage (unless ``inherit_params`` is set to `False`).\n",
     "\n",
     "Let's start by displaying this stage on its own:"
    ]
@@ -86,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To summarize we have followed several conventions when setting up this stage of our ``Pipeline``:\n",
+    "To summarize, we have followed several conventions when setting up this stage of our ``Pipeline``:\n",
     "\n",
     "1. Declare a Parameterized class with some input parameters.\n",
     "2. Declare one or more methods decorated with the `param.output` decorator.\n",
@@ -108,7 +111,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that ``Stage1`` declares an output of name ``c`` of ``Number`` type which can be accessed by calling the ``output`` method on the object. Now let us add this stage to our ``Pipeline`` using the ``add_stage`` method:"
+    "We can see that ``Stage1`` declares outputs named ``c`` and ``d`` of type ``param.Number`` that can be accessed by calling the ``output`` method on the object. Now let us add this stage to our ``Pipeline`` using the ``add_stage`` method:"
    ]
   },
   {
@@ -124,16 +127,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``add_stage`` method takes the name of the stage as its first argument, the stage class or instance as the second parameter and any additional keyword arguments to override default behavior."
+    "The ``add_stage`` method takes the name of the stage as its first argument, the stage class or instance as the second parameter, and any additional keyword arguments if you want to override default behavior."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A ``Pipeline`` with only a single stage is not much of a ``Pipeline`` of course, so it's time to set up a second stage, consuming the outputs of the first. Recall that ``Stage1`` declares one output named ``c``. This means that if the output from ``Stage1`` should flow to ``Stage2``, the latter should declare a ``Parameter`` named ``c`` that will consume the output of the first stage. It does not have to consume all parameters, so we can ignore output ``d``.\n",
+    "A ``Pipeline`` with only a single stage is not much of a ``Pipeline``, of course! So let's set up a second stage, consuming the output of the first. Recall that ``Stage1`` declares an  output named ``c``. If output ``c`` from ``Stage1`` should flow to ``Stage2``, the latter should declare a ``Parameter`` named ``c`` to consume the output of the first stage. ``Stage2`` does not have to consume all parameters, and here we will ignore output ``d``.\n",
     "\n",
-    "Below we therefore define parameters ``c`` and ``exp`` and since ``c`` is the output of the first stage the ``c`` parameter will be declared with a negative precedence stopping Panel from generating a widget for it. In other respects this class is very similar to the first one; it declares both a ``view`` method that depends on the parameters of the class and a ``panel`` method that returns a view of the object."
+    "In the second stage we will define parameters ``c`` and ``exp``. To make sure that we don't get a widget for ``c`` (as it will be set by the previous stage, not the user), we'll set its precedence to be negative (which tells Panel to skip creating a widget for it). In other respects this class is very similar to the first one; it declares both a ``view`` method that depends on the parameters of the class, and a ``panel`` method that returns a view of the object."
    ]
   },
   {
@@ -180,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And that's it; we have no declared a two stage pipeline, where the output ``c`` flows from the first stage into the second stage. To display it we can now view the ``pipeline.layout``:"
+    "And that's it; we have now declared a two-stage pipeline, where the output ``c`` flows from the first stage into the second stage. To display it we can now view the ``pipeline.layout``:"
    ]
   },
   {
@@ -190,7 +193,7 @@
    "outputs": [],
    "source": [
     "pipeline = pn.pipeline.Pipeline(debug=True)\n",
-    "pipeline.add_stage('Stage 1', Stage1(), ready_parameter='ready', auto_advance=True)\n",
+    "pipeline.add_stage('Stage 1', Stage1())\n",
     "pipeline.add_stage('Stage 2', Stage2)\n",
     "pipeline.layout"
    ]
@@ -199,9 +202,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see the ``Pipeline`` renders a little diagram displaying the available stages in the workflow along with previous and next buttons to move between each stage. This allows setting up complex workflows with multiple stages, where each component is a self-contained unit, with minimal declarations about its outputs (using the ``param.output`` decorator) and how to render it (by declaring a ``panel`` method).\n",
+    "As you can see the ``Pipeline`` renders a little diagram displaying the available stages in the workflow along with previous and next buttons to move between each stage. This allows setting up complex workflows with multiple stages, where each component is a self-contained unit, with minimal declarations about stage outputs (using the ``param.output`` decorator) and how to render the stage (by declaring a ``panel`` method).\n",
     "\n",
-    "Above we created the ``Pipeline`` as we went along which makes some sense in a notebook to allow debugging and development of each stage.  When deploying the Pipeline as a server app or when there's no reason to instantiate each stage separately, it is also possible to declare the stages as part of the constructor:"
+    "Above we created the ``Pipeline`` as we went along, which makes some sense in a notebook to allow debugging and development of each stage.  When deploying the Pipeline as a server app or when there's no reason to instantiate each stage separately; instead we can declare the stages as part of the constructor:"
    ]
   },
   {
@@ -210,12 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stages = [\n",
-    "    ('Stage 1', Stage1),\n",
-    "    ('Stage 2', Stage2)\n",
-    "]\n",
-    "\n",
-    "pipeline = pn.pipeline.Pipeline(stages)\n",
+    "pipeline = pn.pipeline.Pipeline([('Stage 1', Stage1), ('Stage 2', Stage2)])\n",
     "pipeline.layout"
    ]
   },
@@ -223,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you will note the Pipeline stages may be either ``Parameterized`` instances or ``Parameterized`` classes, but when working with instances you must ensure that updating the parameters of the class is sufficient to update the current state of the class."
+    "Pipeline stages may be either ``Parameterized`` instances or ``Parameterized`` classes. With classes, the class will not be instantiated until that stage is reached, which lets you postpone allocating memory, reading files, querying databases, and other expensive actions that might be in the constructor until the parameters for that stage have been collected from previous stages. You can also use an instantiated ``Parameterized`` object instance, e.g. if you want to set some parameters to non-default values before putting the stage into the pipeline, but in that case you will need to ensure that updating the parameters of the instantiated object is sufficient to update the full current state of that stage."
    ]
   },
   {
@@ -232,7 +230,7 @@
    "source": [
     "## Non-linear pipelines\n",
     "\n",
-    "Pipelines are not limited to simple linear UI workflows, they support any arbitrary branching structures, or put another way any acyclic graph. A simple example might be a workflow with two alternative stages which rejoin at a later point. In the very simple example below we declare four stages, an `Input`, `Multiply` and `Add` and finally a `Result` stage."
+    "Pipelines are not limited to simple linear UI workflows like the ones listed above. They support any arbitrary branching structures, i.e., an acyclic graph. A simple example might be a workflow with two alternative stages that rejoin at a later point. In the very simple example below we declare four stages: an `Input`, `Multiply`, `Add`, and `Result`."
    ]
   },
   {
@@ -243,9 +241,9 @@
    "source": [
     "class Input(param.Parameterized):\n",
     "    \n",
-    "    value1 = param.Integer(default=0)\n",
+    "    value1 = param.Integer(default=2)\n",
     "\n",
-    "    value2 = param.Integer(default=0)\n",
+    "    value2 = param.Integer(default=3)\n",
     "    \n",
     "    def panel(self):\n",
     "        return pn.Row(self.param.value1, self.param.value2)\n",
@@ -321,20 +319,22 @@
    "source": [
     "## Custom layout\n",
     "\n",
-    "The `Pipeline` has a default `layout` with a `header` bar containing the navigation elements and the main `stage`. To achieve more custom layouts, each of the components can be arranged manually:\n",
+    "For a `Pipeline` object `p`, `p.layout` is a Panel layout with the following hierarchically arranged components:\n",
     "\n",
     "* `layout`: The overall layout of the header and stage.\n",
-    "* `header`: The navigation components and network diagram.\n",
-    "  - `title`: The name of the current stage.\n",
-    "  - `network`: A network diagram representing the pipeline.\n",
-    "  - `buttons`: All navigation buttons and selectors.\n",
-    "  - `prev_button`: The button to go to the previous stage.\n",
-    "  - `prev_selector`: The selector widget to select between previous branching stages.\n",
-    "  - `next_button`:   The button to go to the previous stage\n",
-    "  - `next_selector`: The selector widget to select the next branching stages.\n",
-    "* `stage`: The contents of the current pipeline stage.\n",
+    "  - `header`: The navigation components and network diagram.\n",
+    "    * `title`: The name of the current stage.\n",
+    "    * `network`: A network diagram representing the pipeline.\n",
+    "    * `buttons`: All navigation buttons and selectors.\n",
+    "       - `prev_button`: The button to go to the previous stage.\n",
+    "       - `prev_selector`: The selector widget to select between previous branching stages.\n",
+    "       - `next_button`:   The button to go to the previous stage\n",
+    "       - `next_selector`: The selector widget to select the next branching stages.\n",
+    "  * `stage`: The contents of the current pipeline stage.\n",
     "\n",
-    "When displaying a pipeline in this way it is important to first initialize it:"
+    "You can pick and choose any combination of these components to display in any configuration, e.g. just `pn.Column(p.title,p.network,p.stage)` if you don't want to show any buttons for a pipeline `p`. When displaying a pipeline in this way it is important to first initialize it, so that the network graph has been constructed.\n",
+    "\n",
+    "For instance, let's rearrange our `dag` pipeline to fit into a smaller horizontal space:"
    ]
   },
   {
@@ -343,14 +343,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dag.init()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can compose the components in any way that is desired:"
+    "dag.init()\n",
+    "print(dag.stage)"
    ]
   },
   {
@@ -372,11 +366,11 @@
    "source": [
     "## Programmatic flow control\n",
     "\n",
-    "By default controlling the flow between different stages is done using the \"Previous\" and \"Next\" buttons. However often we want to control the UI flow programmatically from within a stage. A `Pipeline` allows programmatic control by declaring a `ready_parameter` either per stage or globally on the Pipeline, which blocks and unblocks the buttons and allow advancing automatically when combined with the ``auto_advance`` parameter. In this way we can control the workflow programmatically from inside the stages.\n",
+    "By default, controlling the flow between different stages is done using the \"Previous\" and \"Next\" buttons. However often we want to control the UI flow programmatically from within a stage. A `Pipeline` allows programmatic control by declaring a `ready_parameter` either per stage or globally on the Pipeline, which can block or unblock the buttons depending on the information obtained so far, as well as advancing automatically when combined with the ``auto_advance`` parameter. In this way we can control the workflow programmatically from inside the stages.\n",
     "\n",
-    "In the example below we create a version of the previous workflow which can be used without the buttons by declaring ``ready`` parameters on each of the stages, which we can toggle with a custom button or simply set to `True` by default to automatically skip the stage.\n",
+    "In the example below we create a version of the previous workflow that can be used without the buttons by declaring ``ready`` parameters for each of the stages, which we can toggle with a custom button or simply set to `True` by default to automatically skip the stage.\n",
     "\n",
-    "Lastly, we can also control which branching stage to switch to from within a stage. To do so we declare a parameter which will hold the name of the next stage to switch to, in this case selecting between 'Add' and 'Multiply', later we will point the pipeline to this parameter using the `next_parameter` argument."
+    "Lastly, we can also control which branching stage to switch to from within a stage. To do so we declare a parameter which will hold the name of the next stage to switch to, in this case selecting between 'Add' and 'Multiply'. Later we will point the pipeline to this parameter using the `next_parameter` argument."
    ]
   },
   {
@@ -412,7 +406,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have declared these stages let us set up the pipeline ensuring that we declare the `ready_parameter`, `next_parameter` and `auto_advance` settings appropriately:"
+    "Now that we have declared these stages let us set up the pipeline, ensuring that we declare the `ready_parameter`, `next_parameter`, and `auto_advance` settings appropriately:"
    ]
   },
   {
@@ -421,12 +415,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dag = pn.pipeline.Pipeline() # could set ready_parameter='ready' and auto_advance=True globally\n",
+    "dag = pn.pipeline.Pipeline() # could instead set ready_parameter='ready' and auto_advance=True globally here\n",
     "\n",
-    "dag.add_stage('Input', AutoInput, ready_parameter='ready', auto_advance=True, next_parameter='operator')\n",
+    "dag.add_stage('Input',    AutoInput,    ready_parameter='ready', auto_advance=True, next_parameter='operator')\n",
     "dag.add_stage('Multiply', AutoMultiply, ready_parameter='ready', auto_advance=True)\n",
-    "dag.add_stage('Add', AutoAdd, ready_parameter='ready', auto_advance=True)\n",
-    "dag.add_stage('Result', Result)\n",
+    "dag.add_stage('Add',      AutoAdd,      ready_parameter='ready', auto_advance=True)\n",
+    "dag.add_stage('Result',   Result)\n",
     "\n",
     "dag.define_graph({'Input': ('Multiply', 'Add'), 'Multiply': 'Result', 'Add': 'Result'})\n",
     "\n",
@@ -437,7 +431,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally we display the pipeline, without the buttons because all the flow control is now handled from within the stages:"
+    "Finally we display the pipeline without the buttons, which is appropriate because all the flow control is now handled from within the stages:"
    ]
   },
   {
@@ -449,8 +443,14 @@
     "pn.Column(\n",
     "    dag.title,\n",
     "    dag.network,\n",
-    "    dag.stage\n",
-    ")"
+    "    dag.stage)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, a panel Pipeline can be used to set up complex workflows when needed, with each stage controlled either manually or from within the stage, without having to define complex callbacks or other GUI logic."
    ]
   }
  ],


### PR DESCRIPTION
Main changes:

- The first section was written as if there was only one output, but the code had two; looks like the markdown wasn't updated when the code was
- Removed stray `, ready_parameter='ready', auto_advance=True` in early example; looks like something meant for the last example
- Clarified hierarchical arrangement of `.layout`
- Cleaned up descriptions and narrative flow

I opened some issues found while reviewing this (#731, #732, #733, #734). When those are fixed, the text in this notebook will need to be updated accordingly, so this PR should probably be merged before addressing any of those (or updated each time).  

One additional issue is that I wasn't sure why `.init()` needed to be called or precisely when it should be called; isn't there some way that it can be called automatically?  It's a confusing, stateful thing...