### PR TITLE
Add Streamz pane with ReplacementPane base class

### DIFF
--- a/examples/reference/panes/Streamz.ipynb
+++ b/examples/reference/panes/Streamz.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "from streamz import Stream\n",
+    "\n",
+    "pn.extension('vega')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``Streamz`` pane renders [streamz](https://github.com/python-streamz/streamz) Stream objects emitting arbitrary objects, unlike the ``DataFrame`` pane which specifically handles streamz DataFrame and Series objects and exposes various formatting objects.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``always_watch``** (boolean, default=False): Whether to watch the stream even when not displayed.\n",
+    "* **``object``** (streamz.Stream): The streamz.Stream object being watched\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Streamz` pane uses the default panel resolution to figure out the appropriate way to render the object returned by a Stream. By default the pane will only watch the ``Stream`` if it is displayed, we can tell it to watch the stream as soon as it is created by setting `always_watch=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def increment(x):\n",
+    "    return x + 1\n",
+    "\n",
+    "source = Stream()\n",
+    "\n",
+    "streamz_pane = pn.pane.Streamz(source.map(increment), always_watch=True)\n",
+    "\n",
+    "# Note: To ensure that a static render of the stream displays anything\n",
+    "#       we set always_watch=True and emit an event before displaying\n",
+    "source.emit(1)\n",
+    "\n",
+    "streamz_pane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Streamz` stream can be used to stream any kind of data, e.g. we can create a streamz DataFrame, accumulate the data into a sliding window and then map it to a altair `line_plot` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import altair as alt\n",
+    "import pandas as pd\n",
+    "from streamz.dataframe import DataFrame as sDataFrame\n",
+    "\n",
+    "df = sDataFrame(example=pd.DataFrame({'y': []}, index=pd.DatetimeIndex([])))\n",
+    "\n",
+    "def line_plot(data):\n",
+    "    return alt.Chart(pd.concat(data).reset_index()).mark_line().encode(\n",
+    "        x='index',\n",
+    "        y='y',\n",
+    "    )\n",
+    "\n",
+    "altair_stream = df.cumsum().stream.sliding_window(100).map(line_plot)\n",
+    "\n",
+    "altair_pane = pn.pane.Streamz(altair_stream, height=350, always_watch=True)\n",
+    "\n",
+    "for i in range(100):\n",
+    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([pd.datetime.now()])))\n",
+    "\n",
+    "altair_pane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can emit additional data on the DataFrame and watch the plot update:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "for i in range(100):\n",
+    "    time.sleep(0.2)\n",
+    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([pd.datetime.now()])))"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/links.py
+++ b/panel/links.py
@@ -8,7 +8,6 @@ import weakref
 import sys
 
 from .viewable import Viewable, Reactive
-from .pane.holoviews import HoloViews, generate_panel_bokeh_map, is_bokeh_element_plot
 from .util import unicode_repr
 
 from bokeh.models import (CustomJS, Model as BkModel)
@@ -96,6 +95,8 @@ class Callback(param.Parameterized):
 
         arg_overrides = {}
         if 'holoviews' in sys.modules:
+            from .pane.holoviews import HoloViews, generate_panel_bokeh_map
+
             hv_views = root_view.select(HoloViews)
             map_hve_bk = generate_panel_bokeh_map(root_model, hv_views)
             for src in linkable:
@@ -270,6 +271,8 @@ class CallbackGenerator(object):
                 references[k] = v
 
         if 'holoviews' in sys.modules:
+            from .pane.holoviews import HoloViews, is_bokeh_element_plot
+
             if isinstance(source, HoloViews):
                 src = source._plots[ref][0]
             else:

