### PR TITLE
Correct GridSpec override behavior

### DIFF
--- a/panel/layout.py
+++ b/panel/layout.py
@@ -824,12 +824,12 @@ class GridSpec(Panel):
     @property
     def nrows(self):
         max_yidx = [y1 for (_, _, y1, _) in self.objects if y1 is not None]
-        return max(max_yidx) if max_yidx else 0
+        return max(max_yidx) if max_yidx else (1 if len(self.objects) else 0)
 
     @property
     def ncols(self):
         max_xidx = [x1 for (_, _, _, x1) in self.objects if x1 is not None]
-        return max(max_xidx) if max_xidx else 0
+        return max(max_xidx) if max_xidx else (1 if len(self.objects) else 0)
 
     @property
     def grid(self):
@@ -947,7 +947,10 @@ class GridSpec(Panel):
             overlapping = ''
             objects = []
             for (yidx, xidx) in zip(*np.where(overlap_grid)):
-                old_obj = self[yidx, xidx]
+                try:
+                    old_obj = self[yidx, xidx]
+                except:
+                    continue
                 if old_obj not in objects:
                     objects.append(old_obj)
                     overlapping += '    (%d, %d): %s\n\n' % (yidx, xidx, old_obj)
@@ -962,7 +965,10 @@ class GridSpec(Panel):
                 self.param.warning(overlap_text)
 
             subgrid = self._object_grid[index]
-            objects = OrderedDict([list(o)[0] for o in subgrid.flatten()])
+            if isinstance(subgrid, set):
+                objects = [list(subgrid)[0][0]] if subgrid else []
+            else:
+                objects = [list(o)[0][0] for o in subgrid.flatten()]
             for dkey in objects:
                 del self.objects[dkey]
         self.objects[key] = Pane(obj)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -719,7 +719,7 @@ class GridSpec(Panel):
 
     mode = param.ObjectSelector(
         default='warn', objects=['warn', 'error', 'override'], doc="""
-        Whether to error or simply override on overlapping assignment.""")
+        Whether to warn, error or simply override on overlapping assignment.""")
 
     width = param.Integer(default=600)
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -950,7 +950,6 @@ class GridSpec(Panel):
             objects = []
             for (yidx, xidx) in zip(*np.where(overlap_grid)):
                 old_obj = self[yidx, xidx]
-                print((yidx, xidx), old_obj)
                 if old_obj not in objects:
                     objects.append(old_obj)
                     overlapping += '    (%d, %d): %s\n\n' % (yidx, xidx, old_obj)

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -718,9 +718,8 @@ class GridSpec(Panel):
         The dictionary of child objects that make up the grid.""")
 
     mode = param.ObjectSelector(
-        default='warn', objects=['warn', 'error', 'override'], doc="""
-        Whether to warn, error or simply override on overlapping
-        assignment.""")
+        default='override', objects=['error', 'override'], doc="""
+        Whether to error or simply override on overlapping assignment.""")
 
     width = param.Integer(default=600)
 
@@ -951,6 +950,7 @@ class GridSpec(Panel):
             objects = []
             for (yidx, xidx) in zip(*np.where(overlap_grid)):
                 old_obj = self[yidx, xidx]
+                print((yidx, xidx), old_obj)
                 if old_obj not in objects:
                     objects.append(old_obj)
                     overlapping += '    (%d, %d): %s\n\n' % (yidx, xidx, old_obj)
@@ -961,8 +961,7 @@ class GridSpec(Panel):
                             str(grid.astype('uint8')))
             if self.mode == 'error':
                 raise IndexError(overlap_text)
-            elif self.mode == 'warn':
-                self.param.warning(overlap_text)
+            self.objects.__delitem__(*self.__getitem__(index).objects.keys())
             self.__delitem__(index, False)
         self.objects[key] = Pane(obj)
         self.param.trigger('objects')


### PR DESCRIPTION
Closes #514 .

Removed the 'warn' mode to keep only 'error' and 'override'.
'override' behavior now correctly removes the pre-existing Panel.

WIP since the object deletion feels like a kludge and an additional latent bug was noticed during 'error' behavior resulting from line 937-945.

https://github.com/kleavor/panel/blob/a5dff2e30cc08eee713d18ff6ac06d2f20e65c25/panel/layout.py#L937-L945

The if-statement on `overlap` only evaluates to true if the location of the new Panel object exactly matches the location of the conflicting Panel object. In the case of the example provided in the Issue, neither of the new panels matches the "Initial" Panel exactly, and the new object is still added despite erroring, since the error is not raised until the end of the method.

Behavior can be observed in a notebook with the following cells

```python
pn.extension()
gs = pn.GridSpec(mode='error')
gs[0:2, 0] = pn.widgets.MultiSelect(options=[0, 1, 2, 3], name='Initial')
display(gs.objects)
gs
```

The following cell will raise an Exception.
```python
gs[0:1, 0] = pn.widgets.MultiSelect(options=[5, 6, 7], name='Second')
gs[1:2, 0] = pn.widgets.MultiSelect(options=[9, 10, 11], name='Third')
display(gs.objects)
```

This cell will show that the state of the gs object now still contains the MultiSelect object despite erroring.

```python
print(gs)
```
```