### PR TITLE
Remove object attribute from Panel class

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -24,9 +24,6 @@ class Panel(Reactive):
     Abstract baseclass for a layout of Viewables.
     """
 
-    objects = param.Parameter(default=[], doc="""
-        The list of child objects that make up the layout.""")
-
     _bokeh_model = None
 
     __abstract = True


### PR DESCRIPTION
Closes #546 

Inheriting classes define this attribute individually.