--- a/panel/links.py
+++ b/panel/links.py
@@ -224,6 +224,8 @@ class CallbackGenerator(object):
         model: bokeh.model.Model
           The resolved bokeh model
         """
+        from .pane.holoviews import is_bokeh_element_plot
+
         model = None
         if 'holoviews' in sys.modules and is_bokeh_element_plot(obj):
             if model_spec is None:

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -17,6 +17,7 @@ from .markup import DataFrame, HTML, Markdown, Str # noqa
 from .media import Audio, Video # noqa
 from .plotly import Plotly # noqa
 from .plot import Bokeh, Matplotlib, RGGPlot, YT # noqa
+from .streamz import Streamz # noqa
 from .vega import Vega # noqa
 from .vtk import VTK, VTKVolume # noqa
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -264,7 +264,6 @@ class ReplacementPane(PaneBase):
         self._kwargs =  {p: params.pop(p) for p in list(params)
                          if p not in self.param}
         super(ReplacementPane, self).__init__(object, **params)
-        kwargs = dict(self.get_param_values(), **self._kwargs)
         self._pane = Pane(None)
         self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -286,7 +286,8 @@ class ReplacementPane(PaneBase):
             # Replace pane entirely
             kwargs = dict(self.get_param_values(), **self._kwargs)
             del kwargs['object']
-            self._pane = Pane(new_object, **kwargs)
+            self._pane = Pane(new_object, **{k: v for k, v in kwargs.items()
+                                             if k in pane_type.param})
             self._inner_layout[0] = self._pane
 
     def _get_model(self, doc, root=None, parent=None, comm=None):

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -13,6 +13,7 @@ from bokeh.models.layouts import GridBox as _BkGridBox
 
 from ..io import push, state
 from ..layout import Panel, Row
+from ..links import Link
 from ..viewable import Viewable, Reactive, Layoutable
 from ..util import param_reprs
 
@@ -245,3 +246,79 @@ class PaneBase(Reactive):
             if isinstance(applies, bool) and not applies: continue
             return pane_type
         raise TypeError('%s type could not be rendered.' % type(obj).__name__)
+
+
+
+class ReplacementPane(PaneBase):
+    """
+    A Pane type which allows for complete replacement of the underlying
+    bokeh model by creating an internal layout to replace the children
+    on.
+    """
+
+    __abstract = True
+
+    _updates = True
+
+    def __init__(self, object=None, **params):
+        self._kwargs =  {p: params.pop(p) for p in list(params)
+                         if p not in self.param}
+        super(ReplacementPane, self).__init__(object, **params)
+        kwargs = dict(self.get_param_values(), **self._kwargs)
+        self._pane = Pane(None)
+        self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
+
+    def _update_pane(self, new_object):
+        pane_type = self.get_pane_type(new_object)
+        try:
+            links = Link.registry.get(new_object)
+        except TypeError:
+            links = []
+        if type(self._pane) is pane_type and not links:
+            if isinstance(new_object, Reactive):
+                pvals = dict(self._pane.get_param_values())
+                new_params = {k: v for k, v in new_object.get_param_values()
+                              if k != 'name' and v is not pvals[k]}
+                self._pane.set_param(**new_params)
+            else:
+                self._pane.object = new_object
+        else:
+            # Replace pane entirely
+            kwargs = dict(self.get_param_values(), **self._kwargs)
+            del kwargs['object']
+            self._pane = Pane(new_object, **kwargs)
+            self._inner_layout[0] = self._pane
+
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        if root:
+            ref = root.ref['id']
+            if ref in self._models:
+                self._cleanup(root)
+        model = self._inner_layout._get_model(doc, root, parent, comm)
+        if root is None:
+            ref = model.ref['id']
+        self._models[ref] = (model, parent)
+        return model
+
+    def _cleanup(self, root=None):
+        self._inner_layout._cleanup(root)
+        super(ReplacementPane, self)._cleanup(root)
+
+    def select(self, selector=None):
+        """
+        Iterates over the Viewable and any potential children in the
+        applying the Selector.
+
+        Arguments
+        ---------
+        selector: type or callable or None
+          The selector allows selecting a subset of Viewables by
+          declaring a type or callable function to filter by.
+
+        Returns
+        -------
+        viewables: list(Viewable)
+        """
+        selected = super(ReplacementPane, self).select(selector)
+        selected += self._pane.select(selector)
+        return selected

--- a/panel/pane/streamz.py
+++ b/panel/pane/streamz.py
@@ -3,6 +3,8 @@ Renders Streamz Stream objects.
 """
 from __future__ import absolute_import, division, unicode_literals
 
