### PR TITLE
Add DataFrame pane for pandas, dask and streamz

### DIFF
--- a/examples/reference/panes/DataFrame.ipynb
+++ b/examples/reference/panes/DataFrame.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``DataFrame`` pane renders pandas, dask and streamz ``DataFrame`` and ``Series`` types as an HTML table. If you need to edit the values of a `DataFrame` use the `DataFrame` widget instead. The Pane supports all the arguments to the `DataFrame.to_html` function. \n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``bold_rows``** (boolean, default=True): Make the row labels bold in the output.\n",
+    "* **``border``** (int, default=0): Width of the border included in the opening ``table`` tag.\n",
+    "* **``classes``** (list[str]): CSS class(es) to apply to the resulting html table.\n",
+    "* **``col_space``** (int or str): The minimum width of each column in CSS length units. An int is assumed to be px units.\n",
+    "* **``decimal``** (str, default='.'): Character recognized as decimal separator, e.g. ',' in Europe.\n",
+    "* **``escape``** (boolean, default=False): Convert the characters <, >, and & to HTML-safe sequences.\n",
+    "* **``float_format``** (function): Formatter function to apply to columns' elements if they are floats. The result of this function must be a unicode string.\n",
+    "* **``formatters``** (dict or list): Formatter functions to apply to columns' elements by position or name. The result of each function must be a unicode string.\n",
+    "* **``object``** (object): The HoloViews object being displayed\n",
+    "* **``header``** (boolean, default=True): Whether to print column labels.\n",
+    "* **``index``** (boolean, default=True): Whether to print index (row) labels.\n",
+    "* **``index_names``** (boolean, default=True): Whether to print the names of the indexes.\n",
+    "* **``justify``** (str): How to justify the column labels ('left', 'right', 'center', 'justify', 'justify-all', 'start', 'end', 'inherit', 'match-parent', 'initial', 'unset')\n",
+    "* **``max_rows``** (int): Maximum number of rows to display.\n",
+    "* **``max_rows``** (int): Maximum number of rows to display.\n",
+    "* **``max_cols``** (int): Maximum number of columns to display.\n",
+    "* **``na_rep``** (str, default='NaN'): String representation of NAN to use.\n",
+    "* **``render_links``** (boolean, default=False): Convert URLs to HTML links.\n",
+    "* **``show_dimensions``** (boolean, default=False): Display DataFrame dimensions (number of rows by number of columns).\n",
+    "* **``sparsify``** (boolean, default=True): Set to False for a DataFrame with a hierarchical index to print every multi-index key at each row.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `DataFrame` uses the inbuilt HTML repr to render the underlying DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.util.testing.makeMixedDataFrame()\n",
+    "\n",
+    "df_pane = pn.pane.DataFrame(df)\n",
+    "\n",
+    "df_pane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like all other Panel objects changing a parameter will update the view allowing us to control the styling of the dataframe. In this example we will control these parameters using a set of widgets created directly from Pane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.panel(df_pane.param, parameters=['bold_rows', 'index', 'header', 'max_rows', 'show_dimensions'],\n",
+    "         widgets={'max_rows': {'start': 1, 'end': len(df), 'value': len(df)}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to rendering standard pandas `DataFrame` and `Series` types the `DataFrame` pane will also render updating `streamz` types (Note: in a live kernel you should see the dataframe update every 0.5 seconds):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from streamz.dataframe import Random\n",
+    "\n",
+    "sdf = Random(interval='200ms', freq='50ms')\n",
+    "\n",
+    "pn.pane.DataFrame(sdf, width=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(sdf.groupby('y').sum().x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -13,7 +13,7 @@ from .base import PaneBase, Pane # noqa
 from .equation import LaTeX # noqa
 from .holoviews import HoloViews # noqa
 from .image import GIF, JPG, PNG, SVG # noqa
-from .markup import HTML, Markdown, Str # noqa
+from .markup import DataFrame, HTML, Markdown, Str # noqa
 from .media import Audio, Video # noqa
 from .plotly import Plotly # noqa
 from .plot import Bokeh, Matplotlib, RGGPlot, YT # noqa

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -133,7 +133,7 @@ class DataFrame(HTML):
     index_names = param.Boolean(default=True, doc="""
         Prints the names of the indexes.""")
 
