### PR TITLE
Updated some extra requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,4 @@ requires = [
     "bokeh >=1.4.0",
     "pyviz_comms >=0.6.0"
 ]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ extras_require = {
         'altair',
         'streamz',
         'vega_datasets',
-        'vtk == 8.1.2',
+        'vtk ==8.1.2',
         'scikit-learn',
         'datashader',
         'jupyter_bokeh'

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ extras_require = {
         'altair',
         'streamz',
         'vega_datasets',
-        'vtk ==8.1.1',
+        'vtk == 8.1.2',
         'scikit-learn',
         'datashader',
         'jupyter_bokeh'
@@ -129,7 +129,6 @@ extras_require = {
         'sphinx_ioam_theme',
         'sphinx <2',
         'selenium',
-        'phantomjs',
         'lxml',
         'pyvista'
     ]


### PR DESCRIPTION
And also added setuptools explicitly as build backend. `phantomjs` is no longer on pyPI and didn't seem to be necessary for generating the docs, and `vtk` doesn't have a python3.7 compatible wheel for version `8.1.1`.

Environment:
 - os: Ubuntu 18.04.3
 - python: 3.7.2+
 - nodejs: v8.10.0
 - npm: 3.5.2
 - phantomjs: 2.1.1

Tests run:
 - install
   - `pip install -e .` ✔️
   - `pip install -e .[tests]` ✔️
   - `pip install -e .[extras]` ✔️
   - `pip install -e .[doc]` ✔️
 - build
   - `pip wheel -w dist . --no-deps` ✔️
   - `nbsite generate-rst --org pyviz --project-name panel && nbsite build --what=html --output=builtdocs` ✔️
 - tests
   - `pytest panel/tests/` ✔️
   - manual execution of all cells of getting_started/Introduction.ipynb ✔️