+import sys
+
 import param
 
 from .base import ReplacementPane
@@ -10,19 +12,25 @@ from .base import ReplacementPane
 
 class Streamz(ReplacementPane):
 
+    always_watch = param.Boolean(default=False, doc="""
+        Whether to watch even when not displayed.""")
+
     def __init__(self, object=None, **params):
         super(Streamz, self).__init__(object, **params)
         self._stream = None
+        if self.always_watch:
+            self._setup_stream()
 
-    @param.depends('object', watch=True)
+    @param.depends('object', 'always_watch', watch=True)
     def _setup_stream(self):
-        if self.object is None:
+        if self.object is None or (self.always_watch and self._stream):
             return
         elif self._stream:
             self._stream.destroy()
             self._stream = None
-        self._stream = self.object.latest().rate_limit(0.5).gather()
-        self._stream.sink(self._update_pane)
+        if self._pane._models or self.always_watch:
+            self._stream = self.object.latest().rate_limit(0.5).gather()
+            self._stream.sink(self._update_pane)
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         model = super(Streamz, self)._get_model(doc, root, parent, comm)
@@ -41,8 +49,7 @@ class Streamz(ReplacementPane):
 
     @classmethod
     def applies(cls, obj):
-        module = getattr(obj, '__module__', '')
-        name = type(obj).__name__
-        if 'streamz' in module and name == 'Stream':
-            return 0.3
+        if 'streamz' in sys.modules:
+            from streamz import Stream
+            return isinstance(obj, Stream)
         return False

--- a/panel/pane/streamz.py
+++ b/panel/pane/streamz.py
@@ -1,0 +1,48 @@
+"""
+Renders Streamz Stream objects.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import param
+
+from .base import ReplacementPane
+
+
+class Streamz(ReplacementPane):
+
+    def __init__(self, object=None, **params):
+        super(Streamz, self).__init__(object, **params)
+        self._stream = None
+
+    @param.depends('object', watch=True)
+    def _setup_stream(self):
+        if self.object is None:
+            return
+        elif self._stream:
+            self._stream.destroy()
+            self._stream = None
+        self._stream = self.object.latest().rate_limit(0.5).gather()
+        self._stream.sink(self._update_pane)
+
+    def _get_model(self, doc, root=None, parent=None, comm=None):
+        model = super(Streamz, self)._get_model(doc, root, parent, comm)
+        self._setup_stream()
+        return model
+
+    def _cleanup(self, root=None):
+        super(Streamz, self)._cleanup(root)
+        if not self._pane._models and self._stream:
+            self._stream.destroy()
+            self._stream = None
+
+    #----------------------------------------------------------------
+    # Public API
+    #----------------------------------------------------------------
+
+    @classmethod
+    def applies(cls, obj):
+        module = getattr(obj, '__module__', '')
+        name = type(obj).__name__
+        if 'streamz' in module and name == 'Stream':
+            return 0.3
+        return False

--- a/panel/param.py
+++ b/panel/param.py
@@ -21,13 +21,12 @@ from param.parameterized import classlist
 
 from .io import state
 from .layout import Row, Panel, Tabs, Column
-from .links import Link
-from .pane.base import Pane, PaneBase, ReplacementPane
+from .pane.base import PaneBase, ReplacementPane
 from .util import (
     abbreviated_repr, full_groupby, get_method_owner, is_parameterized,
     param_name
 )
-from .viewable import Layoutable, Reactive
+from .viewable import Layoutable
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
     MultiSelect, StaticText, Button, Toggle, TextInput, DatetimeInput,

--- a/panel/param.py
+++ b/panel/param.py
@@ -22,15 +22,17 @@ from param.parameterized import classlist
 from .io import state
 from .layout import Row, Panel, Tabs, Column
 from .links import Link
-from .pane.base import Pane, PaneBase
+from .pane.base import Pane, PaneBase, ReplacementPane
 from .util import (
-    abbreviated_repr, full_groupby,
-    get_method_owner, is_parameterized, param_name)
+    abbreviated_repr, full_groupby, get_method_owner, is_parameterized,
+    param_name
+)
 from .viewable import Layoutable, Reactive
 from .widgets import (
     LiteralInput, Select, Checkbox, FloatSlider, IntSlider, RangeSlider,
     MultiSelect, StaticText, Button, Toggle, TextInput, DatetimeInput,
-    DateRangeSlider, ColorPicker, Widget)
+    DateRangeSlider, ColorPicker, Widget
+)
 from .widgets.button import _ButtonBase
 
 
@@ -104,20 +106,20 @@ class Param(PaneBase):
 
     _mapping = {
         param.Action:         Button,
-        param.Parameter:      LiteralInput,
-        param.Color:          ColorPicker,
-        param.Dict:           LiteralInput,
-        param.Selector:       Select,
-        param.ObjectSelector: Select,
-        param.FileSelector:   FileSelector,
         param.Boolean:        Checkbox,
-        param.Number:         FloatSlider,
-        param.Integer:        IntSlider,
-        param.Range:          RangeSlider,
-        param.String:         TextInput,
-        param.ListSelector:   MultiSelect,
+        param.Color:          ColorPicker,
         param.Date:           DatetimeInput,
-        param.DateRange:      DateRangeSlider
+        param.DateRange:      DateRangeSlider,
+        param.Dict:           LiteralInput,
+        param.FileSelector:   FileSelector,
+        param.Integer:        IntSlider,
+        param.ListSelector:   MultiSelect,
+        param.Number:         FloatSlider,
+        param.ObjectSelector: Select,
+        param.Parameter:      LiteralInput,
+        param.Range:          RangeSlider,
+        param.Selector:       Select,
+        param.String:         TextInput,
     }
 
     _rerender_params = []
@@ -507,7 +509,7 @@ class Param(PaneBase):
         return root
 
 
-class ParamMethod(PaneBase):
+class ParamMethod(ReplacementPane):
     """
     ParamMethod panes wrap methods on parameterized classes and
     rerenders the plot when any of the method's parameters change. By