-    justify = param.ObjectSelector(default=None, objects=[
+    justify = param.ObjectSelector(default=None, allow_None=True, objects=[
         'left', 'right', 'center', 'justify', 'justify-all', 'start',
         'end', 'inherit', 'match-parent', 'initial', 'unset'], doc="""
         How to justify the column labels.""")

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from panel.pane import HTML, Markdown, PaneBase, Pane, Str
+from panel.pane import DataFrame, HTML, Markdown, PaneBase, Pane, Str
 from panel.tests.util import pd_available
 
 
@@ -11,13 +11,13 @@ def test_get_markdown_pane_type():
 def test_get_dataframe_pane_type():
     import pandas as pd
     df = pd.util.testing.makeDataFrame()
-    assert PaneBase.get_pane_type(df) is HTML
+    assert PaneBase.get_pane_type(df) is DataFrame
 
 @pd_available
 def test_get_series_pane_type():
     import pandas as pd
     df = pd.util.testing.makeDataFrame()
-    assert PaneBase.get_pane_type(df.iloc[:, 0]) is HTML
+    assert PaneBase.get_pane_type(df.iloc[:, 0]) is DataFrame
     
 
 def test_markdown_pane(document, comm):

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 from panel.pane import DataFrame, HTML, Markdown, PaneBase, Pane, Str
-from panel.tests.util import pd_available
+from panel.tests.util import pd_available, streamz_available
 
 
 def test_get_markdown_pane_type():
@@ -18,7 +18,31 @@ def test_get_series_pane_type():
     import pandas as pd
     df = pd.util.testing.makeDataFrame()
     assert PaneBase.get_pane_type(df.iloc[:, 0]) is DataFrame
-    
+
+@streamz_available
+def test_get_streamz_dataframe_pane_type():
+    from streamz.dataframe import Random
+    sdf = Random(interval='200ms', freq='50ms')
+    assert PaneBase.get_pane_type(sdf) is DataFrame
+
+@streamz_available
+def test_get_streamz_dataframes_pane_type():
+    from streamz.dataframe import Random
+    sdf = Random(interval='200ms', freq='50ms').groupby('y').sum()
+    assert PaneBase.get_pane_type(sdf) is DataFrame
+
+@streamz_available
+def test_get_streamz_series_pane_type():
+    from streamz.dataframe import Random
+    sdf = Random(interval='200ms', freq='50ms')
+    assert PaneBase.get_pane_type(sdf.x) is DataFrame
+
+@streamz_available
+def test_get_streamz_seriess_pane_type():
+    from streamz.dataframe import Random
+    sdf = Random(interval='200ms', freq='50ms').groupby('y').sum()
+    assert PaneBase.get_pane_type(sdf.x) is DataFrame
+
 
 def test_markdown_pane(document, comm):
     pane = Pane("**Markdown**")
@@ -53,6 +77,53 @@ def test_html_pane(document, comm):
 
     # Cleanup
     pane._cleanup(model)
+    assert pane._models == {}
+
+
+@pd_available
+def test_dataframe_pane_pandas(document, comm):
+    import pandas as pd
+    pane = DataFrame(pd.util.testing.makeDataFrame())
+
+    # Create pane
+    model = pane.get_root(document, comm=comm)
+    assert pane._models[model.ref['id']][0] is model
+    assert model.text.startswith('&lt;table')
+    orig_text = model.text
+
+    # Replace Pane.object
+    pane.object = pd.util.testing.makeMixedDataFrame()
+    assert pane._models[model.ref['id']][0] is model
+    assert model.text.startswith('&lt;table')
+    assert model.text != orig_text
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._models == {}
+
+
+@streamz_available
+def test_dataframe_pane_streamz(document, comm):
+    from streamz.dataframe import Random
+    sdf = Random(interval='200ms', freq='50ms')
+    pane = DataFrame(sdf)
+    
+    assert pane._stream is None
+
+    # Create pane
+    model = pane.get_root(document, comm=comm)
+    assert pane._stream is not None
+    assert pane._models[model.ref['id']][0] is model
+    assert model.text == ''
+
+    # Replace Pane.object
+    pane.object = sdf.x
+    assert pane._models[model.ref['id']][0] is model
+    assert model.text == ''
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._stream is None
     assert pane._models == {}
 
 

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -22,6 +22,12 @@ except:
     pd = None
 pd_available = pytest.mark.skipif(pd is None, reason="requires pandas")
 
+try:
+    import streamz
+except:
+    streamz = None
+streamz_available = pytest.mark.skipif(streamz is None, reason="requires streamz")
+
 
 def mpl_figure():
     import matplotlib.pyplot as plt

--- a/setup.py
+++ b/setup.py
@@ -112,10 +112,11 @@ extras_require = {
         'nbsmoke >=0.2.0',
         'pytest-cov ==2.5.1',
         'codecov',
-        # For Panes.ipynb
+        # For examples
         'hvplot',
         'plotly',
         'altair',
+        'streamz',
         'vega_datasets',
         'vtk ==8.1.1',
         'scikit-learn',


### PR DESCRIPTION
Renders pandas, dask and streamz DataFrames and Series.

Streamz objects update:

![streamz_df](https://user-images.githubusercontent.com/1550771/68351881-65d3e200-00ca-11ea-9914-bf89bc896c5a.gif)

- [x] Implements https://github.com/pyviz/panel/issues/533
- [x] Only listen to streamz if displayed.
- [x] Add reference notebook 