@@ -518,13 +520,7 @@ class ParamMethod(PaneBase):
     """
 
     def __init__(self, object, **params):
-        self._kwargs =  {p: params.pop(p) for p in list(params)
-                         if p not in self.param}
         super(ParamMethod, self).__init__(object, **params)
-        kwargs = dict(self.get_param_values(), **self._kwargs)
-        del kwargs['object']
-        self._pane = Pane(self._eval_function(self.object), **kwargs)
-        self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
         self._link_object_params()
 
     #----------------------------------------------------------------
@@ -541,28 +537,6 @@ class ParamMethod(PaneBase):
                 args = (getattr(dep.owner, dep.name) for dep in arg_deps)
                 kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw_deps.items()}
         return function(*args, **kwargs)
-
-    def _update_pane(self, *args):
-        new_object = self._eval_function(self.object)
-        pane_type = self.get_pane_type(new_object)
-        try:
-            links = Link.registry.get(new_object)
-        except TypeError:
-            links = []
-        if type(self._pane) is pane_type and not links:
-            if isinstance(new_object, Reactive):
-                pvals = dict(self._pane.get_param_values())
-                new_params = {k: v for k, v in new_object.get_param_values()
-                              if k != 'name' and v is not pvals[k]}
-                self._pane.set_param(**new_params)
-            else:
-                self._pane.object = new_object
-        else:
-            # Replace pane entirely
-            kwargs = dict(self.get_param_values(), **self._kwargs)
-            del kwargs['object']
-            self._pane = Pane(new_object, **kwargs)
-            self._inner_layout[0] = self._pane
 
     def _link_object_params(self):
         parameterized = get_method_owner(self.object)
@@ -593,7 +567,8 @@ class ParamMethod(PaneBase):
                     self._callbacks.append(watcher)
                     for p in params:
                         deps.append(p)
-            self._update_pane()
+            new_object = self._eval_function(self.object)
+            self._update_pane(new_object)
 
         for _, params in full_groupby(params, lambda x: (x.inst or x.cls, x.what)):
             p = params[0]
@@ -603,50 +578,13 @@ class ParamMethod(PaneBase):
             self._callbacks.append(watcher)
 
     #----------------------------------------------------------------
-    # Model API
-    #----------------------------------------------------------------
-
-    def _get_model(self, doc, root=None, parent=None, comm=None):
-        if root is None:
-            return self.get_root(doc, comm)
-
-        ref = root.ref['id']
-        if ref in self._models:
-            self._cleanup(root)
-        model = self._inner_layout._get_model(doc, root, parent, comm)
-        self._models[ref] = (model, parent)
-        return model
-
-    def select(self, selector=None):
-        """
-        Iterates over the Viewable and any potential children in the
-        applying the Selector.
-
-        Arguments
-        ---------
-        selector: type or callable or None
-          The selector allows selecting a subset of Viewables by
-          declaring a type or callable function to filter by.
-
-        Returns
-        -------
-        viewables: list(Viewable)
-        """
-        selected = super(ParamMethod, self).select(selector)
-        selected += self._pane.select(selector)
-        return selected
-
-    def _cleanup(self, root=None):
-        self._inner_layout._cleanup(root)
-        super(ParamMethod, self)._cleanup(root)
-
-    #----------------------------------------------------------------
     # Public API
     #----------------------------------------------------------------
 
     @classmethod
     def applies(cls, obj):
         return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)
+
 
 
 class ParamFunction(ParamMethod):
@@ -660,11 +598,15 @@ class ParamFunction(ParamMethod):
 
     priority = 0.6
 
+    def _replace_pane(self, *args):
+        new_object = self._eval_function(self.object)
+        self._update_pane(new_object)
+
     def _link_object_params(self):
         deps = self.object._dinfo
         dep_params = list(deps['dependencies']) + list(deps.get('kw', {}).values())
         for p in dep_params:
-            watcher = p.owner.param.watch(self._update_pane, p.name)
+            watcher = p.owner.param.watch(self._replace_pane, p.name)
             self._callbacks.append(watcher)
 
     #----------------------------------------------------------------

--- a/panel/param.py
+++ b/panel/param.py
@@ -519,9 +519,11 @@ class ParamMethod(ReplacementPane):
     return any object which itself can be rendered as a Pane.
     """
 
-    def __init__(self, object, **params):
+    def __init__(self, object=None, **params):
         super(ParamMethod, self).__init__(object, **params)
         self._link_object_params()
+        if object is not None:
+            self._update_pane(self._eval_function(object))
 
     #----------------------------------------------------------------
     # Callback API

--- a/panel/tests/test_io.py
+++ b/panel/tests/test_io.py
@@ -11,6 +11,8 @@ from panel.io.embed import embed_state
 from panel.pane import Str
 from panel.widgets import Select, FloatSlider, Checkbox
 
+from .util import jb_available
+
 
 def test_embed_discrete(document, comm):
     select = Select(options=['A', 'B', 'C'])
@@ -130,6 +132,7 @@ def test_save_embed_json(tmpdir):
         assert event['new'] == '<pre>%s</pre>' % v
 
 
+@jb_available
 def test_ipywidget():
     pane = Str('A')
     widget = ipywidget(pane)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -824,18 +824,17 @@ def test_param_function_pane(document, comm):
     row = pane.get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    inner_row = row.children[0]
-    model = inner_row.children[0]
-    assert pane._models[row.ref['id']][0] is inner_row
+    model = row.children[0]
+    assert pane._models[row.ref['id']][0] is row
     assert isinstance(model, Div)
     assert model.text == '0'
 
     # Update pane
     test.a = 5
-    new_model = inner_row.children[0]
+    new_model = row.children[0]
     assert inner_pane is pane._pane
     assert new_model.text == '5'
-    assert pane._models[row.ref['id']][0] is inner_row
+    assert pane._models[row.ref['id']][0] is row
 
     # Cleanup pane
     pane._cleanup(row)
@@ -857,18 +856,17 @@ def test_param_method_pane(document, comm):
     row = pane.get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    inner_row = row.children[0]
-    model = inner_row.children[0]
-    assert pane._models[row.ref['id']][0] is inner_row
+    model = row.children[0]
+    assert pane._models[row.ref['id']][0] is row
     assert isinstance(model, Div)
     assert model.text == '0'
 
     # Update pane
     test.a = 5
-    new_model = inner_row.children[0]
+    new_model = row.children[0]
     assert inner_pane is pane._pane
     assert new_model.text == '5'
-    assert pane._models[row.ref['id']][0] is inner_row
+    assert pane._models[row.ref['id']][0] is row
 
     # Cleanup pane
     pane._cleanup(row)
@@ -887,20 +885,19 @@ def test_param_method_pane_subobject(document, comm):
     row = pane.get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    inner_row = row.children[0]
-    model = inner_row.children[0]
+    model = row.children[0]
     assert isinstance(model, Div)
     assert model.text == '42'
 
     # Ensure that subobject is being watched
     watchers = pane._callbacks
     assert any(w.inst is subobject for w in watchers)
-    assert pane._models[row.ref['id']][0] is inner_row
+    assert pane._models[row.ref['id']][0] is row
 
     # Ensure that switching the subobject triggers update in watchers
     new_subobject = View(name='Nested', a=42)
     test.b = new_subobject
-    assert pane._models[row.ref['id']][0] is inner_row
+    assert pane._models[row.ref['id']][0] is row
     watchers = pane._callbacks
     assert not any(w.inst is subobject for w in watchers)
     assert any(w.inst is new_subobject for w in watchers)
@@ -922,18 +919,17 @@ def test_param_method_pane_mpl(document, comm):
     row = pane.get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    inner_row = row.children[0]
-    model = inner_row.children[0]
-    assert pane._models[row.ref['id']][0] is inner_row
+    model = row.children[0]
+    assert pane._models[row.ref['id']][0] is row
     text = model.text
 
     # Update pane
     test.a = 5
-    new_model = inner_row.children[0]
+    new_model = row.children[0]
     assert inner_pane is pane._pane
     assert new_model is model
     assert new_model.text != text
-    assert pane._models[row.ref['id']][0] is inner_row
+    assert pane._models[row.ref['id']][0] is row
 
     # Cleanup pane
     pane._cleanup(row)
@@ -952,14 +948,13 @@ def test_param_method_pane_changing_type(document, comm):
     row = pane.get_root(document, comm=comm)
     assert isinstance(row, BkRow)
     assert len(row.children) == 1
-    inner_row = row.children[0]
-    model = inner_row.children[0]
+    model = row.children[0]
     text = model.text
     assert text.startswith('<img src')
 
     # Update pane
     test.a = 5
-    new_model = inner_row.children[0]
+    new_model = row.children[0]
     new_pane = pane._pane
     assert isinstance(new_pane, Bokeh)
     assert isinstance(new_model, Div)

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import, division, unicode_literals
 from panel import config
 from panel.pane import Str
 
+from .util import jb_available
 
+
+@jb_available
 def test_viewable_ipywidget():
     pane = Str('A')
     with config.set(comms='ipywidgets'):

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -28,6 +28,12 @@ except:
     streamz = None
 streamz_available = pytest.mark.skipif(streamz is None, reason="requires streamz")
 
+try:
+    import jupyter_bokeh
+except:
+    jupyter_bokeh = None
+jb_available = pytest.mark.skipif(jupyter_bokeh is None, reason="requires jupyter_bokeh")
+
 
 def mpl_figure():
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Factors out components from ParamMethod class into a ReplacementPane abstract baseclass which is then used as the basis for a streamz.Stream class which allows streaming all kinds of objects in addition to the objects DataFrame like streamz objects supported by the DataFrame pane.